### PR TITLE
Fix NPC StatusEffect crashes

### DIFF
--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -124,8 +124,8 @@ namespace DelvUI.Interface {
         protected bool PlayerHidePermaBuffs => PluginConfiguration.PlayerHidePermaBuffs;
         
         
-        protected bool TargetBuffsEnabled => PluginConfiguration.PlayerBuffsEnabled;
-        protected bool TargetDebuffsEnabled => PluginConfiguration.PlayerDebuffsEnabled;
+        protected bool TargetBuffsEnabled => PluginConfiguration.TargetBuffsEnabled;
+        protected bool TargetDebuffsEnabled => PluginConfiguration.TargetDebuffsEnabled;
         protected int TargetBuffColumns => PluginConfiguration.TargetBuffColumns;
         protected int TargetDebuffColumns => PluginConfiguration.TargetDebuffColumns;
         protected int TargetBuffPositionX => PluginConfiguration.TargetBuffPositionX;
@@ -916,6 +916,8 @@ namespace DelvUI.Interface {
                 return;
             }
 
+            if (target.ObjectKind != ObjectKind.Player && target.ObjectKind != ObjectKind.BattleNpc) return;
+
             var settings = new StatusSettings
             {
                 BuffsEnabled = TargetBuffsEnabled,
@@ -977,8 +979,6 @@ namespace DelvUI.Interface {
         }
         private void DrawActorStatusEffects(Actor actor, StatusSettings settings)
         {
-            if (actor.ObjectKind != ObjectKind.Player && actor.ObjectKind != ObjectKind.BattleNpc) return;
-
             var buffsEnabled = settings.BuffsEnabled;
             var debuffsEnabled = settings.DebuffsEnabled;
             var currentBuffPos = settings.BuffPosition;

--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -977,6 +977,8 @@ namespace DelvUI.Interface {
         }
         private void DrawActorStatusEffects(Actor actor, StatusSettings settings)
         {
+            if (actor.ObjectKind != ObjectKind.Player && actor.ObjectKind != ObjectKind.BattleNpc) return;
+
             var buffsEnabled = settings.BuffsEnabled;
             var debuffsEnabled = settings.DebuffsEnabled;
             var currentBuffPos = settings.BuffPosition;


### PR DESCRIPTION
Don't draw StatusEffect if target isn't ObjectKind.Player or ObjectKind.BattleNpc

Also, the Player configuration flags for Buffs/Debuffs were used for the Target