### PR TITLE
Display CP and GP for DoH and DoL jobs

### DIFF
--- a/DelvUI/Interface/HandHudWindow.cs
+++ b/DelvUI/Interface/HandHudWindow.cs
@@ -1,0 +1,61 @@
+﻿using Dalamud.Plugin;
+using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DelvUI.Interface
+{
+    public class HandHudWindow : HudWindow
+    {
+
+        public HandHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration) :
+            base(pluginInterface, pluginConfiguration)
+        {
+            JobId = pluginInterface.ClientState.LocalPlayer.ClassJob.Id;
+        }
+        public override uint JobId { get; }
+
+
+        protected override void Draw(bool _)
+        {
+        }
+
+        protected override void DrawPrimaryResourceBar() {
+            Debug.Assert(PluginInterface.ClientState.LocalPlayer != null, "PluginInterface.ClientState.LocalPlayer != null");
+            var barSize = new Vector2(PrimaryResourceBarWidth, PrimaryResourceBarHeight);
+            var actor = PluginInterface.ClientState.LocalPlayer;
+            var scale = (float) actor.CurrentCp / actor.MaxCp;
+            var cursorPos = new Vector2(CenterX - PrimaryResourceBarXOffset + 33, CenterY + PrimaryResourceBarYOffset - 16);
+
+            var drawList = ImGui.GetWindowDrawList();
+            drawList.AddRectFilled(cursorPos, cursorPos + barSize, 0x88000000);
+            drawList.AddRectFilledMultiColor(
+                cursorPos, cursorPos + new Vector2(barSize.X * scale, barSize.Y),
+                0xFFE6CD00, 0xFFD8Df3C, 0xFFD8Df3C, 0xFFE6CD00
+            );
+            drawList.AddRect(cursorPos, cursorPos + barSize, 0xFF000000);
+
+            if (ShowPrimaryResourceBarThresholdMarker)
+            {
+                // threshold
+                var position = new Vector2(cursorPos.X + (PrimaryResourceBarThresholdValue / 10000f) * barSize.X - 3, cursorPos.Y);
+                var size = new Vector2(2, barSize.Y);
+                drawList.AddRect(position, position + size, 0xFF000000);
+            }
+
+            if (!ShowPrimaryResourceBarValue) return;
+
+            // text
+            var currentCp = PluginInterface.ClientState.LocalPlayer.CurrentCp;
+            var text = $"{currentCp,0}";
+            DrawOutlinedText(text, new Vector2(cursorPos.X + 2 + PrimaryResourceBarTextXOffset, cursorPos.Y - 3 + PrimaryResourceBarTextYOffset));
+        }
+
+
+    }
+}

--- a/DelvUI/Interface/LandHudWindow.cs
+++ b/DelvUI/Interface/LandHudWindow.cs
@@ -1,0 +1,61 @@
+﻿using Dalamud.Plugin;
+using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DelvUI.Interface
+{
+    public class LandHudWindow : HudWindow
+    {
+
+        public LandHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration) :
+            base(pluginInterface, pluginConfiguration)
+        {
+            JobId = pluginInterface.ClientState.LocalPlayer.ClassJob.Id;
+        }
+        public override uint JobId { get; }
+
+
+        protected override void Draw(bool _)
+        {
+        }
+
+        protected override void DrawPrimaryResourceBar() {
+            Debug.Assert(PluginInterface.ClientState.LocalPlayer != null, "PluginInterface.ClientState.LocalPlayer != null");
+            var barSize = new Vector2(PrimaryResourceBarWidth, PrimaryResourceBarHeight);
+            var actor = PluginInterface.ClientState.LocalPlayer;
+            var scale = (float) actor.CurrentGp / actor.MaxGp;
+            var cursorPos = new Vector2(CenterX - PrimaryResourceBarXOffset + 33, CenterY + PrimaryResourceBarYOffset - 16);
+
+            var drawList = ImGui.GetWindowDrawList();
+            drawList.AddRectFilled(cursorPos, cursorPos + barSize, 0x88000000);
+            drawList.AddRectFilledMultiColor(
+                cursorPos, cursorPos + new Vector2(barSize.X * scale, barSize.Y),
+                0xFFE6CD00, 0xFFD8Df3C, 0xFFD8Df3C, 0xFFE6CD00
+            );
+            drawList.AddRect(cursorPos, cursorPos + barSize, 0xFF000000);
+
+            if (ShowPrimaryResourceBarThresholdMarker)
+            {
+                // threshold
+                var position = new Vector2(cursorPos.X + (PrimaryResourceBarThresholdValue / 10000f) * barSize.X - 3, cursorPos.Y);
+                var size = new Vector2(2, barSize.Y);
+                drawList.AddRect(position, position + size, 0xFF000000);
+            }
+
+            if (!ShowPrimaryResourceBarValue) return;
+
+            // text
+            var currentGp = PluginInterface.ClientState.LocalPlayer.CurrentGp;
+            var text = $"{currentGp,0}";
+            DrawOutlinedText(text, new Vector2(cursorPos.X + 2 + PrimaryResourceBarTextXOffset, cursorPos.Y - 3 + PrimaryResourceBarTextYOffset));
+        }
+
+
+    }
+}

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -182,19 +182,19 @@ namespace DelvUI {
                 Jobs.ACN => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
                 
                 //Hand
-                Jobs.CRP => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
-                Jobs.BSM => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
-                Jobs.ARM => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
-                Jobs.GSM => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
-                Jobs.LTW => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
-                Jobs.WVR => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
-                Jobs.ALC => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
-                Jobs.CUL => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.CRP => new HandHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.BSM => new HandHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.ARM => new HandHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.GSM => new HandHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.LTW => new HandHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.WVR => new HandHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.ALC => new HandHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.CUL => new HandHudWindow(_pluginInterface, _pluginConfiguration),
                 
                 //Land
-                Jobs.MIN => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
-                Jobs.BOT => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
-                Jobs.FSH => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.MIN => new LandHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.BOT => new LandHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.FSH => new LandHudWindow(_pluginInterface, _pluginConfiguration),
                 
                 //dont have packs yet
                 Jobs.BLU => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),


### PR DESCRIPTION
Adds an initial support for Disciple of Hand and Disciple of Land jobs by displaying their CP and GP in the PrimaryResourceBar

I decided to create separate classes (namely HandHudWindow.cs and LandHudWindow.cs) to avoid putting a job filtering directly in HudWindow.cs, since the job filtering is originally done in Plugin.cs
This might have to change in the future depending on your plans in terms of supporting DoH and DoL

I don't think it fully solves #144 as there is no very specific support or configuration yet (no specific colors, possibility to add a timer until GP Max for DoL, like existing in Simple Tweaks/UI Tweaks)

![image](https://user-images.githubusercontent.com/1774188/131866243-a0fe869e-6493-4602-9d80-23e3b6b24619.png)
![image](https://user-images.githubusercontent.com/1774188/131866284-dbfa87c1-c882-44c9-ac51-896aad3b6e15.png)
