### PR TITLE
fix: GNB Job Bar Independence

### DIFF
--- a/DelvUI/Interface/ConfigurationWindow.cs
+++ b/DelvUI/Interface/ConfigurationWindow.cs
@@ -1528,14 +1528,9 @@ namespace DelvUI.Interface
                         _pluginConfiguration.Save();
                     }
 
-                    var gnbPowderGaugeEnablewd = _pluginConfiguration.GNBPowderGaugeEnabled;
-                    if (ImGui.Checkbox("Powder Gauge Enabled", ref gnbPowderGaugeEnablewd))
-                    {
-                        _pluginConfiguration.GNBPowderGaugeEnabled = gnbPowderGaugeEnablewd;
-                        _pluginConfiguration.Save();
-                    }
+                    _changed |= ImGui.Checkbox("Powder Gauge Enabled", ref _pluginConfiguration.GNBPowderGaugeEnabled);
 
-                    if (gnbPowderGaugeEnablewd) {
+                    if (_pluginConfiguration.GNBPowderGaugeEnabled) {
                         var gnbPowderGaugeHeight = _pluginConfiguration.GNBPowderGaugeHeight;
                         if (ImGui.DragInt("Powder Gauge Height", ref gnbPowderGaugeHeight, .1f, 1, _yOffsetLimit)) {
                             _pluginConfiguration.GNBPowderGaugeHeight = gnbPowderGaugeHeight;
@@ -1569,14 +1564,9 @@ namespace DelvUI.Interface
                         _changed |= ImGui.ColorEdit4("Powder Gauge Color", ref _pluginConfiguration.GNBGunPowderColor);
                     }
 
-                    var gnbNoMercyBarEnablewd = _pluginConfiguration.GNBNoMercyBarEnabled;
-                    if (ImGui.Checkbox("No Mercy Bar Enabled", ref gnbNoMercyBarEnablewd))
-                    {
-                        _pluginConfiguration.GNBNoMercyBarEnabled = gnbNoMercyBarEnablewd;
-                        _pluginConfiguration.Save();
-                    }
+                    _changed |= ImGui.Checkbox("No Mercy Bar Enabled", ref _pluginConfiguration.GNBNoMercyBarEnabled);
 
-                    if (gnbNoMercyBarEnablewd) {
+                    if (_pluginConfiguration.GNBNoMercyBarEnabled) {
                         var gnbNoMercyBarHeight = _pluginConfiguration.GNBNoMercyBarHeight;
                         if (ImGui.DragInt("No Mercy Bar Height", ref gnbNoMercyBarHeight, .1f, 1, _yOffsetLimit)) {
                             _pluginConfiguration.GNBNoMercyBarHeight = gnbNoMercyBarHeight;
@@ -1602,13 +1592,6 @@ namespace DelvUI.Interface
                         }
 
                         _changed |= ImGui.ColorEdit4("No Mercy Color", ref _pluginConfiguration.GNBNoMercyColor);
-                    }
-
-                    var gnbInterBarOffset = _pluginConfiguration.GNBInterBarOffset;
-                    if (ImGui.DragInt("Space Between Bars", ref gnbInterBarOffset, .1f, 0, 1000))
-                    {
-                        _pluginConfiguration.GNBInterBarOffset = gnbInterBarOffset;
-                        _pluginConfiguration.Save();
                     }
 
                     ImGui.EndTabItem();

--- a/DelvUI/Interface/GunbreakerHudWindow.cs
+++ b/DelvUI/Interface/GunbreakerHudWindow.cs
@@ -31,26 +31,23 @@ namespace DelvUI.Interface {
         private int NoMercyBarYOffset => PluginConfiguration.GNBNoMercyBarYOffset;
         private Dictionary<string, uint> NoMercyColor => PluginConfiguration.JobColorMap[Jobs.GNB * 1000 + 1];
 
-        private int InterBarOffset => PluginConfiguration.GNBInterBarOffset;
-
         public GunbreakerHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration) : base(pluginInterface, pluginConfiguration) { }
 
         protected override void Draw(bool _) {
-            var initialOffset = YOffset;
             if (PowderGaugeEnabled)
-                initialOffset = DrawPowderGauge(initialOffset);
+                DrawPowderGauge();
             if (NoMercyBarEnabled)
-                DrawNoMercyBar(initialOffset);
+                DrawNoMercyBar();
         }
         protected override void DrawPrimaryResourceBar()
         {
         }
 
-        private int DrawPowderGauge(int initialOffset) {
+        private void DrawPowderGauge() {
             var gauge = PluginInterface.ClientState.JobGauges.Get<GNBGauge>();
 
             var xPos = CenterX - XOffset + PowderGaugeXOffset;
-            var yPos = CenterY + initialOffset + PowderGaugeYOffset;
+            var yPos = CenterY + YOffset + PowderGaugeYOffset;
 
             var builder = BarBuilder.Create(xPos, yPos, PowderGaugeHeight, PowderGaugeWidth);
             builder.SetChunks(2)
@@ -59,13 +56,11 @@ namespace DelvUI.Interface {
 
             var drawList = ImGui.GetWindowDrawList();
             builder.Build().Draw(drawList);
-
-            return initialOffset + PowderGaugeHeight + InterBarOffset;
         }
 
-        private void DrawNoMercyBar(int initialOffset) {
+        private void DrawNoMercyBar() {
             var xPos = CenterX - XOffset + NoMercyBarXOffset;
-            var yPos = CenterY + initialOffset + NoMercyBarYOffset;
+            var yPos = CenterY + YOffset + NoMercyBarYOffset;
 
             var noMercyBuff = PluginInterface.ClientState.LocalPlayer.StatusEffects.Where(o => o.EffectId == 1831);
 

--- a/DelvUI/PluginConfiguration.cs
+++ b/DelvUI/PluginConfiguration.cs
@@ -625,10 +625,8 @@ namespace DelvUI {
         public int GNBNoMercyBarHeight { get; set; } = 20;
         public int GNBNoMercyBarWidth { get; set; } = 254;
         public int GNBNoMercyBarXOffset { get; set; }
-        public int GNBNoMercyBarYOffset { get; set; }
+        public int GNBNoMercyBarYOffset { get; set; } = 22;
         public Vector4 GNBNoMercyColor = new Vector4(252f / 255f, 204f / 255f, 255f / 255f, 1f);
-
-        public int GNBInterBarOffset { get; set; } = 2;
 
         #endregion
 


### PR DESCRIPTION
- Removes initialHeight.
- Removes "Space Between Bars".
- Sets correct default offsets.

Relates to #154 