### PR TITLE
Dancer Proc Bar

### DIFF
--- a/DelvUI/Interface/ConfigurationWindow.cs
+++ b/DelvUI/Interface/ConfigurationWindow.cs
@@ -3822,6 +3822,13 @@ namespace DelvUI.Interface
                         _pluginConfiguration.Save();
                     }
 
+                    var procTimersEnabled = _pluginConfiguration.DNCProcTimersEnabled;
+                    if (ImGui.Checkbox("Proc Timers Enabled", ref procTimersEnabled))
+                    {
+                        _pluginConfiguration.DNCProcTimersEnabled = procTimersEnabled;
+                        _pluginConfiguration.Save();
+                    }
+
                     var procHeight = _pluginConfiguration.DNCProcHeight;
                     if (ImGui.DragInt("Proc Bar Height", ref procHeight, .1f, 1, 1000))
                     {
@@ -3874,6 +3881,8 @@ namespace DelvUI.Interface
                     _changed |= ImGui.ColorEdit4("Pirouette Color", ref _pluginConfiguration.DNCStepPirouetteColor);
                     _changed |= ImGui.ColorEdit4("Flourishing Cascade Color", ref _pluginConfiguration.DNCFlourishingCascadeColor);
                     _changed |= ImGui.ColorEdit4("Flourishing Fountain Color", ref _pluginConfiguration.DNCFlourishingFountainColor);
+                    _changed |= ImGui.ColorEdit4("Flourishing Windmill Color", ref _pluginConfiguration.DNCFlourishingWindmillColor);
+                    _changed |= ImGui.ColorEdit4("Flourishing Shower Color", ref _pluginConfiguration.DNCFlourishingShowerColor);
                     _changed |= ImGui.ColorEdit4("Bar Not Full Color", ref _pluginConfiguration.DNCEmptyColor);
 
                     ImGui.EndTabItem();

--- a/DelvUI/Interface/ConfigurationWindow.cs
+++ b/DelvUI/Interface/ConfigurationWindow.cs
@@ -3806,6 +3806,51 @@ namespace DelvUI.Interface
                         _pluginConfiguration.DNCStepPadding = stepPadding;
                         _pluginConfiguration.Save();
                     }
+
+                    var procEnabled = _pluginConfiguration.DNCProcEnabled;
+                    if (ImGui.Checkbox("Proc Bar Enabled", ref procEnabled))
+                    {
+                        _pluginConfiguration.DNCProcEnabled = procEnabled;
+                        _pluginConfiguration.Save();
+                    }
+
+                    var procHeight = _pluginConfiguration.DNCProcHeight;
+                    if (ImGui.DragInt("Proc Bar Height", ref procHeight, .1f, 1, 1000))
+                    {
+                        _pluginConfiguration.DNCProcHeight = procHeight;
+                        _pluginConfiguration.Save();
+                    }
+
+                    var procWidth = _pluginConfiguration.DNCProcWidth;
+                    if (ImGui.DragInt("Proc Bar Width", ref procWidth, .1f, 1, 1000))
+                    {
+                        _pluginConfiguration.DNCProcWidth = procWidth;
+                        _pluginConfiguration.Save();
+                    }
+
+                    var procXOffset = _pluginConfiguration.DNCProcXOffset;
+                    if (ImGui.DragInt("Proc X Offset", ref procXOffset, .1f, -2000, 2000))
+                    {
+                        _pluginConfiguration.DNCProcXOffset = procXOffset;
+                        _pluginConfiguration.Save();
+                    }
+
+                    var procYOffset = _pluginConfiguration.DNCProcYOffset;
+                    if (ImGui.DragInt("Proc Y Offset", ref procYOffset, .1f, -2000, 2000))
+                    {
+                        _pluginConfiguration.DNCProcYOffset = procYOffset;
+                        _pluginConfiguration.Save();
+                    }
+
+                    var procPadding = _pluginConfiguration.DNCProcPadding;
+                    if (ImGui.DragInt("Proc Padding", ref procPadding, .1f, 0, 1000))
+                    {
+                        _pluginConfiguration.DNCProcPadding = procPadding;
+                        _pluginConfiguration.Save();
+                    }
+
+                   
+                    
                     
                     _changed |= ImGui.ColorEdit4("Esprit Bar Color", ref _pluginConfiguration.DNCEspritColor);
                     _changed |= ImGui.ColorEdit4("Feather Bar Color", ref _pluginConfiguration.DNCFeatherColor);
@@ -3819,6 +3864,8 @@ namespace DelvUI.Interface
                     _changed |= ImGui.ColorEdit4("Entrechat Step Color", ref _pluginConfiguration.DNCStepEntrechatColor);
                     _changed |= ImGui.ColorEdit4("Jete Step Color", ref _pluginConfiguration.DNCStepJeteColor);
                     _changed |= ImGui.ColorEdit4("Pirouette Color", ref _pluginConfiguration.DNCStepPirouetteColor);
+                    _changed |= ImGui.ColorEdit4("Flourishing Cascade Color", ref _pluginConfiguration.DNCFlourishingCascadeColor);
+                    _changed |= ImGui.ColorEdit4("Flourishing Fountain Color", ref _pluginConfiguration.DNCFlourishingFountainColor);
                     _changed |= ImGui.ColorEdit4("Bar Not Full Color", ref _pluginConfiguration.DNCEmptyColor);
 
                     ImGui.EndTabItem();

--- a/DelvUI/Interface/DancerHudWindow.cs
+++ b/DelvUI/Interface/DancerHudWindow.cs
@@ -50,7 +50,13 @@ namespace DelvUI.Interface {
         private int StepXOffset => PluginConfiguration.DNCStepXOffset;
         private int StepYOffset => PluginConfiguration.DNCStepYOffset;
         private int StepPadding => PluginConfiguration.DNCStepPadding;
-        
+        private bool ProcEnabled => PluginConfiguration.DNCProcEnabled;
+        private int ProcHeight => PluginConfiguration.DNCProcHeight;
+        private int ProcWidth => PluginConfiguration.DNCProcWidth;
+        private int ProcPadding => PluginConfiguration.DNCProcPadding;
+        private int ProcXOffset => PluginConfiguration.DNCProcXOffset;
+        private int ProcYOffset => PluginConfiguration.DNCProcYOffset;
+
         private Dictionary<string, uint> EspritColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000]; 
         private Dictionary<string, uint> FeatherColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 1]; 
         private Dictionary<string, uint> FlourishingProcColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 2]; 
@@ -64,12 +70,16 @@ namespace DelvUI.Interface {
         private Dictionary<string, uint> EmptyColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 10];
         private Dictionary<string, uint> DanceReadyColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 11];
         private Dictionary<string, uint> DevilmentColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 12];
+        private Dictionary<string, uint> FlourishingCascadeColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 13];
+        private Dictionary<string, uint> FlourishingFountainColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 14];
 
         public DancerHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration) : base(pluginInterface, pluginConfiguration) { }
 
         protected override void Draw(bool _) {
             if (EspritEnabled)
                 DrawEspritBar();
+            if (ProcEnabled)
+                DrawProcBar();
             if (FeatherEnabled)
                 DrawFeathersBar();
             if (BuffEnabled)
@@ -256,6 +266,26 @@ namespace DelvUI.Interface {
             var drawList = ImGui.GetWindowDrawList();
             builder.Build().Draw(drawList);
         }
-    }
-}
 
+        private void DrawProcBar()
+        {
+            Debug.Assert(PluginInterface.ClientState.LocalPlayer != null, "PluginInterface.ClientState.LocalPlayer != null");
+            var flourishingCascadeBuff = PluginInterface.ClientState.LocalPlayer.StatusEffects.Where(o => o.EffectId is 1814);
+            var flourishingFountainBuff = PluginInterface.ClientState.LocalPlayer.StatusEffects.Where(o => o.EffectId is 1815);
+
+            var xPos = CenterX - ProcXOffset;
+            var yPos = CenterY + ProcYOffset;
+
+            var cascadeBuilder = BarBuilder.Create(xPos, yPos, ProcHeight, ProcWidth);
+            var fountainBuilder = BarBuilder.Create(xPos + ProcWidth + ProcPadding, yPos, ProcHeight, ProcWidth);
+
+            if (flourishingCascadeBuff.Any() && ProcEnabled)
+                cascadeBuilder.AddInnerBar(Math.Abs(flourishingCascadeBuff.First().Duration), 20, FlourishingCascadeColor);
+            if (flourishingFountainBuff.Any() && ProcEnabled)
+                fountainBuilder.AddInnerBar(Math.Abs(flourishingFountainBuff.First().Duration), 20, FlourishingFountainColor);
+            var drawList = ImGui.GetWindowDrawList();
+            cascadeBuilder.Build().Draw(drawList);
+            fountainBuilder.Build().Draw(drawList);
+        }
+}
+}

--- a/DelvUI/Interface/DancerHudWindow.cs
+++ b/DelvUI/Interface/DancerHudWindow.cs
@@ -51,6 +51,7 @@ namespace DelvUI.Interface {
         private int StepYOffset => PluginConfiguration.DNCStepYOffset;
         private int StepPadding => PluginConfiguration.DNCStepPadding;
         private bool ProcEnabled => PluginConfiguration.DNCProcEnabled;
+        private bool ProcTimersEnabled => PluginConfiguration.DNCProcTimersEnabled;
         private int ProcHeight => PluginConfiguration.DNCProcHeight;
         private int ProcWidth => PluginConfiguration.DNCProcWidth;
         private int ProcPadding => PluginConfiguration.DNCProcPadding;
@@ -72,6 +73,8 @@ namespace DelvUI.Interface {
         private Dictionary<string, uint> DevilmentColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 12];
         private Dictionary<string, uint> FlourishingCascadeColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 13];
         private Dictionary<string, uint> FlourishingFountainColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 14];
+        private Dictionary<string, uint> FlourishingWindmillColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 15];
+        private Dictionary<string, uint> FlourishingShowerColor => PluginConfiguration.JobColorMap[Jobs.DNC * 1000 + 16];
 
         public DancerHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration) : base(pluginInterface, pluginConfiguration) { }
 
@@ -272,20 +275,42 @@ namespace DelvUI.Interface {
             Debug.Assert(PluginInterface.ClientState.LocalPlayer != null, "PluginInterface.ClientState.LocalPlayer != null");
             var flourishingCascadeBuff = PluginInterface.ClientState.LocalPlayer.StatusEffects.Where(o => o.EffectId is 1814);
             var flourishingFountainBuff = PluginInterface.ClientState.LocalPlayer.StatusEffects.Where(o => o.EffectId is 1815);
+            var flourishingWindmillBuff = PluginInterface.ClientState.LocalPlayer.StatusEffects.Where(o => o.EffectId is 1816);
+            var flourishingShowerBuff = PluginInterface.ClientState.LocalPlayer.StatusEffects.Where(o => o.EffectId is 1817);
 
             var xPos = CenterX - ProcXOffset;
             var yPos = CenterY + ProcYOffset;
 
             var cascadeBuilder = BarBuilder.Create(xPos, yPos, ProcHeight, ProcWidth);
             var fountainBuilder = BarBuilder.Create(xPos + ProcWidth + ProcPadding, yPos, ProcHeight, ProcWidth);
+            var windmillBuilder = BarBuilder.Create(xPos + 2 * ProcWidth + 2 * ProcPadding, yPos, ProcHeight, ProcWidth);
+            var showerBuilder = BarBuilder.Create(xPos + 3 * ProcWidth + 3 * ProcPadding, yPos, ProcHeight, ProcWidth);
 
             if (flourishingCascadeBuff.Any() && ProcEnabled)
-                cascadeBuilder.AddInnerBar(Math.Abs(flourishingCascadeBuff.First().Duration), 20, FlourishingCascadeColor);
+            {
+                var cascadeStart = ProcTimersEnabled ? Math.Abs(flourishingCascadeBuff.First().Duration) : 20;
+                cascadeBuilder.AddInnerBar(cascadeStart, 20, FlourishingCascadeColor);
+            }
             if (flourishingFountainBuff.Any() && ProcEnabled)
-                fountainBuilder.AddInnerBar(Math.Abs(flourishingFountainBuff.First().Duration), 20, FlourishingFountainColor);
+            {
+                var fountainStart = ProcTimersEnabled ? Math.Abs(flourishingFountainBuff.First().Duration) : 20;
+                fountainBuilder.AddInnerBar(fountainStart, 20, FlourishingFountainColor);
+            }
+            if (flourishingWindmillBuff.Any() && ProcEnabled)
+            {
+                var windmillStart = ProcTimersEnabled ? Math.Abs(flourishingWindmillBuff.First().Duration) : 20;
+                windmillBuilder.AddInnerBar(windmillStart, 20, FlourishingWindmillColor);
+            }
+            if (flourishingShowerBuff.Any() && ProcEnabled)
+            {
+                var showerStart = ProcTimersEnabled ? Math.Abs(flourishingShowerBuff.First().Duration) : 20;
+                showerBuilder.AddInnerBar(showerStart, 20, FlourishingShowerColor);
+            }
             var drawList = ImGui.GetWindowDrawList();
             cascadeBuilder.Build().Draw(drawList);
             fountainBuilder.Build().Draw(drawList);
+            windmillBuilder.Build().Draw(drawList);
+            showerBuilder.Build().Draw(drawList);
         }
 }
 }

--- a/DelvUI/PluginConfiguration.cs
+++ b/DelvUI/PluginConfiguration.cs
@@ -777,6 +777,12 @@ namespace DelvUI {
         public int DNCStepXOffset { get; set; } = 127;
         public int DNCStepYOffset { get; set; } = 365;
         public int DNCStepPadding { get; set; } = 2;
+        public bool DNCProcEnabled { get; set; } = true;
+        public int DNCProcHeight { get; set; } = 13;
+        public int DNCProcWidth { get; set; } = 62;
+        public int DNCProcPadding { get; set; } = 2;
+        public int DNCProcXOffset { get; set; } = 127;
+        public int DNCProcYOffset { get; set; } = 365;
         
         public Vector4 DNCEspritColor = new Vector4(72f/255f, 20f/255f, 99f/255f, 100f/100f);
         public Vector4 DNCFeatherColor = new Vector4(175f/255f, 229f/255f, 29f/255f, 100f/100f);
@@ -791,6 +797,9 @@ namespace DelvUI {
         public Vector4 DNCEmptyColor = new Vector4(143f/255f, 141f/255f, 142f/255f, 100f/100f);
         public Vector4 DNCDanceReadyColor = new Vector4(255f/255f, 215f/255f, 0f/255f, 100f/100f);
         public Vector4 DNCDevilmentColor = new Vector4(52f/255f, 78f/255f, 29f/255f, 100f/100f);
+        public Vector4 DNCFlourishingCascadeColor = new Vector4(0f/255f, 255f/255f, 0f/255f, 100f/100f);
+
+        public Vector4 DNCFlourishingFountainColor = new Vector4(255f/255f, 215f/255f, 0f/255f, 100f/100f);
 
         #endregion
 
@@ -1720,6 +1729,20 @@ namespace DelvUI {
                     ["background"] = ImGui.ColorConvertFloat4ToU32(DNCDevilmentColor.AdjustColor(-.8f)),
                     ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(DNCDevilmentColor.AdjustColor(-.1f)),
                     ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(DNCDevilmentColor.AdjustColor(.1f))
+                },
+                [Jobs.DNC * 1000 + 13] = new Dictionary<string, uint> // Devilment
+                {
+                    ["base"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingCascadeColor),
+                    ["background"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingCascadeColor.AdjustColor(-.8f)),
+                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingCascadeColor.AdjustColor(-.1f)),
+                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingCascadeColor.AdjustColor(.1f))
+                },
+                [Jobs.DNC * 1000 + 14] = new Dictionary<string, uint> // Devilment
+                {
+                    ["base"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingFountainColor),
+                    ["background"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingFountainColor.AdjustColor(-.8f)),
+                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingFountainColor.AdjustColor(-.1f)),
+                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingFountainColor.AdjustColor(.1f))
                 },
 
                 [Jobs.BLM] = new Dictionary<string, uint>

--- a/DelvUI/PluginConfiguration.cs
+++ b/DelvUI/PluginConfiguration.cs
@@ -779,6 +779,7 @@ namespace DelvUI {
         public int DNCStepYOffset { get; set; } = 365;
         public int DNCStepPadding { get; set; } = 2;
         public bool DNCProcEnabled { get; set; } = true;
+        public bool DNCProcTimersEnabled { get; set; } = false;
         public int DNCProcHeight { get; set; } = 13;
         public int DNCProcWidth { get; set; } = 62;
         public int DNCProcPadding { get; set; } = 2;
@@ -799,8 +800,9 @@ namespace DelvUI {
         public Vector4 DNCDanceReadyColor = new Vector4(255f/255f, 215f/255f, 0f/255f, 100f/100f);
         public Vector4 DNCDevilmentColor = new Vector4(52f/255f, 78f/255f, 29f/255f, 100f/100f);
         public Vector4 DNCFlourishingCascadeColor = new Vector4(0f/255f, 255f/255f, 0f/255f, 100f/100f);
-
         public Vector4 DNCFlourishingFountainColor = new Vector4(255f/255f, 215f/255f, 0f/255f, 100f/100f);
+        public Vector4 DNCFlourishingWindmillColor = new Vector4(0f/255f, 215f/255f, 215f/255f, 100f/100f);
+        public Vector4 DNCFlourishingShowerColor = new Vector4(255f/255f, 100f/255f, 0f/255f, 100f/100f);
 
         #endregion
 
@@ -1744,6 +1746,20 @@ namespace DelvUI {
                     ["background"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingFountainColor.AdjustColor(-.8f)),
                     ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingFountainColor.AdjustColor(-.1f)),
                     ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingFountainColor.AdjustColor(.1f))
+                },
+                [Jobs.DNC * 1000 + 15] = new Dictionary<string, uint> // Devilment
+                {
+                    ["base"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingWindmillColor),
+                    ["background"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingWindmillColor.AdjustColor(-.8f)),
+                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingWindmillColor.AdjustColor(-.1f)),
+                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingWindmillColor.AdjustColor(.1f))
+                },
+                [Jobs.DNC * 1000 + 16] = new Dictionary<string, uint> // Devilment
+                {
+                    ["base"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingShowerColor),
+                    ["background"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingShowerColor.AdjustColor(-.8f)),
+                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingShowerColor.AdjustColor(-.1f)),
+                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(DNCFlourishingShowerColor.AdjustColor(.1f))
                 },
 
                 [Jobs.BLM] = new Dictionary<string, uint>


### PR DESCRIPTION
This pull request adds bars for the single target DNC procs (Flourishing Cascade and Flourishing Fountain), which default to the color of their corresponding step transformation (i.e., the color of Flourishing Cascade defaults to that of Jete, Flourishing Fountain to Pirouette). The bars default to the size of the feather bars, use the same padding as the feather bars, and default to a location just above those feather bars.