### PR TITLE
Fix positioning of SecondaryResourcebar for WHM

### DIFF
--- a/DelvUI/Interface/WhiteMageHudWindow.cs
+++ b/DelvUI/Interface/WhiteMageHudWindow.cs
@@ -36,7 +36,7 @@ namespace DelvUI.Interface
             var barWidth = (BarWidth - xPadding * (numChunks - 1)) / numChunks;
             var barSize = new Vector2(barWidth, BarHeight);
             var xPos = CenterX - XOffset;
-            var yPos = CenterY + YOffset - 20;
+            var yPos = CenterY + YOffset - 10;
 
             const float lilyCooldown = 30000f;
 


### PR DESCRIPTION
At the introduction of  32debcc1a8da9aa006234a2d1f5a326c5e3d7d96, changes to the positioning of PrimaryResourcebar lead to an overlap with SecondaryResourcebar for WHM.

This patch repositions WHM's SecondaryResourcebar and its associated text as to match the layout before 32debcc1a8da9aa006234a2d1f5a326c5e3d7d96.

Before:
![Before](https://user-images.githubusercontent.com/969264/131095291-cb6e67c4-4769-44f9-9c4d-f2e9ee4c4a45.png)

After:
![After](https://user-images.githubusercontent.com/969264/131095110-474ed7f7-eae6-42ef-8e1b-89c100328727.png)
