### PR TITLE
fix: issue with shields on target an focus bars

### DIFF
--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -223,8 +223,8 @@ namespace DelvUI.Interface {
             ImGui.SetNextWindowSize(BarSize);
             ImGui.SetNextWindowPos(cursorPos);
             
-            ImGui.Begin("t_bar", windowFlags);
-            if (ImGui.BeginChild("t_bar", BarSize))
+            ImGui.Begin("target_bar", windowFlags);
+            if (ImGui.BeginChild("target_bar", BarSize))
             {
                 if (target is not Chara actor)
                 {
@@ -247,8 +247,6 @@ namespace DelvUI.Interface {
                         colors["gradientLeft"], colors["gradientRight"], colors["gradientRight"], colors["gradientLeft"]
                     );
                     drawList.AddRect(cursorPos, cursorPos + BarSize, 0xFF000000);
-
-                    DrawTargetShield(target, cursorPos, BarSize, true);
                 }
                 if (ImGui.GetIO().MouseClicked[1] && ImGui.IsMouseHoveringRect(cursorPos, cursorPos + BarSize))
                 {
@@ -262,6 +260,8 @@ namespace DelvUI.Interface {
             }
             ImGui.EndChild();
             ImGui.End();
+            
+            DrawTargetShield(target, cursorPos, BarSize, true);
 
             var textLeft = Helpers.TextTags.GenerateFormattedTextFromTags(target, PluginConfiguration.TargetBarTextLeft);
             DrawOutlinedText(textLeft,
@@ -325,8 +325,6 @@ namespace DelvUI.Interface {
                         colors["gradientLeft"], colors["gradientRight"], colors["gradientRight"], colors["gradientLeft"]
                     );
                     drawList.AddRect(cursorPos, cursorPos + barSize, 0xFF000000);
-
-                    DrawTargetShield(focus, cursorPos, barSize, true);
                 }
 
                 if (ImGui.GetIO().MouseClicked[1] && ImGui.IsMouseHoveringRect(cursorPos, cursorPos + BarSize))
@@ -343,6 +341,8 @@ namespace DelvUI.Interface {
 
             ImGui.EndChild();
             ImGui.End();
+            
+            DrawTargetShield(focus, cursorPos, barSize, true);
 
             var text = Helpers.TextTags.GenerateFormattedTextFromTags(focus, PluginConfiguration.FocusBarText);
             var textSize = ImGui.CalcTextSize(text);


### PR DESCRIPTION
Issue was due to where the the DrawShield methods were being called. Needed to move them outside of the ImGui Begin and BeginChilds.