### PR TITLE
fix: NIN Job Bar Independence

### DIFF
--- a/DelvUI/Interface/ConfigurationWindow.cs
+++ b/DelvUI/Interface/ConfigurationWindow.cs
@@ -2664,66 +2664,84 @@ namespace DelvUI.Interface
                         _pluginConfiguration.Save();
                     }
 
-                    var ninHutonGaugeHeight = _pluginConfiguration.NINHutonGaugeHeight;
-                    if (ImGui.DragInt("Huton Gauge Height", ref ninHutonGaugeHeight, .1f, 1, 1000))
+                    _changed |= ImGui.Checkbox("Enable Huton Gauge", ref _pluginConfiguration.NINHutonGaugeEnabled);
+
+                    if (_pluginConfiguration.NINHutonGaugeEnabled)
                     {
-                        _pluginConfiguration.NINHutonGaugeHeight = ninHutonGaugeHeight;
-                        _pluginConfiguration.Save();
+                        var ninHutonGaugeHeight = _pluginConfiguration.NINHutonGaugeHeight;
+                        if (ImGui.DragInt("Huton Gauge Height", ref ninHutonGaugeHeight, .1f, 1, 1000))
+                        {
+                            _pluginConfiguration.NINHutonGaugeHeight = ninHutonGaugeHeight;
+                            _pluginConfiguration.Save();
+                        }
+
+                        var ninHutonGaugeWidth = _pluginConfiguration.NINHutonGaugeWidth;
+                        if (ImGui.DragInt("Huton Gauge Width", ref ninHutonGaugeWidth, .1f, 1, 1000))
+                        {
+                            _pluginConfiguration.NINHutonGaugeWidth = ninHutonGaugeWidth;
+                            _pluginConfiguration.Save();
+                        }
+
+                        var ninHutonGaugeXOffset = _pluginConfiguration.NINHutonGaugeXOffset;
+                        if (ImGui.DragInt("Huton Gauge X Offset", ref ninHutonGaugeXOffset, .1f, -2000, 2000))
+                        {
+                            _pluginConfiguration.NINHutonGaugeXOffset = ninHutonGaugeXOffset;
+                            _pluginConfiguration.Save();
+                        }
+
+                        var ninHutonGaugeYOffset = _pluginConfiguration.NINHutonGaugeYOffset;
+                        if (ImGui.DragInt("Huton Gauge Y Offset", ref ninHutonGaugeYOffset, .1f, -2000, 2000))
+                        {
+                            _pluginConfiguration.NINHutonGaugeYOffset = ninHutonGaugeYOffset;
+                            _pluginConfiguration.Save();
+                        }
+
+                        _changed |= ImGui.ColorEdit4("Huton Bar Color", ref _pluginConfiguration.NINHutonColor);
                     }
 
-                    var ninHutonGaugeWidth = _pluginConfiguration.NINHutonGaugeWidth;
-                    if (ImGui.DragInt("Huton Gauge Width", ref ninHutonGaugeWidth, .1f, 1, 1000))
-                    {
-                        _pluginConfiguration.NINHutonGaugeWidth = ninHutonGaugeWidth;
-                        _pluginConfiguration.Save();
-                    }
+                    _changed |= ImGui.Checkbox("Enable Ninki Gauge", ref _pluginConfiguration.NINNinkiGaugeEnabled);
 
-                    var ninNinkiGaugeHeight = _pluginConfiguration.NINNinkiGaugeHeight;
-                    if (ImGui.DragInt("Ninki Gauge Height", ref ninNinkiGaugeHeight, .1f, 1, 1000))
+                    if (_pluginConfiguration.NINNinkiGaugeEnabled)
                     {
-                        _pluginConfiguration.NINNinkiGaugeHeight = ninNinkiGaugeHeight;
-                        _pluginConfiguration.Save();
-                    }
+                        var ninNinkiGaugeHeight = _pluginConfiguration.NINNinkiGaugeHeight;
+                        if (ImGui.DragInt("Ninki Gauge Height", ref ninNinkiGaugeHeight, .1f, 1, 1000))
+                        {
+                            _pluginConfiguration.NINNinkiGaugeHeight = ninNinkiGaugeHeight;
+                            _pluginConfiguration.Save();
+                        }
 
-                    var ninNinkiGaugeWidth = _pluginConfiguration.NINNinkiGaugeWidth;
-                    if (ImGui.DragInt("Ninki Gauge Width", ref ninNinkiGaugeWidth, .1f, 1, 1000))
-                    {
-                        _pluginConfiguration.NINNinkiGaugeWidth = ninNinkiGaugeWidth;
-                        _pluginConfiguration.Save();
-                    }
+                        var ninNinkiGaugeWidth = _pluginConfiguration.NINNinkiGaugeWidth;
+                        if (ImGui.DragInt("Ninki Gauge Width", ref ninNinkiGaugeWidth, .1f, 1, 1000))
+                        {
+                            _pluginConfiguration.NINNinkiGaugeWidth = ninNinkiGaugeWidth;
+                            _pluginConfiguration.Save();
+                        }
 
-                    var ninNinkiGaugePadding = _pluginConfiguration.NINNinkiGaugePadding;
-                    if (ImGui.DragInt("Ninki Gauge Padding", ref ninNinkiGaugePadding, .1f, 1, 1000))
-                    {
-                        _pluginConfiguration.NINNinkiGaugePadding = ninNinkiGaugePadding;
-                        _pluginConfiguration.Save();
-                    }
+                        var ninNinkiGaugePadding = _pluginConfiguration.NINNinkiGaugePadding;
+                        if (ImGui.DragInt("Ninki Gauge Padding", ref ninNinkiGaugePadding, .1f, 1, 1000))
+                        {
+                            _pluginConfiguration.NINNinkiGaugePadding = ninNinkiGaugePadding;
+                            _pluginConfiguration.Save();
+                        }
 
-                    var ninNinkiGaugeXOffset = _pluginConfiguration.NINNinkiGaugeXOffset;
-                    if (ImGui.DragInt("Ninki Gauge X Offset", ref ninNinkiGaugeXOffset, .1f, -2000, 2000))
-                    {
-                        _pluginConfiguration.NINNinkiGaugeXOffset = ninNinkiGaugeXOffset;
-                        _pluginConfiguration.Save();
-                    }
+                        var ninNinkiGaugeXOffset = _pluginConfiguration.NINNinkiGaugeXOffset;
+                        if (ImGui.DragInt("Ninki Gauge X Offset", ref ninNinkiGaugeXOffset, .1f, -2000, 2000))
+                        {
+                            _pluginConfiguration.NINNinkiGaugeXOffset = ninNinkiGaugeXOffset;
+                            _pluginConfiguration.Save();
+                        }
 
-                    var ninNinkiGaugeYOffset = _pluginConfiguration.NINNinkiGaugeYOffset;
-                    if (ImGui.DragInt("Ninki Gauge Y Offset", ref ninNinkiGaugeYOffset, .1f, -2000, 2000))
-                    {
-                        _pluginConfiguration.NINNinkiGaugeYOffset = ninNinkiGaugeYOffset;
-                        _pluginConfiguration.Save();
-                    }
+                        var ninNinkiGaugeYOffset = _pluginConfiguration.NINNinkiGaugeYOffset;
+                        if (ImGui.DragInt("Ninki Gauge Y Offset", ref ninNinkiGaugeYOffset, .1f, -2000, 2000))
+                        {
+                            _pluginConfiguration.NINNinkiGaugeYOffset = ninNinkiGaugeYOffset;
+                            _pluginConfiguration.Save();
+                        }
 
-
-                    var ninInterBarOffset = _pluginConfiguration.NINInterBarOffset;
-                    if (ImGui.DragInt("Space Between Bars", ref ninInterBarOffset, .1f, 1, 1000))
-                    {
-                        _pluginConfiguration.NINInterBarOffset = ninInterBarOffset;
-                        _pluginConfiguration.Save();
+                        _changed |= ImGui.ColorEdit4("Ninki Bar Color", ref _pluginConfiguration.NINNinkiColor);
                     }
 
                     _changed |= ImGui.ColorEdit4("Empty Color", ref _pluginConfiguration.NINEmptyColor);
-                    _changed |= ImGui.ColorEdit4("Huton Bar Color", ref _pluginConfiguration.NINHutonColor);
-                    _changed |= ImGui.ColorEdit4("Ninki Bar Color", ref _pluginConfiguration.NINNinkiColor);
 
                     ImGui.EndTabItem();
                 }

--- a/DelvUI/Interface/NinjaHudWindow.cs
+++ b/DelvUI/Interface/NinjaHudWindow.cs
@@ -17,8 +17,13 @@ namespace DelvUI.Interface
         private new int XOffset => PluginConfiguration.NINBaseXOffset;
         private new int YOffset => PluginConfiguration.NINBaseYOffset;
 
+        private bool HutonGaugeEnabled => PluginConfiguration.NINHutonGaugeEnabled;
         private int HutonGaugeHeight => PluginConfiguration.NINHutonGaugeHeight;
         private int HutonGaugeWidth => PluginConfiguration.NINHutonGaugeWidth;
+        private int HutonGaugeXOffset => PluginConfiguration.NINHutonGaugeXOffset;
+        private int HutonGaugeYOffset => PluginConfiguration.NINHutonGaugeYOffset;
+
+        private bool NinkiGaugeEnabled => PluginConfiguration.NINNinkiGaugeEnabled;
         private int NinkiGaugeHeight => PluginConfiguration.NINNinkiGaugeHeight;
         private int NinkiGaugeWidth => PluginConfiguration.NINNinkiGaugeWidth;
         private int NinkiGaugePadding => PluginConfiguration.NINNinkiGaugePadding;
@@ -29,27 +34,27 @@ namespace DelvUI.Interface
         private Dictionary<string, uint> HutonColor => PluginConfiguration.JobColorMap[Jobs.NIN * 1000 + 1];
         private Dictionary<string, uint> NinkiColor => PluginConfiguration.JobColorMap[Jobs.NIN * 1000 + 2];
 
-        private int InterBarOffset => PluginConfiguration.NINInterBarOffset;
-
         public NinjaHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration) : base(pluginInterface, pluginConfiguration) { }
 
         protected override void Draw(bool _)
         {
-            var nextHeight = DrawHutonGauge(0);
-            nextHeight = DrawNinkiGauge(nextHeight);
+            if (HutonGaugeEnabled)
+                DrawHutonGauge();
+            if (NinkiGaugeEnabled)
+                DrawNinkiGauge();
         }
 
         protected override void DrawPrimaryResourceBar()
         {
         }
 
-        private int DrawHutonGauge(int initialHeight)
+        private void DrawHutonGauge()
         {
             var gauge = PluginInterface.ClientState.JobGauges.Get<NINGauge>();
             var hutonDurationLeft = (int)Math.Ceiling((float) (gauge.HutonTimeLeft / (double)1000));
 
-            var xPos = CenterX - XOffset;
-            var yPos = CenterY + YOffset + initialHeight;
+            var xPos = CenterX - XOffset + HutonGaugeXOffset;
+            var yPos = CenterY + YOffset + HutonGaugeYOffset;
 
             var builder = BarBuilder.Create(xPos, yPos, HutonGaugeHeight, HutonGaugeWidth);
             float maximum = 70f;
@@ -61,16 +66,14 @@ namespace DelvUI.Interface
 
             var drawList = ImGui.GetWindowDrawList();
             bar.Draw(drawList);
-
-            return HutonGaugeHeight + initialHeight + InterBarOffset;
         }
 
-        private int DrawNinkiGauge(int initialHeight)
+        private void DrawNinkiGauge()
         {
             var gauge = PluginInterface.ClientState.JobGauges.Get<NINGauge>();
 
             var xPos = CenterX - XOffset + NinkiGaugeXOffset;
-            var yPos = CenterY + YOffset + initialHeight + NinkiGaugeYOffset;
+            var yPos = CenterY + YOffset + NinkiGaugeYOffset;
 
             var bar = BarBuilder.Create(xPos, yPos, NinkiGaugeHeight, NinkiGaugeWidth)
                 .SetChunks(2)
@@ -80,8 +83,6 @@ namespace DelvUI.Interface
 
             var drawList = ImGui.GetWindowDrawList();
             bar.Draw(drawList);
-
-            return NinkiGaugeHeight + initialHeight + InterBarOffset;
         }
     }
 }

--- a/DelvUI/PluginConfiguration.cs
+++ b/DelvUI/PluginConfiguration.cs
@@ -365,16 +365,21 @@ namespace DelvUI {
 
 
         #region NIN Configuration
-
         public int NINBaseXOffset { get; set; } = 127;
-        public int NINBaseYOffset { get; set; } = 420;
+        public int NINBaseYOffset { get; set; } = 417;
+
+        public bool NINHutonGaugeEnabled = true;
         public int NINHutonGaugeHeight { get; set; } = 20;
         public int NINHutonGaugeWidth { get; set; } = 254;
+        public int NINHutonGaugeXOffset { get; set; }
+        public int NINHutonGaugeYOffset { get; set; }
+
+        public bool NINNinkiGaugeEnabled = true;
         public int NINNinkiGaugeHeight { get; set; } = 20;
         public int NINNinkiGaugeWidth { get; set; } = 254;
         public int NINNinkiGaugePadding { get; set; } = 2;
         public int NINNinkiGaugeXOffset { get; set; }
-        public int NINNinkiGaugeYOffset { get; set; }
+        public int NINNinkiGaugeYOffset { get; set; } = 22;
 
         public int NINInterBarOffset { get; set; } = 2;
         public Vector4 NINHutonColor = new Vector4(110f / 255f, 197f / 255f, 207f / 255f, 100f / 100f);


### PR DESCRIPTION
- Adds missing config.
- Removes initialHeight.
- Removes "Space Between Bars".
- Sets correct default offsets.

Closes #124 
Relates to #154 