### PR TITLE
Fix crash on object interaction with purple quest ground marker

### DIFF
--- a/DelvUI/Helpers/DrawHelper.cs
+++ b/DelvUI/Helpers/DrawHelper.cs
@@ -10,6 +10,9 @@ namespace DelvUI.Helpers
         }
         
         public static void DrawOutlinedText(string text, Vector2 pos, Vector4 color, Vector4 outlineColor) {
+            // super ugly temporary hack to avoid crashes on certain quest interactions
+            text ??= "";
+
             ImGui.SetCursorPos(new Vector2(pos.X - 1, pos.Y + 1));
             ImGui.TextColored(outlineColor, text);
                 

--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -443,7 +443,7 @@ namespace DelvUI.Interface {
 
             if (PluginConfiguration.ShowActionName) {
                 DrawOutlinedText(
-                    castText ??= "",
+                    castText,
                     new Vector2(
                         cursorPos.X + (PluginConfiguration.ShowActionIcon && _lastPlayerUsedCast.HasIcon ? CastBarHeight : 0) + 5,
                         cursorPos.Y + CastBarHeight / 2f - castTextSize.Y / 2f

--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -443,7 +443,7 @@ namespace DelvUI.Interface {
 
             if (PluginConfiguration.ShowActionName) {
                 DrawOutlinedText(
-                    castText,
+                    castText ??= "",
                     new Vector2(
                         cursorPos.X + (PluginConfiguration.ShowActionIcon && _lastPlayerUsedCast.HasIcon ? CastBarHeight : 0) + 5,
                         cursorPos.Y + CastBarHeight / 2f - castTextSize.Y / 2f


### PR DESCRIPTION
Interaction with quest item on purple ground marker objective would lead to null being passed to DrawOutlinedText and a memory access violation.

Now passes empty string if argument is null.