### PR TITLE
Improvements on config system

### DIFF
--- a/DelvUI/Config/ConfigurationWindow.cs
+++ b/DelvUI/Config/ConfigurationWindow.cs
@@ -4,9 +4,9 @@ using System.Numerics;
 using Dalamud.Interface;
 using ImGuiNET;
 using Dalamud.Plugin;
-using DelvUI.Interface.StatusEffects;
 
-namespace DelvUI.Interface
+
+namespace DelvUI.Config
 {
     public class ConfigurationWindow
     {
@@ -250,16 +250,16 @@ namespace DelvUI.Interface
                     switch (subConfig)
                     {
                         case "Player Buffs":
-                            DrawPlayerBuffsConfig();
+                            _changed |= _pluginConfiguration.PlayerBuffListConfig.Draw();
                             break;
                         case "Player Debuffs":
-                            DrawPlayerDebuffsConfig();
+                            _changed |= _pluginConfiguration.PlayerDebuffListConfig.Draw();
                             break;
                         case "Target Buffs":
-                            DrawTargetBuffsConfig();
+                            _changed |= _pluginConfiguration.TargetBuffListConfig.Draw();
                             break;
                         case "Target Debuffs":
-                            DrawTargetDebuffsConfig();
+                            _changed |= _pluginConfiguration.TargetDebuffListConfig.Draw();
                             break;
                     }
                     break;
@@ -1584,130 +1584,6 @@ namespace DelvUI.Interface
                     _changed |= ImGui.Checkbox("Show Target Cast Time", ref _pluginConfiguration.ShowTargetCastTime);
                     _changed |= ImGui.Checkbox("Show Interruptable Casts", ref _pluginConfiguration.ShowTargetInterrupt);
 
-        }
-
-        private void DrawPlayerBuffsConfig()
-        {
-            DrawStatusEffectListConfig(ref _pluginConfiguration.PlayerBuffListConfig);
-        }
-
-        private void DrawPlayerDebuffsConfig()
-        {
-            DrawStatusEffectListConfig(ref _pluginConfiguration.PlayerDebuffListConfig);
-        }
-
-        private void DrawTargetBuffsConfig()
-        {
-            DrawStatusEffectListConfig(ref _pluginConfiguration.TargetBuffListConfig);
-        }
-
-        private void DrawTargetDebuffsConfig()
-        {
-            DrawStatusEffectListConfig(ref _pluginConfiguration.TargetDebuffListConfig);
-        }
-
-        private void DrawStatusEffectListConfig(ref StatusEffectsListConfig config)
-        { 
-            _changed |= ImGui.Checkbox("Enabled", ref config.Enabled);
-
-            ImGui.Text("Layout");
-            ImGui.BeginGroup();
-            {
-                int posX = (int)config.Position.X;
-                if (ImGui.DragInt("Position X", ref posX, 1, -_xOffsetLimit, _xOffsetLimit))
-                {
-                    config.Position.X = posX;
-                    _pluginConfiguration.Save();
-                }
-                int posY = (int)config.Position.Y;
-                if (ImGui.DragInt("Position Y", ref posY, 1, -_yOffsetLimit, _yOffsetLimit))
-                {
-                    config.Position.Y = posY;
-                    _pluginConfiguration.Save();
-                }
-
-                int areaWidth = (int)config.MaxSize.X;
-                if (ImGui.DragInt("Area Width", ref areaWidth, 1, -2000, 2000))
-                {
-                    config.MaxSize.X = areaWidth;
-                    _pluginConfiguration.Save();
-                }
-                int areaHeight = (int)config.MaxSize.Y;
-                if (ImGui.DragInt("Area Height", ref areaHeight, 1, -2000, 2000))
-                {
-                    config.MaxSize.Y = areaHeight;
-                    _pluginConfiguration.Save();
-                }
-
-                int paddingX = (int)config.IconPadding.X;
-                if (ImGui.DragInt("Horizontal Padding", ref paddingX, 1, -200, 200))
-                {
-                    config.IconPadding.X = paddingX;
-                    _pluginConfiguration.Save();
-                }
-                int paddingY = (int)config.IconPadding.Y;
-                if (ImGui.DragInt("Vertical Padding", ref paddingY, 1, -200, 200))
-                {
-                    config.IconPadding.Y = paddingY;
-                    _pluginConfiguration.Save();
-                }
-
-                List<GrowthDirections> directions = new List<GrowthDirections>()
-                {
-                    GrowthDirections.RIGHT | GrowthDirections.DOWN,
-                    GrowthDirections.RIGHT | GrowthDirections.UP,
-                    GrowthDirections.LEFT | GrowthDirections.DOWN,
-                    GrowthDirections.LEFT | GrowthDirections.UP
-                };
-                int selection = Math.Max(0, directions.IndexOf((GrowthDirections)config.GrowthDirections));
-                string[] directionsStrings = new string[]
-                {
-                    "Right and Down",
-                    "Right and Up",
-                    "Left and Down",
-                    "Left and Up"
-                };
-                if (ImGui.Combo("Icons Growth Direction", ref selection, directionsStrings, directionsStrings.Length))
-                {
-                    config.GrowthDirections = (short)directions[selection];
-                    _pluginConfiguration.Save();
-                }
-
-                _changed |= ImGui.Checkbox("Show Area", ref config.ShowArea);
-                _changed |= ImGui.Checkbox("Fill Rows First", ref config.FillRowsFirst);
-                _changed |= ImGui.DragInt("Limit (-1 means no limit)", ref config.Limit, .1f, -1, 100);
-            }
-            ImGui.EndGroup();
-
-            ImGui.Text("Icons");
-            ImGui.BeginGroup();
-            {
-                int iconWidth = (int)config.IconConfig.Size.X;
-                if (ImGui.DragInt("Icons Width", ref iconWidth, 1, 1, 200))
-                {
-                    config.IconConfig.Size.X = iconWidth;
-                    _pluginConfiguration.Save();
-                }
-                int iconHeight = (int)config.IconConfig.Size.Y;
-                if (ImGui.DragInt("Icons Height", ref iconHeight, 1, 1, 200))
-                {
-                    config.IconConfig.Size.Y = iconHeight;
-                    _pluginConfiguration.Save();
-                }
-
-                _changed |= ImGui.Checkbox("Show Duration", ref config.IconConfig.ShowDurationText);
-                _changed |= ImGui.Checkbox("Show Stacks", ref config.IconConfig.ShowStacksText);
-                _changed |= ImGui.Checkbox("Show Permanent Effects", ref config.ShowPermanentEffects);
-
-                _changed |= ImGui.Checkbox("Show Border", ref config.IconConfig.ShowBorder);
-                _changed |= ImGui.DragInt("Border Thickness", ref config.IconConfig.BorderThickness, .1f, 1, 5);
-                _changed |= ImGui.ColorEdit4("Border Color", ref config.IconConfig.BorderColor);
-
-                _changed |= ImGui.Checkbox("Show Dispellable Border", ref config.IconConfig.ShowDispellableBorder);
-                _changed |= ImGui.DragInt("Dispellable Border Thickness", ref config.IconConfig.DispellableBorderThickness, .1f, 1, 5);
-                _changed |= ImGui.ColorEdit4("Dispellable order Color", ref config.IconConfig.DispellableBorderColor);
-            }
-            ImGui.EndGroup();
         }
 
         private void DrawJobsGeneralConfig()
@@ -5017,138 +4893,7 @@ namespace DelvUI.Interface
 
                 if (ImGui.BeginTabItem("Black Mage"))
                 {
-                    var blmVerticalOffset = _pluginConfiguration.BLMVerticalOffset;
-                    if (ImGui.DragInt("Vertical Offset", ref blmVerticalOffset, 1f, -1000, 1000))
-                    {
-                        _pluginConfiguration.BLMVerticalOffset = blmVerticalOffset;
-                        _pluginConfiguration.Save();
-                    }                    
-                    
-                    var blmHorizontalOffset = _pluginConfiguration.BLMHorizontalOffset;
-                    if (ImGui.DragInt("Horizontal Offset", ref blmHorizontalOffset, 1f, -1000, 1000))
-                    {
-                        _pluginConfiguration.BLMHorizontalOffset = blmHorizontalOffset;
-                        _pluginConfiguration.Save();
-                    }
-
-                    var blmVerticalSpaceBetweenBars = _pluginConfiguration.BLMVerticalSpaceBetweenBars;
-                    if (ImGui.DragInt("Vertical Padding", ref blmVerticalSpaceBetweenBars, .1f, 1, 1000))
-                    {
-                        _pluginConfiguration.BLMVerticalSpaceBetweenBars = blmVerticalSpaceBetweenBars;
-                        _pluginConfiguration.Save();
-                    }
-
-                    var blmHorizontalSpaceBetweenBars = _pluginConfiguration.BLMHorizontalSpaceBetweenBars;
-                    if (ImGui.DragInt("Horizontal Padding", ref blmHorizontalSpaceBetweenBars, .1f, 1, 1000))
-                    {
-                        _pluginConfiguration.BLMHorizontalSpaceBetweenBars = blmHorizontalSpaceBetweenBars;
-                        _pluginConfiguration.Save();
-                    }
-
-                    var blmManaBarHeight = _pluginConfiguration.BLMManaBarHeight;
-                    if (ImGui.DragInt("Mana Bar Height", ref blmManaBarHeight, .1f, 1, 1000))
-                    {
-                        _pluginConfiguration.BLMManaBarHeight = blmManaBarHeight;
-                        _pluginConfiguration.Save();
-                    }
-
-                    var blmManaBarWidth = _pluginConfiguration.BLMManaBarWidth;
-                    if (ImGui.DragInt("Mana Bar Width", ref blmManaBarWidth, .1f, -2000, 2000))
-                    {
-                        _pluginConfiguration.BLMManaBarWidth = blmManaBarWidth;
-                        _pluginConfiguration.Save();
-                    }
-
-                    var blmUmbralHeartHeight = _pluginConfiguration.BLMUmbralHeartHeight;
-                    if (ImGui.DragInt("Umbral Heart Height", ref blmUmbralHeartHeight, .1f, -2000, 2000))
-                    {
-                        _pluginConfiguration.BLMUmbralHeartHeight = blmUmbralHeartHeight;
-                        _pluginConfiguration.Save();
-                    }                    
-                    
-                    var blmUmbralHeartWidth = _pluginConfiguration.BLMUmbralHeartWidth;
-                    if (ImGui.DragInt("Umbral Heart Width", ref blmUmbralHeartWidth, .1f, -2000, 2000))
-                    {
-                        _pluginConfiguration.BLMUmbralHeartWidth = blmUmbralHeartWidth;
-                        _pluginConfiguration.Save();
-                    }
-
-                    var blmPolyglotHeight = _pluginConfiguration.BLMPolyglotHeight;
-                    if (ImGui.DragInt("Polyglot Height", ref blmPolyglotHeight, .1f, 1, 1000))
-                    {
-                        _pluginConfiguration.BLMPolyglotHeight = blmPolyglotHeight;
-                        _pluginConfiguration.Save();
-                    }
-
-                    var blmPolyglotWidth = _pluginConfiguration.BLMPolyglotWidth;
-                    if (ImGui.DragInt("Polyglot Width", ref blmPolyglotWidth, .1f, 1, 1000))
-                    {
-                        _pluginConfiguration.BLMPolyglotWidth = blmPolyglotWidth;
-                        _pluginConfiguration.Save();
-                    }
-
-                    _changed |= ImGui.Checkbox("Show Mana Value", ref _pluginConfiguration.BLMShowManaValue);
-                    _changed |= ImGui.Checkbox("Show Mana Threshold Marker During Astral Fire",
-                        ref _pluginConfiguration.BLMShowManaThresholdMarker);
-
-                    var blmManaThresholdValue = _pluginConfiguration.BLMManaThresholdValue;
-                    if (ImGui.DragInt("Mana Threshold Marker Value", ref blmManaThresholdValue, 1f, 1, 10000))
-                    {
-                        _pluginConfiguration.BLMManaThresholdValue = blmManaThresholdValue;
-                        _pluginConfiguration.Save();
-                    }
-
-                    _changed |= ImGui.Checkbox("Show Triplecast", ref _pluginConfiguration.BLMShowTripleCast);
-
-                    var blmTripleCastHeight = _pluginConfiguration.BLMTripleCastHeight;
-                    if (ImGui.DragInt("Triplecast Bar Height", ref blmTripleCastHeight, .1f, -2000, 2000))
-                    {
-                        _pluginConfiguration.BLMTripleCastHeight = blmTripleCastHeight;
-                        _pluginConfiguration.Save();
-                    }   
-                    
-                    var blmTripleCastWidth = _pluginConfiguration.BLMTripleCastWidth;
-                    if (ImGui.DragInt("Triplecast Bar Width", ref blmTripleCastWidth, .1f, -2000, 2000))
-                    {
-                        _pluginConfiguration.BLMTripleCastWidth = blmTripleCastWidth;
-                        _pluginConfiguration.Save();
-                    }
-
-                    _changed |= ImGui.Checkbox("Show Firestarter Procs",
-                        ref _pluginConfiguration.BLMShowFirestarterProcs);
-                    _changed |= ImGui.Checkbox("Show Thundercloud Procs",
-                        ref _pluginConfiguration.BLMShowThundercloudProcs);
-
-                    var blmProcsHeight = _pluginConfiguration.BLMProcsHeight;
-                    if (ImGui.DragInt("Procs Height", ref blmProcsHeight, .1f, -2000, 2000))
-                    {
-                        _pluginConfiguration.BLMProcsHeight = blmProcsHeight;
-                        _pluginConfiguration.Save();
-                    }
-
-                    _changed |= ImGui.Checkbox("Show DoT Timer", ref _pluginConfiguration.BLMShowDotTimer);
-
-                    var blmDotTimerHeight = _pluginConfiguration.BLMDotTimerHeight;
-                    if (ImGui.DragInt("DoT Timer Height", ref blmDotTimerHeight, .1f, -2000, 2000))
-                    {
-                        _pluginConfiguration.BLMDotTimerHeight = blmDotTimerHeight;
-                        _pluginConfiguration.Save();
-                    }
-
-                    _changed |= ImGui.ColorEdit4("Mana Bar Color",
-                        ref _pluginConfiguration.BLMManaBarNoElementColor);
-                    _changed |= ImGui.ColorEdit4("Mana Bar Ice Color", ref _pluginConfiguration.BLMManaBarIceColor);
-                    _changed |= ImGui.ColorEdit4("Mana Bar Fire Color",
-                        ref _pluginConfiguration.BLMManaBarFireColor);
-                    _changed |= ImGui.ColorEdit4("Umbral Heart Color", ref _pluginConfiguration.BLMUmbralHeartColor);
-                    _changed |= ImGui.ColorEdit4("Polyglot Color", ref _pluginConfiguration.BLMPolyglotColor);
-                    _changed |= ImGui.ColorEdit4("Triplecast Color", ref _pluginConfiguration.BLMTriplecastColor);
-                    _changed |= ImGui.ColorEdit4("Firestarter Proc Color",
-                        ref _pluginConfiguration.BLMFirestarterColor);
-                    _changed |= ImGui.ColorEdit4("Thundercloud Proc Color",
-                        ref _pluginConfiguration.BLMThundercloudColor);
-                    _changed |= ImGui.ColorEdit4("DoT Timer Color", ref _pluginConfiguration.BLMDotColor);
-                    
+                    _changed |= _pluginConfiguration.BLMConfig.Draw();
                     ImGui.EndTabItem();
                 }
             }

--- a/DelvUI/Config/PluginConfigObject.cs
+++ b/DelvUI/Config/PluginConfigObject.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using ImGuiNET;
+using Newtonsoft.Json;
+using DelvUI.Helpers;
+
+namespace DelvUI.Config
+{
+    [Serializable]
+    public abstract class PluginConfigObject
+    {
+        [JsonIgnore] protected int _xOffsetLimit => (int) ImGui.GetMainViewport().Size.X / 2;
+        [JsonIgnore] protected int _yOffsetLimit => (int) ImGui.GetMainViewport().Size.Y / 2;
+
+        protected bool ColorEdit4(string label, ref PluginConfigColor color)
+        {
+            var vector = color.Vector;
+            if (ImGui.ColorEdit4(label, ref vector))
+            {
+                color.Vector = vector;
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    [Serializable]
+    public class PluginConfigColor
+    {
+        [JsonIgnore] private Vector4 _vector;
+        public Vector4 Vector
+        {
+            get { return _vector; }
+            set
+            {
+                if (_vector == value) return;
+                _vector = value;
+
+                Update();
+            }
+        }
+
+        [JsonIgnore] private uint _base;
+        [JsonIgnore] public uint Base { get { return _base; } }
+
+        [JsonIgnore] private uint _background;
+        [JsonIgnore] public uint Background { get { return _background; } }
+
+        [JsonIgnore] private uint _leftGradient;
+        [JsonIgnore] public uint LeftGradient { get { return _leftGradient; } }
+
+        [JsonIgnore] private uint _rightGradient;
+        [JsonIgnore] public uint RightGradient { get { return _rightGradient; } }
+
+        [JsonIgnore] private Dictionary<string, uint> _map;
+        [JsonIgnore] public Dictionary<string, uint> Map { get { return _map; } }
+
+        [JsonIgnore] private float[] _colorMapRatios = new float[] { -.8f, -.1f, .1f };
+
+
+        public PluginConfigColor(Vector4 vector, float[] colorMapRatios = null)
+        {
+            _vector = vector;
+
+            if (colorMapRatios != null && colorMapRatios.Length >= 3)
+            {
+                _colorMapRatios = colorMapRatios;
+            }
+
+            Update();
+        }
+
+        private void Update()
+        {
+            _base = ImGui.ColorConvertFloat4ToU32(_vector);
+            _background = ImGui.ColorConvertFloat4ToU32(_vector.AdjustColor(_colorMapRatios[0]));
+            _leftGradient = ImGui.ColorConvertFloat4ToU32(_vector.AdjustColor(_colorMapRatios[1]));
+            _rightGradient = ImGui.ColorConvertFloat4ToU32(_vector.AdjustColor(_colorMapRatios[2]));
+            _map = new Dictionary<string, uint>()
+            {
+                ["base"] = _base,
+                ["background"] = _background,
+                ["gradientLeft"] = _leftGradient,
+                ["gradientRight"] = _rightGradient
+            };
+        }
+    }
+}

--- a/DelvUI/Config/PluginConfigObject.cs
+++ b/DelvUI/Config/PluginConfigObject.cs
@@ -10,9 +10,6 @@ namespace DelvUI.Config
     [Serializable]
     public abstract class PluginConfigObject
     {
-        [JsonIgnore] protected int _xOffsetLimit => (int) ImGui.GetMainViewport().Size.X / 2;
-        [JsonIgnore] protected int _yOffsetLimit => (int) ImGui.GetMainViewport().Size.Y / 2;
-
         protected bool ColorEdit4(string label, ref PluginConfigColor color)
         {
             var vector = color.Vector;

--- a/DelvUI/Config/PluginConfiguration.cs
+++ b/DelvUI/Config/PluginConfiguration.cs
@@ -4,12 +4,14 @@ using System.IO;
 using System.Numerics;
 using Dalamud.Configuration;
 using Dalamud.Plugin;
+using DelvUI.Interface;
 using DelvUI.Interface.StatusEffects;
 using ImGuiNET;
 using ImGuiScene;
 using Newtonsoft.Json;
 
-namespace DelvUI {
+namespace DelvUI.Config
+{
     public class PluginConfiguration : IPluginConfiguration {
 
         public event EventHandler<EventArgs> ConfigChangedEvent;
@@ -690,45 +692,7 @@ namespace DelvUI {
 
         #endregion
 
-        #region BLM Configuration
-
-        public int BLMVerticalOffset { get; set; } = -2;
-        public int BLMHorizontalOffset { get; set; } = 0;
-        public int BLMVerticalSpaceBetweenBars { get; set; } = 2;
-        public int BLMHorizontalSpaceBetweenBars { get; set; } = 2;
-        public int BLMManaBarHeight { get; set; } = 20;
-        public int BLMManaBarWidth { get; set; } = 253;
-        public int BLMUmbralHeartHeight { get; set; } = 16;
-        public int BLMUmbralHeartWidth { get; set; } = 83;
-        public int BLMPolyglotHeight { get; set; } = 18;
-        public int BLMPolyglotWidth { get; set; } = 18;
-        
-        public bool BLMShowManaValue = false;
-        
-        public bool BLMShowManaThresholdMarker = true;
-        public int BLMManaThresholdValue { get; set; } = 2600;
-
-        public bool BLMShowTripleCast = true;
-        public int BLMTripleCastHeight { get; set; } = 16;
-        public int BLMTripleCastWidth { get; set; } = 83;
-
-        public bool BLMShowFirestarterProcs = true;
-        public bool BLMShowThundercloudProcs = true;
-        public int BLMProcsHeight { get; set; } = 7;
-        public bool BLMShowDotTimer = true;
-        public int BLMDotTimerHeight { get; set; } = 10;
-
-        public Vector4 BLMManaBarNoElementColor = new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f);
-        public Vector4 BLMManaBarIceColor = new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 100f / 100f);
-        public Vector4 BLMManaBarFireColor = new Vector4(204f / 255f, 40f / 255f, 40f / 255f, 100f / 100f);
-        public Vector4 BLMUmbralHeartColor = new Vector4(125f / 255f, 195f / 255f, 205f / 255f, 100f / 100f);
-        public Vector4 BLMPolyglotColor = new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f);
-        public Vector4 BLMTriplecastColor = new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f);
-        public Vector4 BLMFirestarterColor = new Vector4(255f / 255f, 136f / 255f, 0 / 255f, 90f / 100f);
-        public Vector4 BLMThundercloudColor = new Vector4(240f / 255f, 163f / 255f, 255f / 255f, 90f / 100f);
-        public Vector4 BLMDotColor = new Vector4(67f / 255f, 187 / 255f, 255f / 255f, 90f / 100f);
-
-        #endregion
+        public BlackMageHudConfig BLMConfig = new BlackMageHudConfig();
 
         #region RDM Configuration
 
@@ -2093,86 +2057,6 @@ namespace DelvUI {
                     ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(JobColorBLM.AdjustColor(.1f))
                 },
 
-                [Jobs.BLM * 1000] = new Dictionary<string, uint> // Mana Bar no element
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarNoElementColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarNoElementColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarNoElementColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarNoElementColor.AdjustColor(.1f))
-                },
-
-                [Jobs.BLM * 1000 + 1] = new Dictionary<string, uint> // Mana bar ice
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarIceColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarIceColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarIceColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarIceColor.AdjustColor(.1f))
-                },
-
-                [Jobs.BLM * 1000 + 2] = new Dictionary<string, uint> // Mana bar fire
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarFireColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarFireColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarFireColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(BLMManaBarFireColor.AdjustColor(.1f))
-                },
-
-                [Jobs.BLM * 1000 + 3] = new Dictionary<string, uint> // Umbral heart
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(BLMUmbralHeartColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(BLMUmbralHeartColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(BLMUmbralHeartColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(BLMUmbralHeartColor.AdjustColor(.1f))
-                },
-
-                [Jobs.BLM * 1000 + 4] = new Dictionary<string, uint> // Polyglot
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(BLMPolyglotColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(BLMPolyglotColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(BLMPolyglotColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(BLMPolyglotColor.AdjustColor(.1f))
-                },
-
-                [Jobs.BLM * 1000 + 5] = new Dictionary<string, uint> // Triplecast
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(BLMTriplecastColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(BLMTriplecastColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(BLMTriplecastColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(BLMTriplecastColor.AdjustColor(.1f))
-                },
-
-                [Jobs.BLM * 1000 + 6] = new Dictionary<string, uint> // Firestarter
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(BLMFirestarterColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(BLMFirestarterColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(BLMFirestarterColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(BLMFirestarterColor.AdjustColor(.1f))
-                },
-
-                [Jobs.BLM * 1000 + 7] = new Dictionary<string, uint> // Thundercloud
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(BLMThundercloudColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(BLMThundercloudColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(BLMThundercloudColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(BLMThundercloudColor.AdjustColor(.1f))
-                },
-
-                [Jobs.BLM * 1000 + 8] = new Dictionary<string, uint> // DoT
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(BLMDotColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(BLMDotColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(BLMDotColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(BLMDotColor.AdjustColor(.1f))
-                },
-
-                [Jobs.BLM * 1000 + 9] = new Dictionary<string, uint> // Empty
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(EmptyColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(EmptyColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(EmptyColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(EmptyColor.AdjustColor(.1f))
-                },
-
                 [Jobs.RDM] = new Dictionary<string, uint>
                 {
                     ["base"] = ImGui.ColorConvertFloat4ToU32(JobColorRDM),
@@ -2341,7 +2225,14 @@ namespace DelvUI {
                     ["background"] = ImGui.ColorConvertFloat4ToU32(GCDIndicatorColor.AdjustColor(-.8f)),
                     ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(GCDIndicatorColor.AdjustColor(-.1f)),
                     ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(GCDIndicatorColor.AdjustColor(.1f))
-                }
+                },
+                ["empty"] = new Dictionary<string, uint>
+                {
+                    ["base"] = ImGui.ColorConvertFloat4ToU32(EmptyColor),
+                    ["background"] = ImGui.ColorConvertFloat4ToU32(EmptyColor.AdjustColor(-.8f)),
+                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(EmptyColor.AdjustColor(-.1f)),
+                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(EmptyColor.AdjustColor(.1f))
+                },
             };
 
             CastBarColorMap = new Dictionary<string, Dictionary<string, uint>>

--- a/DelvUI/Helpers/DrawHelper.cs
+++ b/DelvUI/Helpers/DrawHelper.cs
@@ -1,8 +1,7 @@
 ﻿using System.Numerics;
 using ImGuiNET;
-using Actor = Dalamud.Game.ClientState.Actors.Types.Actor;
 using Lumina.Excel;
-using Lumina.Excel.GeneratedSheets;
+using DelvUI.Config;
 
 namespace DelvUI.Helpers
 {

--- a/DelvUI/Helpers/GCDHelper.cs
+++ b/DelvUI/Helpers/GCDHelper.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using Dalamud.Game.ClientState.Actors;
+﻿using System.Collections.Generic;
 using Dalamud.Game.ClientState.Actors.Types;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using DelvUI.Config;
 
 namespace DelvUI.Helpers
 {

--- a/DelvUI/Interface/AstrologianHudWindow.cs
+++ b/DelvUI/Interface/AstrologianHudWindow.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using DelvUI.Helpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/BardHudWindow.cs
+++ b/DelvUI/Interface/BardHudWindow.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Numerics;
 using Dalamud.Game.ClientState.Actors.Types;
 using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface {
     public class BardHudWindow : HudWindow {

--- a/DelvUI/Interface/Bars/Bar.cs
+++ b/DelvUI/Interface/Bars/Bar.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Numerics;
 using DelvUI.Helpers;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface.Bars
 {

--- a/DelvUI/Interface/Bars/BarBuilder.cs
+++ b/DelvUI/Interface/Bars/BarBuilder.cs
@@ -15,6 +15,10 @@ namespace DelvUI.Interface.Bars
             _bar = initialBar;
         }
 
+        public static BarBuilder Create(float xPosition, float yPosition, float height, float width)
+        {
+            return Create(xPosition, yPosition, (int)height, (int)width);
+        }
         public static BarBuilder Create(float xPosition, float yPosition, int height, int width)
         {
             var bar = new Bar(xPosition, yPosition, height, width);
@@ -53,6 +57,10 @@ namespace DelvUI.Interface.Bars
             return this;
         }
 
+        public BarBuilder SetChunkPadding(float padding)
+        {
+            return SetChunkPadding((int)padding);
+        }
         public BarBuilder SetChunkPadding(int padding)
         {
             _bar.ChunkPadding = padding;

--- a/DelvUI/Interface/BlackMageHudWindow.cs
+++ b/DelvUI/Interface/BlackMageHudWindow.cs
@@ -7,47 +7,25 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
 using DelvUI.Interface.Bars;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {
     public class BlackMageHudWindow : HudWindow
     {
         public override uint JobId => Jobs.BLM;
+        private BlackMageHudConfig _config;
 
-        private float OriginX => CenterX + PluginConfiguration.BLMHorizontalOffset;
-        private float OriginY => CenterY + YOffset + PluginConfiguration.BLMVerticalOffset;
-        private int VerticalSpaceBetweenBars => PluginConfiguration.BLMVerticalSpaceBetweenBars;
-        private int HorizontalSpaceBetweenBars => PluginConfiguration.BLMHorizontalSpaceBetweenBars;
-        private int ManaBarWidth => PluginConfiguration.BLMManaBarWidth;
-        private int ManaBarHeight => PluginConfiguration.BLMManaBarHeight;
-        private int UmbralHeartHeight => PluginConfiguration.BLMUmbralHeartHeight;
-        private int UmbralHeartWidth=> PluginConfiguration.BLMUmbralHeartWidth;
-        private int PolyglotHeight => PluginConfiguration.BLMPolyglotHeight;
-        private int PolyglotWidth => PluginConfiguration.BLMPolyglotWidth;
-        private bool ShowManaValue => PluginConfiguration.BLMShowManaValue;
-        private bool ShowManaThresholdMarker => PluginConfiguration.BLMShowManaThresholdMarker;
-        private int ManaThresholdValue => PluginConfiguration.BLMManaThresholdValue;
-        private bool ShowTripleCast => PluginConfiguration.BLMShowTripleCast;
-        private int TripleCastHeight => PluginConfiguration.BLMTripleCastHeight;
-        private int TripleCastWidth => PluginConfiguration.BLMTripleCastWidth;
-        private bool ShowFirestarterProcs => PluginConfiguration.BLMShowFirestarterProcs;
-        private bool ShowThundercloudProcs => PluginConfiguration.BLMShowThundercloudProcs;
-        private int ProcsHeight => PluginConfiguration.BLMProcsHeight;
-        private bool ShowDotTimer => PluginConfiguration.BLMShowDotTimer;
-        private int DotTimerHeight => PluginConfiguration.BLMDotTimerHeight;
+        private float OriginX => CenterX + _config.Position.X;
+        private float OriginY => CenterY + YOffset + _config.Position.Y;
+        private Dictionary<string, uint> EmptyColor => PluginConfiguration.MiscColorMap["empty"];
 
-        private Dictionary<string, uint> ManaBarNoElementColor => PluginConfiguration.JobColorMap[Jobs.BLM * 1000];
-        private Dictionary<string, uint> ManaBarIceColor => PluginConfiguration.JobColorMap[Jobs.BLM * 1000 + 1];
-        private Dictionary<string, uint> ManaBarFireColor => PluginConfiguration.JobColorMap[Jobs.BLM * 1000 + 2];
-        private Dictionary<string, uint> UmbralHeartColor => PluginConfiguration.JobColorMap[Jobs.BLM * 1000 + 3];
-        private Dictionary<string, uint> PolyglotColor => PluginConfiguration.JobColorMap[Jobs.BLM * 1000 + 4];
-        private Dictionary<string, uint> TriplecastColor => PluginConfiguration.JobColorMap[Jobs.BLM * 1000 + 5];
-        private Dictionary<string, uint> FirestarterColor => PluginConfiguration.JobColorMap[Jobs.BLM * 1000 + 6];
-        private Dictionary<string, uint> ThundercloudColor => PluginConfiguration.JobColorMap[Jobs.BLM * 1000 + 7];
-        private Dictionary<string, uint> DotColor => PluginConfiguration.JobColorMap[Jobs.BLM * 1000 + 8];
-        private Dictionary<string, uint> EmptyColor => PluginConfiguration.JobColorMap[Jobs.BLM * 1000 + 9];
+        public BlackMageHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration, BlackMageHudConfig config) 
+            : base(pluginInterface, pluginConfiguration) 
+        {
 
-        public BlackMageHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration) : base(pluginInterface, pluginConfiguration) { }
+            _config = config;
+        }
 
         protected override void Draw(bool _)
         {
@@ -55,17 +33,17 @@ namespace DelvUI.Interface
             DrawUmbralHeartStacks();
             DrawPolyglot();
 
-            if (ShowTripleCast)
+            if (_config.ShowTripleCast)
             {
                 DrawTripleCast();
             }
 
-            if (ShowFirestarterProcs || ShowThundercloudProcs)
+            if (_config.ShowFirestarterProcs || _config.ShowThundercloudProcs)
             {
                 DrawProcs();
             }
 
-            if (ShowDotTimer)
+            if (_config.ShowDotTimer)
             {
                 DrawDotTimer();
             }
@@ -77,16 +55,17 @@ namespace DelvUI.Interface
 
         protected virtual void DrawManaBar()
         {
-            Debug.Assert(PluginInterface.ClientState.LocalPlayer != null, "PluginInterface.ClientState.LocalPlayer != null");
-
             var gauge = PluginInterface.ClientState.JobGauges.Get<BLMGauge>();
 
             var actor = PluginInterface.ClientState.LocalPlayer;
-            var barSize = new Vector2(ManaBarWidth, ManaBarHeight);
+            var barSize = _config.ManaBarSize;
             var cursorPos = new Vector2(OriginX - barSize.X / 2, OriginY - barSize.Y);
-            var color = gauge.InAstralFire() ? ManaBarFireColor : (gauge.InUmbralIce() ? ManaBarIceColor : ManaBarNoElementColor);
+            var color = gauge.InAstralFire() ? _config.ManaBarFireColor.Map : (gauge.InUmbralIce() ? 
+                _config.ManaBarIceColor.Map : _config.ManaBarNoElementColor.Map);
 
-            var builder = BarBuilder.Create(OriginX - ManaBarWidth / 2, OriginY - ManaBarHeight, ManaBarHeight, ManaBarWidth);
+            var builder = BarBuilder.Create(OriginX - barSize.X / 2, OriginY - barSize.Y, (int)barSize.Y, (int)barSize.X);
+
+
             builder.AddInnerBar(actor.CurrentMp, actor.MaxMp, color).SetBackgroundColor(EmptyColor["background"]);
 
             // element timer
@@ -108,9 +87,9 @@ namespace DelvUI.Interface
             builder.Build().Draw(drawList, PluginConfiguration);
 
             // threshold marker
-            if (ShowManaThresholdMarker && gauge.InAstralFire())
+            if (_config.ShowManaThresholdMarker && gauge.InAstralFire())
             {
-                var position = new Vector2(OriginX - barSize.X / 2 + (ManaThresholdValue / 10000f) * barSize.X, cursorPos.Y + barSize.Y);
+                var position = new Vector2(OriginX - barSize.X / 2 + (_config.ManaThresholdValue / 10000f) * barSize.X, cursorPos.Y + barSize.Y);
                 var size = new Vector2(3, barSize.Y);
                 drawList.AddRectFilledMultiColor(
                     position, position - size,
@@ -119,28 +98,26 @@ namespace DelvUI.Interface
             }
 
             // mana
-            if (ShowManaValue)
+            if (_config.ShowManaValue)
             {
                 var mana = PluginInterface.ClientState.LocalPlayer.CurrentMp;
                 var text = $"{mana,0}";
                 var textSize = ImGui.CalcTextSize(text);
-                DrawOutlinedText(text, new Vector2(OriginX - barSize.X / 2f + 2, OriginY - ManaBarHeight / 2f - textSize.Y / 2f));
+                DrawOutlinedText(text, new Vector2(OriginX - barSize.X / 2f + 2, OriginY - _config.ManaBarSize.Y / 2f - textSize.Y / 2f));
             }
         }
 
         protected virtual void DrawUmbralHeartStacks()
         {
-            Debug.Assert(PluginInterface.ClientState.LocalPlayer != null, "PluginInterface.ClientState.LocalPlayer != null");
-
             var gauge = PluginInterface.ClientState.JobGauges.Get<BLMGauge>();
 
-            var totalWidth = UmbralHeartWidth * 3 + HorizontalSpaceBetweenBars * 2;
-            var cursorPos = new Vector2(OriginX - totalWidth / 2, OriginY - ManaBarHeight - VerticalSpaceBetweenBars - UmbralHeartHeight);
+            var totalWidth = _config.UmbralHeartSize.X * 3 + _config.Padding.X * 2;
+            var cursorPos = new Vector2(OriginX - totalWidth / 2, OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y);
 
-            var bar = BarBuilder.Create(cursorPos.X, cursorPos.Y, UmbralHeartHeight, totalWidth)
+            var bar = BarBuilder.Create(cursorPos.X, cursorPos.Y, _config.UmbralHeartSize.Y, totalWidth)
                 .SetChunks(3)
-                .SetChunkPadding(HorizontalSpaceBetweenBars)
-                .AddInnerBar(gauge.NumUmbralHearts, 3, UmbralHeartColor, EmptyColor).SetBackgroundColor(EmptyColor["background"])
+                .SetChunkPadding(_config.Padding.X)
+                .AddInnerBar(gauge.NumUmbralHearts, 3, _config.UmbralHeartColor.Map, EmptyColor).SetBackgroundColor(EmptyColor["background"])
                 .Build();
 
             var drawList = ImGui.GetWindowDrawList();
@@ -149,23 +126,21 @@ namespace DelvUI.Interface
 
         protected virtual void DrawPolyglot()
         {
-            Debug.Assert(PluginInterface.ClientState.LocalPlayer != null, "PluginInterface.ClientState.LocalPlayer != null");
-
             var gauge = PluginInterface.ClientState.JobGauges.Get<BLMGauge>();
-            var totalWidth = PolyglotWidth * 2 + HorizontalSpaceBetweenBars;
-            var y = OriginY - ManaBarHeight - VerticalSpaceBetweenBars - UmbralHeartHeight - VerticalSpaceBetweenBars - PolyglotHeight;
-            if (ShowTripleCast)
+            var totalWidth = _config.PolyglotSize.X * 2 + _config.Padding.X;
+            var y = OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y - _config.Padding.Y - _config.PolyglotSize.Y;
+            if (_config.ShowTripleCast)
             {
-                y = y - VerticalSpaceBetweenBars - TripleCastHeight;
+                y = y - _config.Padding.Y - _config.TripleCastSize.Y;
             }
 
             var scale = 1 - (gauge.IsEnoActive() ? gauge.TimeUntilNextPolyglot / 30000f : 1);
             var drawList = ImGui.GetWindowDrawList();
 
             // 1
-            var builder = BarBuilder.Create(OriginX - totalWidth / 2, y, PolyglotHeight, PolyglotWidth)
-                .AddInnerBar(gauge.NumPolyglotStacks < 1 ? scale : 1, 1, PolyglotColor).SetBackgroundColor(
-                EmptyColor["background"]);
+            var builder = BarBuilder.Create(OriginX - totalWidth / 2, y, _config.PolyglotSize.Y, _config.PolyglotSize.X)
+                .AddInnerBar(gauge.NumPolyglotStacks < 1 ? scale : 1, 1, _config.PolyglotColor.Map)
+                .SetBackgroundColor(EmptyColor["background"]);
 
             if (gauge.NumPolyglotStacks >= 1)
             {
@@ -175,8 +150,9 @@ namespace DelvUI.Interface
             builder.Build().Draw(drawList, PluginConfiguration);
 
             // 2
-            builder = BarBuilder.Create(OriginX - totalWidth / 2 + PolyglotWidth + HorizontalSpaceBetweenBars, y, PolyglotHeight, PolyglotWidth)
-                .AddInnerBar(gauge.NumPolyglotStacks == 1 ? scale : gauge.NumPolyglotStacks == 0 ? 0 : 1, 1, PolyglotColor).SetBackgroundColor(EmptyColor["background"]);
+            builder = BarBuilder.Create(OriginX - totalWidth / 2 + _config.PolyglotSize.X + _config.Padding.X, y, _config.PolyglotSize.Y, _config.PolyglotSize.X)
+                .AddInnerBar(gauge.NumPolyglotStacks == 1 ? scale : gauge.NumPolyglotStacks == 0 ? 0 : 1, 1, _config.PolyglotColor.Map)
+                .SetBackgroundColor(EmptyColor["background"]);
 
             if (gauge.NumPolyglotStacks == 2)
             {
@@ -188,17 +164,19 @@ namespace DelvUI.Interface
 
         protected virtual void DrawTripleCast()
         {
-            Debug.Assert(PluginInterface.ClientState.LocalPlayer != null, "PluginInterface.ClientState.LocalPlayer != null");
-
             var tripleStackBuff = PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 1211);
 
-            var totalWidth = TripleCastWidth * 3 + HorizontalSpaceBetweenBars * 2;
-            var cursorPos = new Vector2(OriginX - totalWidth / 2, OriginY - ManaBarHeight - VerticalSpaceBetweenBars - UmbralHeartHeight - VerticalSpaceBetweenBars - TripleCastHeight);
+            var totalWidth = _config.TripleCastSize.X * 3 + _config.Padding.X * 2;
+            var cursorPos = new Vector2(
+                OriginX - totalWidth / 2, 
+                OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y - _config.Padding.Y - _config.TripleCastSize.Y
+            );
 
-            var bar = BarBuilder.Create(cursorPos.X, cursorPos.Y, TripleCastHeight, totalWidth)
+            var bar = BarBuilder.Create(cursorPos.X, cursorPos.Y, _config.TripleCastSize.Y, totalWidth)
                 .SetChunks(3)
-                .SetChunkPadding(HorizontalSpaceBetweenBars)
-                .AddInnerBar(tripleStackBuff.StackCount, 3, TriplecastColor, EmptyColor).SetBackgroundColor(EmptyColor["background"])
+                .SetChunkPadding(_config.Padding.X)
+                .AddInnerBar(tripleStackBuff.StackCount, 3, _config.TriplecastColor.Map, EmptyColor)
+                .SetBackgroundColor(EmptyColor["background"])
                 .Build();
 
             var drawList = ImGui.GetWindowDrawList();
@@ -207,22 +185,20 @@ namespace DelvUI.Interface
 
         protected virtual void DrawProcs()
         {
-            Debug.Assert(PluginInterface.ClientState.LocalPlayer != null, "PluginInterface.ClientState.LocalPlayer != null");
-
-            var firestarterTimer = ShowFirestarterProcs ? Math.Abs(PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 165).Duration) : 0;
-            var thundercloudTimer = ShowThundercloudProcs ? Math.Abs(PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 164).Duration) : 0;
+            var firestarterTimer = _config.ShowFirestarterProcs ? Math.Abs(PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 165).Duration) : 0;
+            var thundercloudTimer = _config.ShowThundercloudProcs ? Math.Abs(PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 164).Duration) : 0;
 
             if (firestarterTimer == 0 && thundercloudTimer == 0)
             {
                 return;
             }
 
-            var totalHeight = firestarterTimer > 0 && thundercloudTimer > 0 ? ProcsHeight * 2 + VerticalSpaceBetweenBars : ProcsHeight;
-            var x = OriginX - HorizontalSpaceBetweenBars * 2f - PolyglotWidth;
-            var y = OriginY - ManaBarHeight - VerticalSpaceBetweenBars - UmbralHeartHeight - VerticalSpaceBetweenBars - PolyglotHeight / 2f + ProcsHeight;
-            if (ShowTripleCast)
+            var totalHeight = firestarterTimer > 0 && thundercloudTimer > 0 ? _config.ProcsHeight * 2 + _config.Padding.Y : _config.ProcsHeight;
+            var x = OriginX - _config.Padding.X * 2f - _config.PolyglotSize.X;
+            var y = OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y - _config.Padding.Y - _config.PolyglotSize.Y / 2f + _config.ProcsHeight;
+            if (_config.ShowTripleCast)
             {
-                y = y - VerticalSpaceBetweenBars - TripleCastHeight;
+                y = y - _config.Padding.Y - _config.TripleCastSize.Y;
             }
 
             // fire starter
@@ -231,23 +207,21 @@ namespace DelvUI.Interface
                 var position = new Vector2(x, y - totalHeight / 2f);
                 var scale = firestarterTimer / 18f;
 
-                DrawTimerBar(position, scale, ProcsHeight, FirestarterColor, true);
+                DrawTimerBar(position, scale, _config.ProcsHeight, _config.FirestarterColor.Map, true);
             }
 
             // thundercloud
             if (thundercloudTimer > 0)
             {
-                var position = new Vector2(x, firestarterTimer == 0 ? y - totalHeight / 2f : y + VerticalSpaceBetweenBars / 2f);
+                var position = new Vector2(x, firestarterTimer == 0 ? y - totalHeight / 2f : y + _config.Padding.Y / 2f);
                 var scale = thundercloudTimer / 18f;
 
-                DrawTimerBar(position, scale, ProcsHeight, ThundercloudColor, true);
+                DrawTimerBar(position, scale, _config.ProcsHeight, _config.ThundercloudColor.Map, true);
             }
         }
 
         protected virtual void DrawDotTimer()
         {
-            Debug.Assert(PluginInterface.ClientState.LocalPlayer != null, "PluginInterface.ClientState.LocalPlayer != null");
-
             var target = PluginInterface.ClientState.Targets.SoftTarget ?? PluginInterface.ClientState.Targets.CurrentTarget;
             if (target is null)
             {
@@ -276,23 +250,23 @@ namespace DelvUI.Interface
                 return;
             }
 
-            var x = OriginX + HorizontalSpaceBetweenBars * 2f + PolyglotWidth;
-            var y = OriginY - ManaBarHeight - VerticalSpaceBetweenBars - UmbralHeartHeight - VerticalSpaceBetweenBars - PolyglotHeight / 2f - DotTimerHeight;
-            if (ShowTripleCast)
+            var x = OriginX + _config.Padding.X * 2f + _config.PolyglotSize.X;
+            var y = OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y - _config.Padding.Y - _config.PolyglotSize.Y / 2f - _config.DotTimerHeight;
+            if (_config.ShowTripleCast)
             {
-                y = y - VerticalSpaceBetweenBars - TripleCastHeight;
+                y = y - _config.Padding.Y - _config.TripleCastSize.Y;
             }
 
-            var position = new Vector2(x, y + DotTimerHeight / 2f);
+            var position = new Vector2(x, y + _config.DotTimerHeight / 2f);
             var scale = timer / maxDuration;
             
-            DrawTimerBar(position, scale, DotTimerHeight, DotColor, false);
+            DrawTimerBar(position, scale, _config.DotTimerHeight, _config.DotColor.Map, false);
         }
 
         private void DrawTimerBar(Vector2 position, float scale, float height, Dictionary<string, uint> colorMap, bool inverted)
         {
             var drawList = ImGui.GetWindowDrawList();
-            var size = new Vector2((ManaBarWidth / 2f - PolyglotWidth - HorizontalSpaceBetweenBars * 2f) * scale, height);
+            var size = new Vector2((_config.ManaBarSize.X / 2f - _config.PolyglotSize.X - _config.Padding.X * 2f) * scale, height);
             size.X = Math.Max(1, size.X);
 
             var startPoint = inverted ? position - size : position;
@@ -302,6 +276,77 @@ namespace DelvUI.Interface
             drawList.AddRectFilledMultiColor(startPoint, startPoint + size,
                 leftColor, rightColor, rightColor, leftColor
             );
+        }
+    }
+
+    [Serializable]
+    public class BlackMageHudConfig: PluginConfigObject
+    {
+        public Vector2 Position = new Vector2(0, -2);
+        public Vector2 Padding = new Vector2(2, 2);
+        public Vector2 ManaBarSize = new Vector2(253, 20);
+        public Vector2 UmbralHeartSize = new Vector2(83, 16);
+        public Vector2 PolyglotSize = new Vector2(18, 18);
+        
+        public bool ShowManaValue = false;
+        public bool ShowManaThresholdMarker = true;
+        public int ManaThresholdValue = 2600;
+
+        public bool ShowTripleCast = true;
+        public Vector2 TripleCastSize = new Vector2(83, 16);
+        
+        public bool ShowFirestarterProcs = true;
+        public bool ShowThundercloudProcs = true;
+        public int ProcsHeight = 7;
+        public bool ShowDotTimer = true;
+        public int DotTimerHeight = 10;
+
+        public PluginConfigColor ManaBarNoElementColor = new PluginConfigColor(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
+        public PluginConfigColor ManaBarIceColor = new PluginConfigColor(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 100f / 100f));
+        public PluginConfigColor ManaBarFireColor = new PluginConfigColor(new Vector4(204f / 255f, 40f / 255f, 40f / 255f, 100f / 100f));
+        public PluginConfigColor UmbralHeartColor = new PluginConfigColor(new Vector4(125f / 255f, 195f / 255f, 205f / 255f, 100f / 100f));
+        public PluginConfigColor PolyglotColor = new PluginConfigColor(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
+        public PluginConfigColor TriplecastColor = new PluginConfigColor(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
+        public PluginConfigColor FirestarterColor = new PluginConfigColor(new Vector4(255f / 255f, 136f / 255f, 0 / 255f, 90f / 100f));
+        public PluginConfigColor ThundercloudColor = new PluginConfigColor(new Vector4(240f / 255f, 163f / 255f, 255f / 255f, 90f / 100f));
+        public PluginConfigColor DotColor = new PluginConfigColor(new Vector4(67f / 255f, 187 / 255f, 255f / 255f, 90f / 100f));
+
+        public bool Draw()
+        {
+            var changed = false;
+
+            changed |= ImGui.DragFloat2("Base Offset", ref Position, 1f, -4000, 4000);
+            changed |= ImGui.DragFloat2("Padding", ref Padding, 1f, -100, 100);
+            changed |= ImGui.DragFloat2("Mana Bar Size", ref ManaBarSize, 1f, 1, 2000);
+            changed |= ImGui.DragFloat2("Umbral Heart Size", ref UmbralHeartSize, 1f, 1, 2000);
+            changed |= ImGui.DragFloat2("Polyglot Size", ref PolyglotSize, 1f, 1, 2000);
+
+            changed |= ImGui.Checkbox("Show Mana Value", ref ShowManaValue);
+            changed |= ImGui.Checkbox("Show Mana Threshold Marker During Astral Fire", ref ShowManaThresholdMarker);
+            changed |= ImGui.DragInt("Mana Threshold Marker Value", ref ManaThresholdValue, 1f, 1, 10000);
+            
+            changed |= ImGui.Checkbox("Show Triplecast", ref ShowTripleCast);
+            changed |= ImGui.DragFloat2("Triplecast Size", ref TripleCastSize, 1f, 1, 2000);
+            
+            changed |= ImGui.Checkbox("Show Firestarter Procs", ref ShowFirestarterProcs);
+            changed |= ImGui.Checkbox("Show Thundercloud Procs", ref ShowThundercloudProcs);
+
+            changed |= ImGui.DragInt("Procs Height", ref ProcsHeight, .1f, 1, 2000);
+
+            changed |= ImGui.Checkbox("Show DoT Timer", ref ShowDotTimer);
+            changed |= ImGui.DragInt("DoT Timer Height", ref DotTimerHeight, .1f, 1, 2000);
+
+            changed |= ColorEdit4("Mana Bar Color", ref ManaBarNoElementColor);
+            changed |= ColorEdit4("Mana Bar Ice Color", ref ManaBarIceColor);
+            changed |= ColorEdit4("Mana Bar Fire Color", ref ManaBarFireColor);
+            changed |= ColorEdit4("Umbral Heart Color", ref UmbralHeartColor);
+            changed |= ColorEdit4("Polyglot Color", ref PolyglotColor);
+            changed |= ColorEdit4("Triplecast Color", ref TriplecastColor);
+            changed |= ColorEdit4("Firestarter Proc Color", ref FirestarterColor);
+            changed |= ColorEdit4("Thundercloud Proc Color", ref ThundercloudColor);
+            changed |= ColorEdit4("DoT Timer Color", ref DotColor);
+
+            return changed;
         }
     }
 }

--- a/DelvUI/Interface/DancerHudWindow.cs
+++ b/DelvUI/Interface/DancerHudWindow.cs
@@ -8,6 +8,7 @@ using Dalamud.Plugin;
 using DelvUI.GameStructs;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface {
     public class DancerHudWindow : HudWindow {

--- a/DelvUI/Interface/DarkKnightHudWindow.cs
+++ b/DelvUI/Interface/DarkKnightHudWindow.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface {
     public class DarkKnightHudWindow : HudWindow {

--- a/DelvUI/Interface/DragoonHudWindow.cs
+++ b/DelvUI/Interface/DragoonHudWindow.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.Collections.Generic;
 using Dalamud.Game.ClientState.Actors.Types;
 using System.Linq;
@@ -8,6 +7,7 @@ using System.Numerics;
 using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/GunbreakerHudWindow.cs
+++ b/DelvUI/Interface/GunbreakerHudWindow.cs
@@ -1,10 +1,10 @@
-﻿using System.Numerics;
-using System.Linq;
+﻿using System.Linq;
 using System.Collections.Generic;
 using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface {
     public class GunbreakerHudWindow : HudWindow {

--- a/DelvUI/Interface/HandHudWindow.cs
+++ b/DelvUI/Interface/HandHudWindow.cs
@@ -1,12 +1,8 @@
 ﻿using Dalamud.Plugin;
 using ImGuiNET;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -5,13 +5,9 @@ using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
-using Dalamud.Configuration;
-using Dalamud.Data.LuminaExtensions;
 using Dalamud.Game.ClientState.Actors;
 using Dalamud.Game.ClientState.Actors.Types;
 using Dalamud.Game.ClientState.Actors.Types.NonPlayer;
-using Dalamud.Game.ClientState.Structs;
-using Dalamud.Game.Internal.Gui.Addon;
 using Dalamud.Interface;
 using Dalamud.Plugin;
 using DelvUI.Enums;
@@ -21,10 +17,10 @@ using FFXIVClientStructs.FFXIV.Component.GUI;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using ImGuiNET;
-using Lumina.Excel.GeneratedSheets;
 using Actor = Dalamud.Game.ClientState.Actors.Types.Actor;
 using Addon = Dalamud.Game.Internal.Gui.Addon.Addon;
 using DelvUI.Interface.StatusEffects;
+using DelvUI.Config;
 
 namespace DelvUI.Interface {
     public abstract class HudWindow {

--- a/DelvUI/Interface/LandHudWindow.cs
+++ b/DelvUI/Interface/LandHudWindow.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/MachinistHudWindow.cs
+++ b/DelvUI/Interface/MachinistHudWindow.cs
@@ -5,6 +5,7 @@ using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/MonkHudWindow.cs
+++ b/DelvUI/Interface/MonkHudWindow.cs
@@ -5,6 +5,7 @@ using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using ImGuiNET;
 using DelvUI.Interface.Bars;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/NinjaHudWindow.cs
+++ b/DelvUI/Interface/NinjaHudWindow.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/PaladinHudWindow.cs
+++ b/DelvUI/Interface/PaladinHudWindow.cs
@@ -8,6 +8,7 @@ using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/RedMageHudWindow.cs
+++ b/DelvUI/Interface/RedMageHudWindow.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface {
     public class RedMageHudWindow : HudWindow {

--- a/DelvUI/Interface/SamuraiHudWindow.cs
+++ b/DelvUI/Interface/SamuraiHudWindow.cs
@@ -7,6 +7,7 @@ using Dalamud.Game.ClientState.Actors.Types;
 using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/ScholarHudWindow.cs
+++ b/DelvUI/Interface/ScholarHudWindow.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/StatusEffects/StatusEffectIconDrawHelper.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectIconDrawHelper.cs
@@ -17,13 +17,11 @@ namespace DelvUI.Interface.StatusEffects
             // border
             if (config.ShowDispellableBorder && statusEffectData.data.CanDispel)
             {
-                var color = ImGui.ColorConvertFloat4ToU32(config.DispellableBorderColor);
-                drawList.AddRect(position, position + config.Size, color, 0, ImDrawFlags.None, config.DispellableBorderThickness);
+                drawList.AddRect(position, position + config.Size, config.DispellableBorderColor.Base, 0, ImDrawFlags.None, config.DispellableBorderThickness);
             }
             else if (config.ShowBorder)
             {
-                var color = ImGui.ColorConvertFloat4ToU32(config.BorderColor);
-                drawList.AddRect(position, position + config.Size, color, 0, ImDrawFlags.None, config.BorderThickness);
+                drawList.AddRect(position, position + config.Size, config.BorderColor.Base, 0, ImDrawFlags.None, config.BorderThickness);
             }
 
             // duration

--- a/DelvUI/Interface/StatusEffects/StatusEffectsList.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsList.cs
@@ -202,46 +202,4 @@ namespace DelvUI.Interface.StatusEffects
             }
         }
     }
-
-    [Serializable]
-    public class StatusEffectsListConfig
-    {
-        public bool Enabled = true;
-        public Vector2 Position;
-        public Vector2 MaxSize = new Vector2(340, 100);
-        public Vector2 IconPadding = new Vector2(2, 2);
-        public bool ShowArea = false;
-        public StatusEffectIconConfig IconConfig = new StatusEffectIconConfig();
-        public bool ShowBuffs;
-        public bool ShowDebuffs;
-        public bool ShowPermanentEffects;
-        public bool FillRowsFirst = true;
-        public int Limit = -1;
-        public short GrowthDirections;
-
-        public StatusEffectsListConfig(Vector2 position, bool showBuffs, bool showDebuffs, bool showPermanentEffects, GrowthDirections growthDirections)
-        {
-            Position = position;
-            ShowBuffs = showBuffs;
-            ShowDebuffs = showDebuffs;
-            ShowPermanentEffects = showPermanentEffects;
-            GrowthDirections = (short)growthDirections;
-        }
-    }
-
-    [Serializable]
-    public class StatusEffectIconConfig
-    {
-        public Vector2 Size = new Vector2(40, 40);
-        public bool ShowDurationText = true;
-        public bool ShowStacksText = true;
-
-        public bool ShowBorder = true;
-        public int BorderThickness = 1;
-        public Vector4 BorderColor = new Vector4(0f / 255f, 0 / 255f, 0 / 255f, 100f / 100f);
-
-        public bool ShowDispellableBorder = true;
-        public int DispellableBorderThickness = 2;
-        public Vector4 DispellableBorderColor = new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f);
-    }
 }

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Numerics;
+using ImGuiNET;
+using System.Collections.Generic;
+using DelvUI.Config;
+
+namespace DelvUI.Interface.StatusEffects
+{
+    [Serializable]
+    public class StatusEffectsListConfig: PluginConfigObject
+    {
+        public bool Enabled = true;
+        public Vector2 Position;
+        public Vector2 MaxSize = new Vector2(340, 100);
+        public Vector2 IconPadding = new Vector2(2, 2);
+        public bool ShowArea = false;
+        public StatusEffectIconConfig IconConfig = new StatusEffectIconConfig();
+        public bool ShowBuffs;
+        public bool ShowDebuffs;
+        public bool ShowPermanentEffects;
+        public bool FillRowsFirst = true;
+        public int Limit = -1;
+        public GrowthDirections GrowthDirections;
+
+        public StatusEffectsListConfig(Vector2 position, bool showBuffs, bool showDebuffs, bool showPermanentEffects, GrowthDirections growthDirections)
+        {
+            Position = position;
+            ShowBuffs = showBuffs;
+            ShowDebuffs = showDebuffs;
+            ShowPermanentEffects = showPermanentEffects;
+            GrowthDirections = growthDirections;
+        }
+
+        public bool Draw()
+        {
+            var changed = false;
+
+            changed |= ImGui.Checkbox("Enabled", ref Enabled);
+
+            ImGui.Text("Layout");
+            ImGui.BeginGroup();
+            {
+                changed |= ImGui.DragFloat2("Base Offset", ref Position, 1f, -4000, 4000);
+                changed |= ImGui.DragFloat2("Area Size", ref MaxSize, 1f, 1, 2000);
+                changed |= ImGui.DragFloat2("Padding", ref IconPadding, 1f, -200, 200);
+
+                List<GrowthDirections> directions = new List<GrowthDirections>()
+                {
+                    GrowthDirections.RIGHT | GrowthDirections.DOWN,
+                    GrowthDirections.RIGHT | GrowthDirections.UP,
+                    GrowthDirections.LEFT | GrowthDirections.DOWN,
+                    GrowthDirections.LEFT | GrowthDirections.UP
+                };
+                int selection = Math.Max(0, directions.IndexOf((GrowthDirections)GrowthDirections));
+                string[] directionsStrings = new string[]
+                {
+                    "Right and Down",
+                    "Right and Up",
+                    "Left and Down",
+                    "Left and Up"
+                };
+                if (ImGui.Combo("Icons Growth Direction", ref selection, directionsStrings, directionsStrings.Length))
+                {
+                    GrowthDirections = directions[selection];
+                    changed = true;
+                }
+
+                changed |= ImGui.Checkbox("Show Area", ref ShowArea);
+                changed |= ImGui.Checkbox("Fill Rows First", ref FillRowsFirst);
+                changed |= ImGui.Checkbox("Show Permanent Effects", ref ShowPermanentEffects);
+                changed |= ImGui.DragInt("Limit (-1 means no limit)", ref Limit, .1f, -1, 100);
+            }
+            ImGui.EndGroup();
+
+            changed = IconConfig.Draw();
+            
+            return changed;
+        }
+    }
+
+    [Serializable]
+    public class StatusEffectIconConfig: PluginConfigObject
+    {
+        public Vector2 Size = new Vector2(40, 40);
+        public bool ShowDurationText = true;
+        public bool ShowStacksText = true;
+
+        public bool ShowBorder = true;
+        public int BorderThickness = 1;
+        public PluginConfigColor BorderColor = new PluginConfigColor(new Vector4(0f / 255f, 0 / 255f, 0 / 255f, 100f / 100f));
+
+        public bool ShowDispellableBorder = true;
+        public int DispellableBorderThickness = 2;
+        public PluginConfigColor DispellableBorderColor = new PluginConfigColor(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
+
+        public bool Draw()
+        {
+            var changed = false;
+
+            ImGui.Text("Icons");
+            ImGui.BeginGroup();
+            {
+                changed |= ImGui.DragFloat2("Size", ref Size, 1f, 1, 200);
+
+                changed |= ImGui.Checkbox("Show Duration", ref ShowDurationText);
+                changed |= ImGui.Checkbox("Show Stacks", ref ShowStacksText);
+                
+                changed |= ImGui.Checkbox("Show Border", ref ShowBorder);
+                changed |= ImGui.DragInt("Border Thickness", ref BorderThickness, .1f, 1, 5);
+                changed |= ColorEdit4("Border Color", ref BorderColor);
+
+                changed |= ImGui.Checkbox("Show Dispellable Border", ref ShowDispellableBorder);
+                changed |= ImGui.DragInt("Dispellable Border Thickness", ref DispellableBorderThickness, .1f, 1, 5);
+                changed |= ColorEdit4("Dispellable order Color", ref DispellableBorderColor);
+            }
+            ImGui.EndGroup();
+
+            return changed;
+        }
+    }
+}

--- a/DelvUI/Interface/SummonerHudWindow.cs
+++ b/DelvUI/Interface/SummonerHudWindow.cs
@@ -6,6 +6,7 @@ using Dalamud.Game.ClientState.Actors.Types;
 using Dalamud.Plugin;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/UnitframeOnlyHudWindow.cs
+++ b/DelvUI/Interface/UnitframeOnlyHudWindow.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Plugin;
+using DelvUI.Config;
 
 namespace DelvUI.Interface {
     public class UnitFrameOnlyHudWindow : HudWindow

--- a/DelvUI/Interface/WarriorHudWindow.cs
+++ b/DelvUI/Interface/WarriorHudWindow.cs
@@ -6,6 +6,7 @@ using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Interface/WhiteMageHudWindow.cs
+++ b/DelvUI/Interface/WhiteMageHudWindow.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using ImGuiNET;
+using DelvUI.Config;
 
 namespace DelvUI.Interface
 {

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -7,7 +7,8 @@ using Dalamud.Plugin;
 using ImGuiNET;
 using DelvUI.Interface;
 using FFXIVClientStructs;
-using DelvUI.Helpers; 
+using DelvUI.Helpers;
+using DelvUI.Config;
 
 namespace DelvUI {
     // ReSharper disable once ClassNeverInstantiated.Global
@@ -179,7 +180,7 @@ namespace DelvUI {
                 //Caster DPS
                 Jobs.RDM => new RedMageHudWindow(_pluginInterface, _pluginConfiguration),
                 Jobs.SMN => new SummonerHudWindow(_pluginInterface, _pluginConfiguration),
-                Jobs.BLM => new BlackMageHudWindow(_pluginInterface, _pluginConfiguration),
+                Jobs.BLM => new BlackMageHudWindow(_pluginInterface, _pluginConfiguration, _pluginConfiguration.BLMConfig),
 
                 //Low jobs
                 Jobs.MRD => new UnitFrameOnlyHudWindow(_pluginInterface, _pluginConfiguration),


### PR DESCRIPTION
**New classes PluginConfigObject and PluginConfigColor**
Created these 2 with the purpose of removing the enormous color map on PluginConfiguration. The idea is that each element will have it's own config. The config objects will have all the necessary properties for that particular element, along with a function to draw the settings screen for itself.
PluginConfigColor is a little helper class to automatically generate the color maps for a Vector4. It provides easy access to the base, background and gradient colors, along with the full map.

Updated Buff/Debuff and BLM configs to accommodate with these new classes and to serve as an example on how to use them.
Hopefully the rest of the elements get slowly ported over this system over time.

Starting the modularization of this will help in case we want to automatize the settings drawing in the future.


Note: Lots of "fake" changes being flagged due to difference in end line characters :/