### PR TITLE
Font scaling

### DIFF
--- a/DelvUI/Helpers/DrawHelper.cs
+++ b/DelvUI/Helpers/DrawHelper.cs
@@ -3,10 +3,30 @@ using ImGuiNET;
 
 namespace DelvUI.Helpers
 {
-    public class DrawHelper
+    public static class DrawHelper
     {
+        public static void DrawOutlinedText(string text, Vector2 pos, float fontScale, PluginConfiguration pluginConfiguration)
+        {
+            DrawOutlinedText(text, pos, Vector4.One, Vector4.UnitW, fontScale, pluginConfiguration);
+        }
+        
+        public static void DrawOutlinedText(string text, Vector2 pos, Vector4 color, Vector4 outlineColor, float fontScale, PluginConfiguration pluginConfiguration)
+        {
+            DrawOutlinedText(text, pos, color, outlineColor, fontScale, pluginConfiguration.BigNoodleTooFont);
+        }
+        
+        public static void DrawOutlinedText(string text, Vector2 pos, Vector4 color, Vector4 outlineColor, float fontScale, ImFontPtr fontPtr)
+        {
+            var originalScale = fontPtr.Scale;
+            fontPtr.Scale = fontScale;
+            ImGui.PushFont(fontPtr);
+            DrawOutlinedText(text, pos, color, outlineColor);
+            ImGui.PopFont();
+            fontPtr.Scale = originalScale;
+        }
+        
         public static void DrawOutlinedText(string text, Vector2 pos) {
-            DrawOutlinedText(text, pos, Vector4.One, new Vector4(0f, 0f, 0f, 1f));
+            DrawOutlinedText(text, pos, Vector4.One, Vector4.UnitW);
         }
         
         public static void DrawOutlinedText(string text, Vector2 pos, Vector4 color, Vector4 outlineColor) {

--- a/DelvUI/Interface/AstrologianHudWindow.cs
+++ b/DelvUI/Interface/AstrologianHudWindow.cs
@@ -159,7 +159,7 @@ namespace DelvUI.Interface
                     .SetText(BarTextPosition.CenterMiddle, BarTextType.Custom, textSealReady);
 
                 var drawList = ImGui.GetWindowDrawList();
-                builder.Build().Draw(drawList);
+                builder.Build().Draw(drawList, PluginConfiguration);
             }
 
         }
@@ -211,7 +211,7 @@ namespace DelvUI.Interface
                 .SetText(BarTextPosition.CenterMiddle, BarTextType.Custom, cardJob)
                 .Build();
 
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
 
         private void DrawDot()
@@ -229,7 +229,7 @@ namespace DelvUI.Interface
                     .SetTextMode(BarTextMode.Single)
                     .SetText(BarTextPosition.CenterMiddle, BarTextType.Current)
                     .Build();
-                barNoTarget.Draw(drawList);
+                barNoTarget.Draw(drawList, PluginConfiguration);
                 return;
             };
             var dot = target.StatusEffects.FirstOrDefault(o => o.EffectId == 1881 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId ||
@@ -245,7 +245,7 @@ namespace DelvUI.Interface
                 .SetText(BarTextPosition.CenterMiddle, BarTextType.Current)
                 .Build();
 
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
 
         private void DrawLightspeed()
@@ -273,7 +273,7 @@ namespace DelvUI.Interface
                 .Build();
 
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
 
         private void DrawStar()
@@ -310,7 +310,7 @@ namespace DelvUI.Interface
                 .Build();
 
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
     }
 }

--- a/DelvUI/Interface/BardHudWindow.cs
+++ b/DelvUI/Interface/BardHudWindow.cs
@@ -124,7 +124,7 @@ namespace DelvUI.Interface {
                 var drawList = ImGui.GetWindowDrawList();
                 foreach (var bar in barDrawList)
                 {
-                    bar.Draw(drawList);
+                    bar.Draw(drawList, PluginConfiguration);
                 }
             }
         }
@@ -184,7 +184,7 @@ namespace DelvUI.Interface {
                 .Build();
 
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
 
         private void DrawSoulVoiceBar()
@@ -201,7 +201,7 @@ namespace DelvUI.Interface {
                 .Build();
 
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
 
         private void DrawStacks(int amount, int max, Dictionary<string, uint> stackColor)
@@ -214,7 +214,7 @@ namespace DelvUI.Interface {
                 .AddInnerBar(amount, max, stackColor)
                 .Build();
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
     }
 }

--- a/DelvUI/Interface/Bars/Bar.cs
+++ b/DelvUI/Interface/Bars/Bar.cs
@@ -66,7 +66,7 @@ namespace DelvUI.Interface.Bars
             return new Vector2(BarWidth, BarHeight);
         }
 
-        public void Draw(ImDrawListPtr drawList)
+        public void Draw(ImDrawListPtr drawList, PluginConfiguration configuration)
         {
             var barWidth = BarWidth + ChunkPadding; // For loop adds one extra padding more than is needed
             var barHeight = BarHeight + ChunkPadding; // For loop adds one extra padding more than is needed
@@ -84,7 +84,7 @@ namespace DelvUI.Interface.Bars
 
             foreach (var innerBar in InnerBars)
             {
-                innerBar.Draw(drawList);
+                innerBar.Draw(drawList, configuration);
             }
 
             cursorPos = new Vector2(XPosition, YPosition);
@@ -103,13 +103,13 @@ namespace DelvUI.Interface.Bars
 
             foreach (var innerBar in InnerBars)
             {
-                innerBar.DrawText(drawList);
+                innerBar.DrawText(drawList, configuration);
             }
 
-            DrawText(drawList);
+            DrawText(drawList, configuration);
         }
 
-        public void DrawText(ImDrawListPtr drawList)
+        public void DrawText(ImDrawListPtr drawList, PluginConfiguration configuration)
         {
             foreach (var text in PrimaryTexts)
             {
@@ -126,7 +126,7 @@ namespace DelvUI.Interface.Bars
 
                 var textPos = text.CalcTextPosition(cursorPos, strText, BarWidth, BarHeight);
 
-                DrawHelper.DrawOutlinedText(strText, textPos, text.Color, text.OutlineColor);
+                DrawHelper.DrawOutlinedText(strText, textPos, text.Color, text.OutlineColor, text.Scale, configuration);
             }
         }
     }
@@ -166,7 +166,7 @@ namespace DelvUI.Interface.Bars
         public BarTextMode TextMode { get; set; }
         public BarText[] Texts { get; set; }
 
-        public virtual void Draw(ImDrawListPtr drawList)
+        public virtual void Draw(ImDrawListPtr drawList, PluginConfiguration configuration)
         {
             var barWidth = Parent.Vertical ? (float) 1 / Parent.InnerBars.Count * Parent.BarWidth : Parent.BarWidth + Parent.ChunkPadding;
             var barHeight = Parent.Vertical ? Parent.BarHeight + Parent.ChunkPadding : (float) 1 / Parent.InnerBars.Count * Parent.BarHeight;
@@ -274,7 +274,7 @@ namespace DelvUI.Interface.Bars
             }
         }
 
-        public void DrawText(ImDrawListPtr drawList)
+        public void DrawText(ImDrawListPtr drawList, PluginConfiguration configuration)
         {
             var barWidth = Parent.Vertical ? (float) 1 / Parent.InnerBars.Count * Parent.BarWidth : Parent.BarWidth + Parent.ChunkPadding;
             var barHeight = Parent.Vertical ? Parent.BarHeight + Parent.ChunkPadding : (float) 1 / Parent.InnerBars.Count * Parent.BarHeight;
@@ -294,7 +294,7 @@ namespace DelvUI.Interface.Bars
                 
                 var textPos = textObj.CalcTextPosition(cursorPos, text, Parent.BarWidth, Parent.BarHeight);
                     
-                DrawHelper.DrawOutlinedText(text, textPos, textObj.Color, textObj.OutlineColor);
+                DrawHelper.DrawOutlinedText(text, textPos, textObj.Color, textObj.OutlineColor, textObj.Scale, configuration);
             }
 
             var currentFill = CurrentValue / MaximumValue;
@@ -333,7 +333,7 @@ namespace DelvUI.Interface.Bars
 
                         var textPos = Parent.Vertical ? textObj.CalcTextPosition(cursorPos, text, Parent.BarWidth, barSize.Y) : textObj.CalcTextPosition(cursorPos, text, barSize.X, Parent.BarHeight);
 
-                        DrawHelper.DrawOutlinedText(text, textPos, textObj.Color, textObj.OutlineColor);
+                        DrawHelper.DrawOutlinedText(text, textPos, textObj.Color, textObj.OutlineColor, textObj.Scale, configuration);
                     }
 
                     i++;
@@ -379,7 +379,7 @@ namespace DelvUI.Interface.Bars
 
                         var textPos = Parent.Vertical ? textObj.CalcTextPosition(cursorPos, text, Parent.BarWidth, barSize.Y) : textObj.CalcTextPosition(cursorPos, text, barSize.X, Parent.BarHeight);
                         
-                        DrawHelper.DrawOutlinedText(text, textPos, textObj.Color, textObj.OutlineColor);
+                        DrawHelper.DrawOutlinedText(text, textPos, textObj.Color, textObj.OutlineColor, textObj.Scale, configuration);
                     }
 
                     i++;
@@ -410,7 +410,7 @@ namespace DelvUI.Interface.Bars
             }
         }
 
-        public override void Draw(ImDrawListPtr drawList)
+        public override void Draw(ImDrawListPtr drawList, PluginConfiguration configuration)
         {
             var barWidth = Parent.Vertical ? (float) 1 / Parent.InnerBars.Count * Parent.BarWidth : Parent.BarWidth + Parent.ChunkPadding;
             var barHeight = Parent.Vertical ? Parent.BarHeight + Parent.ChunkPadding : (float) 1 / Parent.InnerBars.Count * Parent.BarHeight;
@@ -455,6 +455,17 @@ namespace DelvUI.Interface.Bars
         public Vector4 Color { get; set; }
         public Vector4 OutlineColor { get; set; }
         public string Text { get; set; }
+        public float Scale { get; set; }
+
+        public BarText(BarTextPosition position, BarTextType type, Vector4 color, Vector4 outlineColor, string text, float scale)
+        {
+            Position = position;
+            Type = type;
+            Color = color;
+            OutlineColor = outlineColor;
+            Text = text;
+            Scale = scale;
+        }
 
         public BarText(BarTextPosition position, BarTextType type, Vector4 color, Vector4 outlineColor, string text)
         {
@@ -463,6 +474,7 @@ namespace DelvUI.Interface.Bars
             Color = color;
             OutlineColor = outlineColor;
             Text = text;
+            Scale = 1.0f;
         }
 
         public BarText(BarTextPosition position, BarTextType type, string text)
@@ -472,6 +484,7 @@ namespace DelvUI.Interface.Bars
             Text = text;
             Color = Vector4.One;
             OutlineColor = new Vector4(0f, 0f, 0f, 1f);
+            Scale = 1.0f;
         }
         
         public BarText(BarTextPosition position, BarTextType type)
@@ -481,6 +494,7 @@ namespace DelvUI.Interface.Bars
             Text = null;
             Color = Vector4.One;
             OutlineColor = new Vector4(0f, 0f, 0f, 1f);
+            Scale = 1.0f;
         }
 
         public Vector2 CalcTextPosition(Vector2 cursorPos, string text, float barWidth, float barHeight)
@@ -489,6 +503,7 @@ namespace DelvUI.Interface.Bars
             float textYPos;
             
             var textSize = ImGui.CalcTextSize(text);
+            textSize *= Scale;
 
             switch (Position)
             {

--- a/DelvUI/Interface/Bars/BarBuilder.cs
+++ b/DelvUI/Interface/Bars/BarBuilder.cs
@@ -248,9 +248,14 @@ namespace DelvUI.Interface.Bars
             return this;
         }
 
-        public BarBuilder SetText(BarTextPosition posotion, BarTextType type)
+        public BarBuilder SetText(BarTextPosition position, BarTextType type)
         {
-            return SetText(new BarText(posotion, type));
+            return SetText(new BarText(position, type));
+        }
+
+        public BarBuilder SetText(BarTextPosition position, BarTextType type, float scale)
+        {
+            return SetText(position, type, null, scale);
         }
 
         public BarBuilder SetText(BarTextPosition position, BarTextType type, string text)
@@ -258,9 +263,19 @@ namespace DelvUI.Interface.Bars
             return SetText(new BarText(position, type, text));
         }
 
+        public BarBuilder SetText(BarTextPosition position, BarTextType type, string text, float scale)
+        {
+            return SetText(position, type, Vector4.One, Vector4.UnitW, text, scale);
+        }
+
         public BarBuilder SetText(BarTextPosition position, BarTextType type, Vector4 color, Vector4 outlineColor, string text)
         {
             return SetText(new BarText(position, type, color, outlineColor, text));
+        }
+
+        public BarBuilder SetText(BarTextPosition position, BarTextType type, Vector4 color, Vector4 outlineColor, string text, float scale)
+        {
+            return SetText(new BarText(position, type, color, outlineColor, text, scale));
         }
 
         public BarBuilder SetText(BarText text)

--- a/DelvUI/Interface/BlackMageHudWindow.cs
+++ b/DelvUI/Interface/BlackMageHudWindow.cs
@@ -105,7 +105,7 @@ namespace DelvUI.Interface
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
 
             // threshold marker
             if (ShowManaThresholdMarker && gauge.InAstralFire())
@@ -144,7 +144,7 @@ namespace DelvUI.Interface
                 .Build();
 
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
 
         protected virtual void DrawPolyglot()
@@ -171,7 +171,7 @@ namespace DelvUI.Interface
                 builder.SetGlowColor(0x88FFFFFF);
             }
 
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
 
             // 2
             builder = BarBuilder.Create(OriginX - totalWidth / 2 + PolyglotWidth + HorizontalSpaceBetweenBars, y, PolyglotHeight, PolyglotWidth)
@@ -182,7 +182,7 @@ namespace DelvUI.Interface
                 builder.SetGlowColor(0x88FFFFFF);
             }
 
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         protected virtual void DrawTripleCast()
@@ -201,7 +201,7 @@ namespace DelvUI.Interface
                 .Build();
 
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
 
         protected virtual void DrawProcs()

--- a/DelvUI/Interface/ConfigurationWindow.cs
+++ b/DelvUI/Interface/ConfigurationWindow.cs
@@ -1634,6 +1634,13 @@ namespace DelvUI.Interface
                         _pluginConfiguration.WARStormsEyeText = stormsEyeText;
                         _pluginConfiguration.Save();
                     }
+
+                    var stormsEyeTextScale = _pluginConfiguration.WARStormsEyeTextScale;
+                    if (ImGui.DragFloat("Storm's Eye Text Scale", ref stormsEyeTextScale, .005f, 0f, 20f))
+                    {
+                        _pluginConfiguration.WARStormsEyeTextScale = stormsEyeTextScale;
+                        _pluginConfiguration.Save();
+                    }
                     
                     var stormsEyeHeight = _pluginConfiguration.WARStormsEyeHeight;
                     if (ImGui.DragInt("Storm's Eye Height", ref stormsEyeHeight, .1f, 1, 1000))
@@ -1674,6 +1681,13 @@ namespace DelvUI.Interface
                     if (ImGui.Checkbox("Beast Gauge Text", ref beastGaugeText))
                     {
                         _pluginConfiguration.WARBeastGaugeText = beastGaugeText;
+                        _pluginConfiguration.Save();
+                    }
+
+                    var beastGaugeTextScale = _pluginConfiguration.WARBeastGaugeTextScale;
+                    if (ImGui.DragFloat("Beast Gauge Text Scale", ref beastGaugeTextScale, .005f, 0f, 20f))
+                    {
+                        _pluginConfiguration.WARBeastGaugeTextScale = beastGaugeTextScale;
                         _pluginConfiguration.Save();
                     }
 

--- a/DelvUI/Interface/DancerHudWindow.cs
+++ b/DelvUI/Interface/DancerHudWindow.cs
@@ -115,7 +115,7 @@ namespace DelvUI.Interface {
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
         
         private void DrawFeathersBar() {
@@ -137,7 +137,7 @@ namespace DelvUI.Interface {
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private unsafe void DrawStepBar()
@@ -207,7 +207,7 @@ namespace DelvUI.Interface {
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawBuffBar()
@@ -243,7 +243,7 @@ namespace DelvUI.Interface {
             }
             
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawStandardBar()
@@ -267,7 +267,7 @@ namespace DelvUI.Interface {
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawProcBar()
@@ -307,10 +307,10 @@ namespace DelvUI.Interface {
                 showerBuilder.AddInnerBar(showerStart, 20, FlourishingShowerColor);
             }
             var drawList = ImGui.GetWindowDrawList();
-            cascadeBuilder.Build().Draw(drawList);
-            fountainBuilder.Build().Draw(drawList);
-            windmillBuilder.Build().Draw(drawList);
-            showerBuilder.Build().Draw(drawList);
+            cascadeBuilder.Build().Draw(drawList, PluginConfiguration);
+            fountainBuilder.Build().Draw(drawList, PluginConfiguration);
+            windmillBuilder.Build().Draw(drawList, PluginConfiguration);
+            showerBuilder.Build().Draw(drawList, PluginConfiguration);
         }
 }
 }

--- a/DelvUI/Interface/GunbreakerHudWindow.cs
+++ b/DelvUI/Interface/GunbreakerHudWindow.cs
@@ -55,7 +55,7 @@ namespace DelvUI.Interface {
                 .AddInnerBar(gauge.NumAmmo, 2, GunPowderColor, null);
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawNoMercyBar() {
@@ -75,7 +75,7 @@ namespace DelvUI.Interface {
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
     }
 }

--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -817,7 +817,7 @@ namespace DelvUI.Interface {
                 .SetVertical(GCDIndicatorVertical)
                 .Build();
             
-            gcdBar.Draw(drawList);
+            gcdBar.Draw(drawList, PluginConfiguration);
         }
 
         protected unsafe virtual float ActorShieldValue(Actor actor) {

--- a/DelvUI/Interface/MachinistHudWindow.cs
+++ b/DelvUI/Interface/MachinistHudWindow.cs
@@ -118,7 +118,7 @@ namespace DelvUI.Interface
                     .SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
             
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawBatteryGauge()
@@ -150,7 +150,7 @@ namespace DelvUI.Interface
 
             var drawList = ImGui.GetWindowDrawList();
             var bar = builder.Build();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
 
         private void DrawOverheatBar()
@@ -171,7 +171,7 @@ namespace DelvUI.Interface
             }
             
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawWildfireBar()
@@ -193,7 +193,7 @@ namespace DelvUI.Interface
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
     }
 }

--- a/DelvUI/Interface/NinjaHudWindow.cs
+++ b/DelvUI/Interface/NinjaHudWindow.cs
@@ -65,7 +65,7 @@ namespace DelvUI.Interface
                 .Build();
 
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
 
         private void DrawNinkiGauge()
@@ -82,7 +82,7 @@ namespace DelvUI.Interface
                 .Build();
 
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
     }
 }

--- a/DelvUI/Interface/PaladinHudWindow.cs
+++ b/DelvUI/Interface/PaladinHudWindow.cs
@@ -143,7 +143,7 @@ namespace DelvUI.Interface
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawOathGauge()
@@ -165,7 +165,7 @@ namespace DelvUI.Interface
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawBuffBar()
@@ -197,7 +197,7 @@ namespace DelvUI.Interface
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawAtonementBar()
@@ -214,7 +214,7 @@ namespace DelvUI.Interface
                 .AddInnerBar(stackCount, 3, AtonementColor, null);
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawDoTBar()
@@ -241,7 +241,7 @@ namespace DelvUI.Interface
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
     }
 }

--- a/DelvUI/Interface/SummonerHudWindow.cs
+++ b/DelvUI/Interface/SummonerHudWindow.cs
@@ -99,7 +99,7 @@ namespace DelvUI.Interface
                 var drawList = ImGui.GetWindowDrawList();
                 foreach (var bar in barDrawList)
                 {
-                    bar.Draw(drawList);
+                    bar.Draw(drawList, PluginConfiguration);
                 }
             }
         }
@@ -116,7 +116,7 @@ namespace DelvUI.Interface
                 .AddInnerBar(ruinBuff.StackCount, 4, SmnRuinColor, SmnEmptyColor)
                 .Build();
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
         private void DrawAetherBar()
         {
@@ -131,7 +131,7 @@ namespace DelvUI.Interface
                 .AddInnerBar(aetherFlowBuff.StackCount, 2, SmnAetherColor, SmnEmptyColor)
                 .Build();
             var drawList = ImGui.GetWindowDrawList();
-            bar.Draw(drawList);
+            bar.Draw(drawList, PluginConfiguration);
         }
     }
 }

--- a/DelvUI/Interface/WarriorHudWindow.cs
+++ b/DelvUI/Interface/WarriorHudWindow.cs
@@ -15,6 +15,7 @@ namespace DelvUI.Interface
 
         private bool StormsEyeEnabled => PluginConfiguration.WARStormsEyeEnabled;
         private bool StormsEyeText => PluginConfiguration.WARStormsEyeText;
+        private float StormsEyeTextScale => PluginConfiguration.WARStormsEyeTextScale;
         private int StormsEyeHeight => PluginConfiguration.WARStormsEyeHeight;
         private int StormsEyeWidth => PluginConfiguration.WARStormsEyeWidth;
 
@@ -23,6 +24,7 @@ namespace DelvUI.Interface
 
         private bool BeastGaugeEnabled => PluginConfiguration.WARBeastGaugeEnabled;
         private bool BeastGaugeText => PluginConfiguration.WARBeastGaugeText;
+        private float BeastGaugeTextScale => PluginConfiguration.WARBeastGaugeTextScale;
         private int BeastGaugeHeight => PluginConfiguration.WARBeastGaugeHeight;
         private int BeastGaugeWidth => PluginConfiguration.WARBeastGaugeWidth;
         private int BeastGaugePadding => PluginConfiguration.WARBeastGaugePadding;
@@ -77,11 +79,11 @@ namespace DelvUI.Interface
             if (StormsEyeText)
             {
                 builder.SetTextMode(BarTextMode.EachChunk)
-                    .SetText(new BarText(BarTextPosition.CenterMiddle, BarTextType.Current));
+                    .SetText(BarTextPosition.CenterMiddle, BarTextType.Current, StormsEyeTextScale);
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
 
         private void DrawBeastGauge() {
@@ -100,11 +102,11 @@ namespace DelvUI.Interface
             if (BeastGaugeText)
             {
                 builder.SetTextMode(BarTextMode.EachChunk)
-                    .SetText(new BarText(BarTextPosition.CenterMiddle, BarTextType.Current));
+                    .SetText(BarTextPosition.CenterMiddle, BarTextType.Current, BeastGaugeTextScale);
             }
 
             var drawList = ImGui.GetWindowDrawList();
-            builder.Build().Draw(drawList);
+            builder.Build().Draw(drawList, PluginConfiguration);
         }
     }
 }

--- a/DelvUI/PluginConfiguration.cs
+++ b/DelvUI/PluginConfiguration.cs
@@ -205,12 +205,14 @@ namespace DelvUI {
 
         public bool WARStormsEyeEnabled { get; set; } = true;
         public bool WARStormsEyeText { get; set; } = true;
+        public float WARStormsEyeTextScale { get; set; } = 1.0f;
         public int WARStormsEyeHeight { get; set; } = 20;
         public int WARStormsEyeWidth { get; set; } = 254;
         public int WARStormsEyeXOffset { get; set; } = 127;
         public int WARStormsEyeYOffset { get; set; } = 417;
         public bool WARBeastGaugeEnabled { get; set; } = true;
         public bool WARBeastGaugeText { get; set; }
+        public float WARBeastGaugeTextScale { get; set; } = 1.0f;
         public int WARBeastGaugeHeight { get; set; } = 20;
         public int WARBeastGaugeWidth { get; set; } = 254;
         public int WARBeastGaugePadding { get; set; } = 2;


### PR DESCRIPTION
Adds the ability to scale text size - this can be done to bar text using new BarBuilder methods (or changing the BarText constructor that you use). Outside of BarBuilder this can be used by changing the DrawOutlinedText overload that is used.
Note this PR only includes the infrastructure required to scale fonts, Warrior job bars is the only text that has had a scaling option added.