### PR TITLE
Fix number encoding issue

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -47,19 +47,19 @@ namespace DelvUIPlugin {
         public static string KiloFormat(this int num)
         {
             if (num >= 100000000)
-                return (num / 1000000).ToString("#,0M");
+                return (num / 1000000).ToString("#,0M", CultureInfo.InvariantCulture);
 
             if (num >= 1000000)
-                return (num / 1000000).ToString("0.#") + "M";
+                return (num / 1000000).ToString("0.#", CultureInfo.InvariantCulture) + "M";
 
             if (num >= 100000)
-                return (num / 1000).ToString("#,0K");
+                return (num / 1000).ToString("#,0K", CultureInfo.InvariantCulture);
 
             if (num >= 10000)
-                return (num / 1000).ToString("0.#") + "K";
+                return (num / 1000).ToString("0.#", CultureInfo.InvariantCulture) + "K";
 
-            return num.ToString("#,0");
-        } 
+            return num.ToString("#,0", CultureInfo.InvariantCulture);
+        }
         
         public static string Truncate(this string value, int maxLength)
         {


### PR DESCRIPTION
**Expected behavior:** Health numbers will be provided in a "kilo format".
**Observed behavior:** Health numbers are provided in a "kilo format", but encoding issues (due to locale?) can occur.

Patch fixes this issue by setting the returned string to the InvariantCulture. Unsure exactly where the error originates, but the InvariantCulture seems to give the intended formatting across all cases.

Illustration is attached.

![Illustration](https://user-images.githubusercontent.com/969264/131006966-4a2b1423-5f6e-4542-9222-6928f2df58cd.png)
