### PR TITLE
Display MP Value and Treshold on Healer jobs

### DIFF
--- a/DelvUI/Interface/ConfigurationWindow.cs
+++ b/DelvUI/Interface/ConfigurationWindow.cs
@@ -1695,7 +1695,38 @@ namespace DelvUI.Interface
                 _pluginConfiguration.PrimaryResourceBarYOffset = primaryResourceBarYOffset;
                 _pluginConfiguration.Save();
             }
-            
+
+            _changed |= ImGui.Checkbox("Show Primary Resource Value", ref _pluginConfiguration.ShowPrimaryResourceBarValue);
+
+            if (_pluginConfiguration.ShowPrimaryResourceBarValue)
+            {
+                var primaryResourceBarTextXOffset = _pluginConfiguration.PrimaryResourceBarTextXOffset;
+                if (ImGui.DragInt("Primary Resource Text X Offset", ref primaryResourceBarTextXOffset, .1f, -_xOffsetLimit, _xOffsetLimit))
+                {
+                    _pluginConfiguration.PrimaryResourceBarTextXOffset = primaryResourceBarTextXOffset;
+                    _pluginConfiguration.Save();
+                }
+
+                var primaryResourceBarTextYOffset = _pluginConfiguration.PrimaryResourceBarTextYOffset;
+                if (ImGui.DragInt("Primary Resource Text Y Offset", ref primaryResourceBarTextYOffset, .1f, -_yOffsetLimit, _yOffsetLimit))
+                {
+                    _pluginConfiguration.PrimaryResourceBarTextYOffset = primaryResourceBarTextYOffset;
+                    _pluginConfiguration.Save();
+                }
+            }
+
+            _changed |= ImGui.Checkbox("Show Primary Resource Threshold Marker", ref _pluginConfiguration.ShowPrimaryResourceBarThresholdMarker);
+                
+            if (_pluginConfiguration.ShowPrimaryResourceBarThresholdMarker)
+            {
+                var primaryResourceBarThresholdValue = _pluginConfiguration.PrimaryResourceBarThresholdValue;
+                if (ImGui.DragInt("Primary Resource Bar Threshold Marker Value", ref primaryResourceBarThresholdValue, 1f, 1, 10000))
+                {
+                    _pluginConfiguration.PrimaryResourceBarThresholdValue = primaryResourceBarThresholdValue;
+                    _pluginConfiguration.Save();
+                }
+            }
+        
             _changed |= ImGui.ColorEdit4("Bar Not Full Color", ref _pluginConfiguration.EmptyColor);
 
         }

--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -51,6 +51,11 @@ namespace DelvUI.Interface {
         protected int PrimaryResourceBarWidth => PluginConfiguration.PrimaryResourceBarWidth;
         protected int PrimaryResourceBarXOffset => PluginConfiguration.PrimaryResourceBarXOffset;
         protected int PrimaryResourceBarYOffset => PluginConfiguration.PrimaryResourceBarYOffset;
+        protected int PrimaryResourceBarTextXOffset => PluginConfiguration.PrimaryResourceBarTextXOffset;
+        protected int PrimaryResourceBarTextYOffset => PluginConfiguration.PrimaryResourceBarTextYOffset;
+        protected bool ShowPrimaryResourceBarValue => PluginConfiguration.ShowPrimaryResourceBarValue;
+        protected bool ShowPrimaryResourceBarThresholdMarker => PluginConfiguration.ShowPrimaryResourceBarThresholdMarker;
+        protected int PrimaryResourceBarThresholdValue => PluginConfiguration.PrimaryResourceBarThresholdValue;
 
         protected int TargetBarHeight => PluginConfiguration.TargetBarHeight;
         protected int TargetBarWidth => PluginConfiguration.TargetBarWidth;
@@ -248,6 +253,21 @@ namespace DelvUI.Interface {
                 0xFFE6CD00, 0xFFD8Df3C, 0xFFD8Df3C, 0xFFE6CD00
             );
             drawList.AddRect(cursorPos, cursorPos + BarSize, 0xFF000000);
+
+            if (ShowPrimaryResourceBarThresholdMarker)
+            {
+                // threshold
+                var position = new Vector2(cursorPos.X + (PrimaryResourceBarThresholdValue / 10000f) * BarSize.X - 3, cursorPos.Y);
+                var size = new Vector2(2, BarSize.Y);
+                drawList.AddRect(position, position + size, 0xFF000000);
+            }
+
+            if (!ShowPrimaryResourceBarValue) return;
+
+            // text
+            var mana = PluginInterface.ClientState.LocalPlayer.CurrentMp;
+            var text = $"{mana,0}";
+            DrawOutlinedText(text, new Vector2(cursorPos.X + 2 + PrimaryResourceBarTextXOffset, cursorPos.Y - 3 + PrimaryResourceBarTextYOffset));
         }
 
         protected virtual void DrawTargetBar() {

--- a/DelvUI/PluginConfiguration.cs
+++ b/DelvUI/PluginConfiguration.cs
@@ -23,6 +23,11 @@ namespace DelvUI {
         public int PrimaryResourceBarWidth { get; set; } = 254;
         public int PrimaryResourceBarXOffset { get; set; } = 160;
         public int PrimaryResourceBarYOffset { get; set; } = 455;
+        public int PrimaryResourceBarTextXOffset { get; set; } = 0;
+        public int PrimaryResourceBarTextYOffset { get; set; } = 0;
+        public bool ShowPrimaryResourceBarValue = false;
+        public bool ShowPrimaryResourceBarThresholdMarker = false;
+        public int PrimaryResourceBarThresholdValue { get; set; } = 7000;
         public int TargetBarHeight { get; set; } = 50;
         public int TargetBarWidth { get; set; } = 270;
         public int TargetBarXOffset { get; set; } = 160;


### PR DESCRIPTION
Currently, all healer jobs (WHM/SCH/AST) use the default PrimaryResourceBar to display their MP.

This modification adds the configuration to display the current MP Value and a threshold bar (like the already existing one for the RDM MP Bar).

I made the configuration modifications in the General tab as it is where the Primary Resource bar configuration is already present but currently, it only affects healer jobs and not currently managed jobs (BLU, DoH, DoL).

Example on AST:
![image](https://user-images.githubusercontent.com/1774188/131845103-d8be8dac-da12-4366-a329-23eccbb2361e.png)

Added configuration:
![image](https://user-images.githubusercontent.com/1774188/131845185-80ce860b-c423-4148-84a3-95e1915f4468.png)

