### PR TITLE
Add target checks to LastUsedCast

### DIFF
--- a/DelvUI/Helpers/LastUsedCast.cs
+++ b/DelvUI/Helpers/LastUsedCast.cs
@@ -8,6 +8,7 @@ using Action = Lumina.Excel.GeneratedSheets.Action;
 using Companion = Lumina.Excel.GeneratedSheets.Companion;
 using DelvUI.Enums;
 using ImGuiScene;
+using Dalamud.Game.ClientState.Actors;
 
 namespace DelvUI.Helpers
 {
@@ -46,9 +47,26 @@ namespace DelvUI.Helpers
 
         private void SetCastProperties()
         {
+            var target = _pluginInterface.ClientState.Targets.SoftTarget ?? _pluginInterface.ClientState.Targets.CurrentTarget;
+            var targetKind = target?.ObjectKind;
+
+            switch (targetKind)
+            {
+                case null: break;
+                case ObjectKind.Aetheryte:
+                    ActionText = "Attuning...";
+                    _icon = _pluginInterface.Data.GetIcon(112);
+                    return;
+                case ObjectKind.EventObj:
+                case ObjectKind.EventNpc:
+                    ActionText = "Interacting...";
+                    _icon = _pluginInterface.Data.GetIcon(0);
+                    return;
+            }
+
             _lastUsedAction = null;
             Interruptable = _castInfo.Interruptible > 0;
-            if (CastId == 1)
+            if (CastId == 1 && ActionType != ActionType.Mount)
             {
                 ActionText = "Interacting...";
                 _icon = _pluginInterface.Data.GetIcon(0);


### PR DESCRIPTION
Adds target type checks to LastUsedCast so that quest item and location interactions should work as expected.

Also fixes issue where the Company Chocobo would have the wrong cast bar.