### PR TITLE
Fix misalignment of lily timer text for WHM

### DIFF
--- a/Interface/WhiteMageHudWindow.cs
+++ b/Interface/WhiteMageHudWindow.cs
@@ -58,7 +58,7 @@ namespace DelvUIPlugin.Interface {
             if (scale < 1) {
                 var timer = (lilyCooldown / 1000f - gauge.LilyTimer / 1000f).ToString("0.0");
                 var size = ImGui.CalcTextSize((lilyCooldown / 1000).ToString("0.0"));
-                DrawOutlinedText(timer, new Vector2(cursorPos.X + barWidth / 2f - size.X / 2f, cursorPos.Y - BarHeight));
+                DrawOutlinedText(timer, new Vector2(cursorPos.X + barWidth / 2f - size.X / 2f, cursorPos.Y + BarHeight));
             }
             
             drawList.AddRect(cursorPos, cursorPos + barSize, 0xFF000000);
@@ -85,10 +85,10 @@ namespace DelvUIPlugin.Interface {
                 if (scale < 1) {
                     var timer = (lilyCooldown / 1000f - gauge.LilyTimer / 1000f).ToString("0.0");
                     var size = ImGui.CalcTextSize((lilyCooldown / 1000).ToString("0.0"));
-                    DrawOutlinedText(timer, new Vector2(cursorPos.X + barWidth / 2f - size.X / 2f, cursorPos.Y));
+                    DrawOutlinedText(timer, new Vector2(cursorPos.X + barWidth / 2f - size.X / 2f, cursorPos.Y + BarHeight));
                 }
             }
-            
+           
             drawList.AddRect(cursorPos, cursorPos + barSize, 0xFF000000);
             
             cursorPos = new Vector2(cursorPos.X + xPadding + barWidth, cursorPos.Y);
@@ -113,7 +113,7 @@ namespace DelvUIPlugin.Interface {
                 if (scale < 1) {
                     var timer = (lilyCooldown / 1000f - gauge.LilyTimer / 1000f).ToString("0.0");
                     var size = ImGui.CalcTextSize((lilyCooldown / 1000).ToString("0.0"));
-                    DrawOutlinedText(timer, new Vector2(cursorPos.X + barWidth / 2f - size.X / 2f, cursorPos.Y));
+                    DrawOutlinedText(timer, new Vector2(cursorPos.X + barWidth / 2f - size.X / 2f, cursorPos.Y + BarHeight));
                 }
             }
             
@@ -148,4 +148,4 @@ namespace DelvUIPlugin.Interface {
             drawList.AddRect(cursorPos, cursorPos + barSize, 0xFF000000);
         }
     }
-}
+}-


### PR DESCRIPTION
Expected behavior: lily timer placed below the mana bar and lily counter boxes, changing x-pos to match filled boxes, but retaining y-pos.
Observed behavior: lily timer wedged between mana bar and lily counter boxes at zero lilies, changing x-pos to match boxes, but y-pos change for lily 1 through 3 compared to zero lilies.

Patch leads to expected behavior.

Illustration is attached. 

![patch-illustration](https://user-images.githubusercontent.com/969264/130987435-d125809d-aade-41b3-ad86-6d6f004fbfe4.png)
