### PR TITLE
GCD Bar - Vertical Width/Height Bugfix

### DIFF
--- a/DelvUI/Interface/ConfigurationWindow.cs
+++ b/DelvUI/Interface/ConfigurationWindow.cs
@@ -334,16 +334,22 @@ namespace DelvUI.Interface
                     // gcd indicator
                     _changed |= ImGui.Checkbox("Show GCD Indicator", ref _pluginConfiguration.GCDIndicatorEnabled);
                     _changed |= ImGui.Checkbox("Always Show GCD Indicator", ref _pluginConfiguration.GCDAlwaysShow);
-                    _changed |= ImGui.Checkbox("Vertical GCD Indicator", ref _pluginConfiguration.GCDIndicatorVertical);
                     
-                    var gcdIndicatorHeight = _pluginConfiguration.GCDIndicatorVertical ? _pluginConfiguration.GCDIndicatorWidth : _pluginConfiguration.GCDIndicatorHeight;
+                    if (ImGui.Checkbox("Vertical GCD Indicator", ref _pluginConfiguration.GCDIndicatorVertical))
+                    {
+                        var __temp = _pluginConfiguration.GCDIndicatorWidth;
+                        _pluginConfiguration.GCDIndicatorWidth = _pluginConfiguration.GCDIndicatorHeight;
+                        _pluginConfiguration.GCDIndicatorHeight = __temp;
+                    }
+                    
+                    var gcdIndicatorHeight = _pluginConfiguration.GCDIndicatorHeight;
                     if (ImGui.DragInt("GCD Indicator Height", ref gcdIndicatorHeight, .1f, 1, 1000))
                     {
                         _pluginConfiguration.GCDIndicatorHeight = gcdIndicatorHeight;
                         _pluginConfiguration.Save();
                     }
 
-                    var gcdIndicatorWidth = _pluginConfiguration.GCDIndicatorVertical ? _pluginConfiguration.GCDIndicatorHeight : _pluginConfiguration.GCDIndicatorWidth;
+                    var gcdIndicatorWidth = _pluginConfiguration.GCDIndicatorWidth;
                     if (ImGui.DragInt("GCD Indicator Width", ref gcdIndicatorWidth, .1f, 1, 1000))
                     {
                         _pluginConfiguration.GCDIndicatorWidth = gcdIndicatorWidth;

--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -862,9 +862,7 @@ namespace DelvUI.Interface {
             var scale = elapsed / total;
             if (scale <= 0) return;
 
-            (int Height, int Width) barSize = GCDIndicatorVertical
-                ?  (-1 * GCDIndicatorWidth, GCDIndicatorHeight) :
-                 (GCDIndicatorHeight, GCDIndicatorWidth);
+            (int Height, int Width) barSize = (GCDIndicatorHeight, GCDIndicatorWidth);
 
             var position = new Vector2(CenterX + GCDIndicatorXOffset - GCDIndicatorWidth / 2f, CenterY + GCDIndicatorYOffset);
             var colors = PluginConfiguration.MiscColorMap["gcd"];

--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -862,7 +862,7 @@ namespace DelvUI.Interface {
             var scale = elapsed / total;
             if (scale <= 0) return;
 
-            (int Height, int Width) barSize = (GCDIndicatorHeight, GCDIndicatorWidth);
+            (int Height, int Width) barSize = GCDIndicatorVertical ? (-GCDIndicatorHeight, GCDIndicatorWidth) : (GCDIndicatorHeight, GCDIndicatorWidth);
 
             var position = new Vector2(CenterX + GCDIndicatorXOffset - GCDIndicatorWidth / 2f, CenterY + GCDIndicatorYOffset);
             var colors = PluginConfiguration.MiscColorMap["gcd"];


### PR DESCRIPTION
Fixed issue #200 in which the gcd bar would be locked to a singular unchangeable height/width value when set to vertical mode. The issue was caused by implementing the vertical bar via swapping the responsibilities of the width/height sliders to affect the opposite bar property. This branch fixes the issue by undoing these swapped responsibilities, and instead swapping the actual values of the sliders when the vertical indicator box is checked.