### PR TITLE
Fix missing using statement

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Numerics;
 using System.Text;
 using FFXIVClientStructs.FFXIV.Client.System.String;


### PR DESCRIPTION
For some reason VS could build fine without the "using System.Globalization" statement until I did I clean build. 

Added explicit using statement to fix the issue.