### PR TITLE
Additional Castbar Options

### DIFF
--- a/Interface/ConfigurationWindow.cs
+++ b/Interface/ConfigurationWindow.cs
@@ -28,7 +28,12 @@ namespace DelvUIPlugin.Interface {
             }
 
             var changed = false;
-            
+
+            int ViewportWidth = (int) ImGui.GetMainViewport().Size.X;
+            int ViewportHeight = (int) ImGui.GetMainViewport().Size.Y;
+            int XOffsetLimit = ViewportWidth / 2;
+            int YOffsetLimit = ViewportHeight / 2;
+
             if (ImGui.BeginTabBar("##settings-tabs")) {
                 if (ImGui.BeginTabItem("General"))
                 {
@@ -72,7 +77,7 @@ namespace DelvUIPlugin.Interface {
                     {
                         _pluginConfiguration.ToTBarWidth = totBarWidth;
                         _pluginConfiguration.Save();
-                    }                    
+                    }
                     var focusBarHeight = _pluginConfiguration.FocusBarHeight;
                     if (ImGui.DragInt("Focus Height", ref focusBarHeight, .1f, 1, 1000))
                     {
@@ -94,6 +99,8 @@ namespace DelvUIPlugin.Interface {
                 }
                 if (ImGui.BeginTabItem("Castbar"))
                 {
+                    changed |= ImGui.Checkbox("Show Cast Bar", ref _pluginConfiguration.ShowCastBar);
+
                     var castBarHeight = _pluginConfiguration.CastBarHeight;
                     if (ImGui.DragInt("Castbar Height", ref castBarHeight, .1f, 1, 1000))
                     {
@@ -107,22 +114,37 @@ namespace DelvUIPlugin.Interface {
                         _pluginConfiguration.CastBarWidth = castBarWidth;
                         _pluginConfiguration.Save();
                     }
-                    changed |= ImGui.ColorEdit4("Cast Bar Color", ref _pluginConfiguration.CastBarColor);
-                    
+
+                    var castBarXOffset = _pluginConfiguration.CastBarXOffset;
+                    if (ImGui.DragInt("Castbar X Offset", ref castBarXOffset, .1f, -XOffsetLimit, XOffsetLimit))
+                    {
+                        _pluginConfiguration.CastBarXOffset = castBarXOffset;
+                        _pluginConfiguration.Save();
+                    }
+
+                    var castBarYOffset = _pluginConfiguration.CastBarYOffset;
+                    if (ImGui.DragInt("Castbar Y Offset", ref castBarYOffset, .1f, -YOffsetLimit, YOffsetLimit))
+                    {
+                        _pluginConfiguration.CastBarYOffset = castBarYOffset;
+                        _pluginConfiguration.Save();
+                    }
+
+                    changed |= ImGui.ColorEdit4("Castbar Color", ref _pluginConfiguration.CastBarColor);
+
                     changed |= ImGui.Checkbox("Show Action Icon", ref _pluginConfiguration.ShowActionIcon);
                     changed |= ImGui.Checkbox("Show Action Name", ref _pluginConfiguration.ShowActionName);
                     changed |= ImGui.Checkbox("Show Cast Time", ref _pluginConfiguration.ShowCastTime);
                     changed |= ImGui.Checkbox("Slide Cast Enabled", ref _pluginConfiguration.SlideCast);
-                    
+
                     var slideCastTime = _pluginConfiguration.SlideCastTime;
                     if (ImGui.DragFloat("Slide Cast Offset", ref slideCastTime, 1, 1, 1000))
                     {
                         _pluginConfiguration.SlideCastTime = slideCastTime;
                         _pluginConfiguration.Save();
                     }
-                    
+
                     changed |= ImGui.ColorEdit4("Slide Cast Color", ref _pluginConfiguration.SlideCastColor);
-                    
+
                     ImGui.EndTabItem();
                 }
                 if (ImGui.BeginTabItem("Color Map")) {

--- a/Interface/HudWindow.cs
+++ b/Interface/HudWindow.cs
@@ -46,6 +46,8 @@ namespace DelvUIPlugin.Interface {
         protected int FocusBarWidth => PluginConfiguration.FocusBarWidth;
         protected int CastBarWidth => PluginConfiguration.CastBarWidth;
         protected int CastBarHeight => PluginConfiguration.CastBarHeight;
+        protected int CastBarXOffset => PluginConfiguration.CastBarXOffset;
+        protected int CastBarYOffset => PluginConfiguration.CastBarYOffset;
         protected Vector2 BarSize => _barsize;
 
         private Lumina.Excel.GeneratedSheets.Action LastUsedAction;
@@ -239,7 +241,9 @@ namespace DelvUIPlugin.Interface {
 
         protected virtual unsafe void DrawCastBar()
         {
-            
+            if (! PluginConfiguration.ShowCastBar)
+              return;
+
             var actor = PluginInterface.ClientState.LocalPlayer;
             var castBar = (AddonCastBar*) PluginInterface.Framework.Gui.GetUiObjectByName("_CastBar", 1);
             var isCasting = StatusFlags.IsCasting;
@@ -291,7 +295,10 @@ namespace DelvUIPlugin.Interface {
                 .ToString(CultureInfo.InvariantCulture);
 
             var barSize = new Vector2(CastBarWidth, CastBarHeight);
-            var cursorPos = new Vector2(CenterX - CastBarWidth / 2f, CenterY + YOffset - 100);
+            var cursorPos = new Vector2(
+                CenterX + PluginConfiguration.CastBarXOffset - CastBarWidth / 2f,
+                CenterY + PluginConfiguration.CastBarYOffset
+            );
 
             ImGui.SetCursorPos(cursorPos);
 

--- a/PluginConfiguration.cs
+++ b/PluginConfiguration.cs
@@ -21,8 +21,11 @@ namespace DelvUIPlugin {
         public int FocusBarWidth { get; set; } = 120;
         public int CastBarHeight { get; set; } = 25;
         public int CastBarWidth { get; set; } = 254;
+        public int CastBarXOffset { get; set; } = 0;
+        public int CastBarYOffset { get; set; } = 460;
         
 
+        public bool ShowCastBar = true;
         public bool ShowActionIcon = true;
         public bool ShowActionName = true;
         public bool ShowCastTime = true;


### PR DESCRIPTION
User Features:
 - Visibility Toggle
 - X Offset
 - Y Offset

![ffxiv_dx11_m71iYkVhQE](https://user-images.githubusercontent.com/89595918/131009220-f19046d4-7737-443e-b87c-37059ed7051a.png)

Internal:
Added XOffsetLimit and YOffsetLimit vars to the ConfigurationWindow Draw function (there's probably somewhere better to put these).
The offset limits are used to allow full castbar position adjustment independent of monitor resolution while still keeping it in bounds.
Could be generally useful for other config options instead of arbitrarily large values.