### PR TITLE
fix: BRD Job Bar Independence

### DIFF
--- a/DelvUI/Interface/BardHudWindow.cs
+++ b/DelvUI/Interface/BardHudWindow.cs
@@ -35,7 +35,6 @@ namespace DelvUI.Interface {
         private int BRDSBXOffset => PluginConfiguration.BRDSBXOffset;
         private int BRDSBYOffset => PluginConfiguration.BRDSBYOffset;
         private int BRDStackPadding => PluginConfiguration.BRDStackPadding;
-        private int InterBarOffset => PluginConfiguration.BRDInterBarOffset;
         private bool BRDShowSongGauge => PluginConfiguration.BRDShowSongGauge;
         private bool BRDShowSoulGauge => PluginConfiguration.BRDShowSoulGauge;
         private bool BRDShowWMStacks => PluginConfiguration.BRDShowWMStacks;
@@ -60,26 +59,25 @@ namespace DelvUI.Interface {
 
         protected override void Draw(bool _)
         {
-            var nextHeight = DrawActiveDots(-2);
-            nextHeight = HandleCurrentSong(nextHeight);
-            DrawSoulVoiceBar(nextHeight);
+            DrawActiveDots();
+            HandleCurrentSong();
+            DrawSoulVoiceBar();
         }
 
         protected override void DrawPrimaryResourceBar()
         {
         }
 
-        private int DrawActiveDots(int initialHeight)
+        private void DrawActiveDots()
         {
-            var nextHeight = Math.Abs(BRDCBYOffset - BRDSBYOffset) + BRDCBHeight;
-            if (!BRDShowCB && !BRDShowSB) return nextHeight;
+            if (!BRDShowCB && !BRDShowSB) return;
             var target = PluginInterface.ClientState.Targets.SoftTarget ?? PluginInterface.ClientState.Targets.CurrentTarget;
 
             if (target is not Chara) {
-                return nextHeight;
+                return;
             }
             var xPos = CenterX - XOffset + BRDCBXOffset;
-            var yPos = CenterY + YOffset + BRDCBYOffset + initialHeight;
+            var yPos = CenterY + YOffset + BRDCBYOffset;
 
             var barDrawList = new List<Bar>();
 
@@ -91,36 +89,36 @@ namespace DelvUI.Interface {
                 var duration = Math.Abs(cb.Duration);
 
                 var color = duration <= 5 ? ExpireColor : CBColor;
-            
+
                 var builder = BarBuilder.Create(xPos, yPos, BRDCBHeight, BRDCBWidth);
-                
+
                 var cbBar = builder.AddInnerBar(duration, 30f, color)
                     .SetFlipDrainDirection(BRDCBInverted)
                     .Build();
                 barDrawList.Add(cbBar);
             }
-            
+
             xPos = CenterX - XOffset + BRDSBXOffset;
-            yPos = CenterY + YOffset + BRDSBYOffset + initialHeight;
-            
+            yPos = CenterY + YOffset + BRDSBYOffset;
+
             if (BRDShowSB)
             {
                 var sb = target.StatusEffects.FirstOrDefault(o =>
                     o.EffectId == 1201 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId ||
                     o.EffectId == 129 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId);
                 var duration = Math.Abs(sb.Duration);
-                
+
                 var color = duration <= 5 ? ExpireColor : SBColor;
-            
+
                 var builder = BarBuilder.Create(xPos, yPos, BRDSBHeight, BRDSBWidth);
-                
+
                 var sbBar = builder.AddInnerBar(duration, 30f, color)
                     .SetFlipDrainDirection(BRDSBInverted)
                     .Build();
                 barDrawList.Add(sbBar);
 
             }
-            
+
             if (barDrawList.Count > 0)
             {
                 var drawList = ImGui.GetWindowDrawList();
@@ -129,89 +127,87 @@ namespace DelvUI.Interface {
                     bar.Draw(drawList);
                 }
             }
-            return nextHeight;
         }
 
-        private int HandleCurrentSong(int initialHeight)
+        private void HandleCurrentSong()
         {
             var gauge = PluginInterface.ClientState.JobGauges.Get<BRDGauge>();
             var songStacks = gauge.NumSongStacks;
             var song = gauge.ActiveSong;
             var songTimer = gauge.SongTimer;
-            
-            var nextHeight = BRDStackHeight + initialHeight + InterBarOffset;
-            
+
             switch (song)
             {
                 case CurrentSong.WANDERER:
-                    if(BRDShowWMStacks) nextHeight = DrawStacks(initialHeight, songStacks, 3, WMStackColor);
-                    return DrawSongTimer(nextHeight, songTimer, WMColor);
+                    if (BRDShowWMStacks)
+                        DrawStacks(songStacks, 3, WMStackColor);
+                    DrawSongTimer(songTimer, WMColor);
+                    break;
                 case CurrentSong.MAGE:
-                    if(BRDShowMBProc) nextHeight = DrawBloodletterReady(initialHeight, MBStackColor);
-                    return DrawSongTimer(nextHeight, songTimer, MBColor);
+                    if (BRDShowMBProc)
+                        DrawBloodletterReady(MBStackColor);
+                    DrawSongTimer(songTimer, MBColor);
+                    break;
                 case CurrentSong.ARMY:
-                    if(BRDShowAPStacks) nextHeight = DrawStacks(initialHeight, songStacks, 4, APStackColor);
-                    return DrawSongTimer(nextHeight, songTimer, APColor);
+                    if (BRDShowAPStacks)
+                        DrawStacks(songStacks, 4, APStackColor);
+                    DrawSongTimer(songTimer, APColor);
+                    break;
                 case CurrentSong.NONE:
-                    return DrawSongTimer(nextHeight, 0, EmptyColor);
+                    DrawSongTimer(0, EmptyColor);
+                    break;
                 default:
-                    return DrawSongTimer(nextHeight, 0, EmptyColor);
+                    DrawSongTimer(0, EmptyColor);
+                    break;
             }
         }
 
-        private int DrawBloodletterReady(int initialHeight, Dictionary<string, uint> color)
+        private void DrawBloodletterReady(Dictionary<string, uint> color)
         {
             // I want to draw Bloodletter procs here (just color entire bar red to indicate cooldown is ready).
             // But can't find a way yet to accomplish this.
-            return initialHeight + BRDStackHeight + InterBarOffset;
         }
 
-        private int DrawSongTimer(int initialHeight, short songTimer, Dictionary<string, uint> songColor)
+        private void DrawSongTimer(short songTimer, Dictionary<string, uint> songColor)
         {
-            var nextHeight = BRDSongGaugeHeight + initialHeight + InterBarOffset;
-            if (!BRDShowSongGauge) return nextHeight;
+            if (!BRDShowSongGauge) return;
             var xPos = CenterX - XOffset + BRDSongGaugeXOffset;
-            var yPos = CenterY + YOffset + BRDSongGaugeYOffset + initialHeight;
-            
+            var yPos = CenterY + YOffset + BRDSongGaugeYOffset;
+
             var builder = BarBuilder.Create(xPos, yPos, BRDSongGaugeHeight, BRDSongGaugeWidth);
 
             var duration = Math.Abs(songTimer);
-            
+
             var bar = builder.AddInnerBar(duration / 1000f, 30f, songColor)
                 .SetTextMode(BarTextMode.EachChunk)
                 .SetText(BarTextPosition.CenterMiddle, BarTextType.Current)
                 .Build();
-            
+
             var drawList = ImGui.GetWindowDrawList();
             bar.Draw(drawList);
-            
-            return nextHeight;
         }
 
-        private int DrawSoulVoiceBar(int initialHeight)
+        private void DrawSoulVoiceBar()
         {
-            var nextHeight = BRDSoulGaugeHeight + initialHeight + InterBarOffset;
-            if (!BRDShowSoulGauge) return nextHeight;
+            if (!BRDShowSoulGauge) return;
             var soulVoice = PluginInterface.ClientState.JobGauges.Get<BRDGauge>().SoulVoiceValue;
 
             var xPos = CenterX - XOffset + BRDSoulGaugeXOffset;
-            var yPos = CenterY + YOffset + BRDSoulGaugeYOffset + initialHeight;
-            
+            var yPos = CenterY + YOffset + BRDSoulGaugeYOffset;
+
             var builder = BarBuilder.Create(xPos, yPos, BRDSoulGaugeHeight, BRDSoulGaugeWidth);
-            
+
             var bar = builder.AddInnerBar(soulVoice, 100f, SVColor)
                 .Build();
-            
+
             var drawList = ImGui.GetWindowDrawList();
             bar.Draw(drawList);
-            
-            return nextHeight;
         }
 
-        private int DrawStacks(int initialHeight, int amount, int max, Dictionary<string, uint> stackColor)
+        private void DrawStacks(int amount, int max, Dictionary<string, uint> stackColor)
         {
             var xPos = CenterX - XOffset + BRDStackXOffset;
-            var yPos = CenterY + YOffset + initialHeight + BRDStackYOffset;
+            var yPos = CenterY + YOffset + BRDStackYOffset;
             var bar = BarBuilder.Create(xPos, yPos, BRDStackHeight, BRDStackWidth)
                 .SetChunks(max)
                 .SetChunkPadding(BRDStackPadding)
@@ -219,8 +215,6 @@ namespace DelvUI.Interface {
                 .Build();
             var drawList = ImGui.GetWindowDrawList();
             bar.Draw(drawList);
-
-            return BRDStackHeight + initialHeight + InterBarOffset;
         }
     }
 }

--- a/DelvUI/Interface/ConfigurationWindow.cs
+++ b/DelvUI/Interface/ConfigurationWindow.cs
@@ -3116,12 +3116,6 @@ namespace DelvUI.Interface
                         _pluginConfiguration.Save();
                     }
                     
-                    var brdInterBarOffset = _pluginConfiguration.BRDInterBarOffset;
-                    if (ImGui.DragInt("Space Between Bars", ref brdInterBarOffset, .1f, 0, 1000)) {
-                        _pluginConfiguration.BRDInterBarOffset = brdInterBarOffset;
-                        _pluginConfiguration.Save();
-                    }
-
                     var brdShowSongGauge = _pluginConfiguration.BRDShowSongGauge;
                     if (ImGui.Checkbox("Song Gauge Enabled", ref brdShowSongGauge))
                     {

--- a/DelvUI/PluginConfiguration.cs
+++ b/DelvUI/PluginConfiguration.cs
@@ -149,17 +149,17 @@ namespace DelvUI {
 
         
         #region BRD Configuration
-        
+
         public int BRDBaseXOffset { get; set; } = 127;
-        public int BRDBaseYOffset { get; set; } = 405;
+        public int BRDBaseYOffset { get; set; } = 415;
         public int BRDSongGaugeWidth { get; set; } = 254;
         public int BRDSongGaugeHeight { get; set; } = 20;
         public int BRDSongGaugeXOffset { get; set; }
-        public int BRDSongGaugeYOffset { get; set; }
+        public int BRDSongGaugeYOffset { get; set; } = 12;
         public int BRDSoulGaugeWidth { get; set; } = 254;
         public int BRDSoulGaugeHeight { get; set; } = 10;
         public int BRDSoulGaugeXOffset { get; set; }
-        public int BRDSoulGaugeYOffset { get; set; }
+        public int BRDSoulGaugeYOffset { get; set; } = 34;
         public int BRDStackWidth { get; set; } = 254;
         public int BRDStackHeight { get; set; } = 10;
         public int BRDStackXOffset { get; set; }
@@ -168,13 +168,12 @@ namespace DelvUI {
         public int BRDCBWidth { get; set; } = 126;
         public int BRDCBHeight { get; set; } = 10;
         public int BRDCBXOffset { get; set; }
-        public int BRDCBYOffset { get; set; }
+        public int BRDCBYOffset { get; set; } = -12;
         public int BRDSBWidth { get; set; } = 126;
         public int BRDSBHeight { get; set; } = 10;
         public int BRDSBXOffset { get; set; } = 128;
-        public int BRDSBYOffset { get; set; }
-        public int BRDInterBarOffset { get; set; } = 2;
-        
+        public int BRDSBYOffset { get; set; } = -12;
+
         public bool BRDShowSB = true;
         public bool BRDShowCB = true;
         public bool BRDSBInverted = false;
@@ -184,7 +183,7 @@ namespace DelvUI {
         public bool BRDShowWMStacks = true;
         public bool BRDShowMBProc = true;
         public bool BRDShowAPStacks = true;
-        
+
         public Vector4 BRDEmptyColor = new Vector4(0f/255f, 0f/255f, 0f/255f, 53f/100f);
         public Vector4 BRDExpireColor = new Vector4(199f/255f, 46f/255f, 46f/255f, 100f/100f);
         public Vector4 BRDCBColor = new Vector4(182f/255f, 68f/255f, 235f/255f, 100f/100f);


### PR DESCRIPTION
- Remove initialHeight pattern
- Remove "Space Between Bars" slider
- Set correct default offsets

![ffxiv_dx11_xTo0zaM4qx](https://user-images.githubusercontent.com/89595918/131652118-c4a5b4b1-0e8a-4595-8bd1-1629ff185d66.png)
![ffxiv_dx11_5Braq6C8UX](https://user-images.githubusercontent.com/89595918/131652122-0e34bd94-e0fa-4679-8642-f1466769fb24.png)

Relates to #154 