### PR TITLE
fix: Partial Fill Bar Visibility

### DIFF
--- a/DelvUI/Config/ConfigurationWindow.cs
+++ b/DelvUI/Config/ConfigurationWindow.cs
@@ -1770,7 +1770,8 @@ namespace DelvUI.Config {
                 }
             }
 
-            _changed |= ImGui.ColorEdit4("Bar Not Full Color", ref _pluginConfiguration.EmptyColor);
+            _changed |= ImGui.ColorEdit4("Bar Background Color", ref _pluginConfiguration.EmptyColor);
+            _changed |= ImGui.ColorEdit4("Bar Partial Fill Color", ref _pluginConfiguration.PartialFillColor);
         }
 
         private void DrawJobsTankConfig() {
@@ -2261,7 +2262,6 @@ namespace DelvUI.Config {
 
                     _changed |= ImGui.ColorEdit4("Mana Bar Color", ref _pluginConfiguration.PLDManaColor);
                     _changed |= ImGui.ColorEdit4("Oath Gauge Color", ref _pluginConfiguration.PLDOathGaugeColor);
-                    _changed |= ImGui.ColorEdit4("Oath Gauge Not Full Chunk Color", ref _pluginConfiguration.PLDOathNotFullColor);
 
                     _changed |= ImGui.ColorEdit4(
                         "Fight or Flight Color",
@@ -3301,10 +3301,6 @@ namespace DelvUI.Config {
                         }
 
                         _changed |= ImGui.ColorEdit4("Ninki Bar Color", ref _pluginConfiguration.NINNinkiColor);
-
-                        if (_pluginConfiguration.NINNinkiChunked) {
-                            _changed |= ImGui.ColorEdit4("Ninki Bar Not Filled Chunk Color", ref _pluginConfiguration.NINNinkiNotFullColor);
-                        }
                     }
 
                     _changed |= ImGui.Checkbox("Enable Trick Bar", ref _pluginConfiguration.NINTrickBarEnabled);

--- a/DelvUI/Config/PluginConfiguration.cs
+++ b/DelvUI/Config/PluginConfiguration.cs
@@ -61,6 +61,7 @@ namespace DelvUI.Config {
         public Vector4 CustomHealthBarColor = new(0f / 255f, 145f / 255f, 6f / 255f, 100f / 100f);
         public bool CustomHealthBarColorEnabled = false;
         public Vector4 EmptyColor = new(0f / 255f, 0f / 255f, 0f / 255f, 50f / 100f);
+        public Vector4 PartialFillColor = new(180f / 255f, 180f / 255f, 180f / 255f, 100f / 100f);
         public string FocusBarText = "[name:abbreviate]";
         public bool GCDAlwaysShow = false;
         public Vector4 GCDIndicatorColor = new(255f / 255f, 255f / 255f, 255f / 255f, 70f / 100f);
@@ -378,13 +379,6 @@ namespace DelvUI.Config {
                     ["background"] = ImGui.ColorConvertFloat4ToU32(PLDDoTColor.AdjustColor(-.8f)),
                     ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(PLDDoTColor.AdjustColor(-.1f)),
                     ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(PLDDoTColor.AdjustColor(.1f))
-                },
-                [Jobs.PLD * 1000 + 7] = new() // DoT
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(PLDOathNotFullColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(PLDOathNotFullColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(PLDOathNotFullColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(PLDOathNotFullColor.AdjustColor(.1f))
                 },
                 [Jobs.WAR] = new()
                 {
@@ -977,21 +971,14 @@ namespace DelvUI.Config {
                     ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(NINNinkiColor.AdjustColor(-.1f)),
                     ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(NINNinkiColor.AdjustColor(.1f))
                 },
-                [Jobs.NIN * 1000 + 3] = new() // Ninki gauge partially filled
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(NINNinkiNotFullColor),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(NINNinkiNotFullColor.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(NINNinkiNotFullColor.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(NINNinkiNotFullColor.AdjustColor(.1f))
-                },
-                [Jobs.NIN * 1000 + 4] = new() // Trick bar
+                [Jobs.NIN * 1000 + 3] = new() // Trick bar
                 {
                     ["base"] = ImGui.ColorConvertFloat4ToU32(NINTrickColor),
                     ["background"] = ImGui.ColorConvertFloat4ToU32(NINTrickColor.AdjustColor(-.8f)),
                     ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(NINTrickColor.AdjustColor(-.1f)),
                     ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(NINTrickColor.AdjustColor(.1f))
                 },
-                [Jobs.NIN * 1000 + 5] = new() // Suiton bar
+                [Jobs.NIN * 1000 + 4] = new() // Suiton bar
                 {
                     ["base"] = ImGui.ColorConvertFloat4ToU32(NINSuitonColor),
                     ["background"] = ImGui.ColorConvertFloat4ToU32(NINSuitonColor.AdjustColor(-.8f)),
@@ -1431,6 +1418,13 @@ namespace DelvUI.Config {
                     ["background"] = ImGui.ColorConvertFloat4ToU32(EmptyColor.AdjustColor(-.8f)),
                     ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(EmptyColor.AdjustColor(-.1f)),
                     ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(EmptyColor.AdjustColor(.1f))
+                },
+                ["partial"] = new()
+                {
+                    ["base"] = ImGui.ColorConvertFloat4ToU32(PartialFillColor),
+                    ["background"] = ImGui.ColorConvertFloat4ToU32(PartialFillColor),
+                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(PartialFillColor),
+                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(PartialFillColor)
                 }
             };
 
@@ -1858,7 +1852,6 @@ namespace DelvUI.Config {
 
         public Vector4 NINHutonColor = new(110f / 255f, 197f / 255f, 207f / 255f, 100f / 100f);
         public Vector4 NINNinkiColor = new(137f / 255f, 82f / 255f, 236f / 255f, 100f / 100f);
-        public Vector4 NINNinkiNotFullColor = new(186 / 255f, 177f / 255f, 183f / 255f, 100f / 100f);
         public Vector4 NINTrickColor = new(191f / 255f, 40f / 255f, 0f / 255f, 100f / 100f);
         public Vector4 NINSuitonColor = new(202f / 255f, 228f / 255f, 246f / 242f, 100f / 100f);
 
@@ -1949,7 +1942,6 @@ namespace DelvUI.Config {
         public Vector4 PLDRequiescatColor = new(61f / 255f, 61f / 255f, 255f / 255f, 100f / 100f);
         public Vector4 PLDAtonementColor = new(240f / 255f, 176f / 255f, 0f / 255f, 100f / 100f);
         public Vector4 PLDDoTColor = new(255f / 255f, 128f / 255f, 0f / 255f, 100f / 100f);
-        public Vector4 PLDOathNotFullColor = new(186 / 255f, 177f / 255f, 183f / 255f, 100f / 100f);
 
         #endregion
 

--- a/DelvUI/Interface/DarkKnightHudWindow.cs
+++ b/DelvUI/Interface/DarkKnightHudWindow.cs
@@ -56,7 +56,8 @@ namespace DelvUI.Interface {
         private Dictionary<string, uint> BloodWeaponColor => PluginConfiguration.JobColorMap[Jobs.DRK * 1000 + 4];
         private Dictionary<string, uint> DeliriumColor => PluginConfiguration.JobColorMap[Jobs.DRK * 1000 + 5];
         private Dictionary<string, uint> LivingShadowColor => PluginConfiguration.JobColorMap[Jobs.DRK * 1000 + 6];
-        private Dictionary<string, uint> EmptyColor => PluginConfiguration.JobColorMap[Jobs.DRK * 1000 + 7];
+        private Dictionary<string, uint> EmptyColor => PluginConfiguration.MiscColorMap["empty"];
+        private Dictionary<string, uint> PartialFillColor => PluginConfiguration.MiscColorMap["partial"];
 
         protected override void Draw(bool _) {
             if (ManaBarEnabled) {
@@ -223,10 +224,10 @@ namespace DelvUI.Interface {
                     drawList.AddRectFilledMultiColor(
                         cursorPos,
                         cursorPos + new Vector2(barWidth * scale, BloodGaugeHeight),
-                        EmptyColor["gradientLeft"],
-                        EmptyColor["gradientRight"],
-                        EmptyColor["gradientRight"],
-                        EmptyColor["gradientLeft"]
+                        PartialFillColor["gradientLeft"],
+                        PartialFillColor["gradientRight"],
+                        PartialFillColor["gradientRight"],
+                        PartialFillColor["gradientLeft"]
                     );
                 }
 

--- a/DelvUI/Interface/NinjaHudWindow.cs
+++ b/DelvUI/Interface/NinjaHudWindow.cs
@@ -41,12 +41,12 @@ namespace DelvUI.Interface {
         private int TrickBarXOffset => PluginConfiguration.NINTrickBarXOffset;
         private int TrickBarYOffset => PluginConfiguration.NINTrickBarYOffset;
 
-        private Dictionary<string, uint> EmptyColor => PluginConfiguration.JobColorMap[Jobs.NIN * 1000];
+        private Dictionary<string, uint> EmptyColor => PluginConfiguration.MiscColorMap["empty"];
         private Dictionary<string, uint> HutonColor => PluginConfiguration.JobColorMap[Jobs.NIN * 1000 + 1];
         private Dictionary<string, uint> NinkiColor => PluginConfiguration.JobColorMap[Jobs.NIN * 1000 + 2];
-        private Dictionary<string, uint> NinkiNotFilledColor => PluginConfiguration.JobColorMap[Jobs.NIN * 1000 + 3];
-        private Dictionary<string, uint> TrickColor => PluginConfiguration.JobColorMap[Jobs.NIN * 1000 + 4];
-        private Dictionary<string, uint> SuitonColor => PluginConfiguration.JobColorMap[Jobs.NIN * 1000 + 5];
+        private Dictionary<string, uint> TrickColor => PluginConfiguration.JobColorMap[Jobs.NIN * 1000 + 3];
+        private Dictionary<string, uint> SuitonColor => PluginConfiguration.JobColorMap[Jobs.NIN * 1000 + 4];
+        private Dictionary<string, uint> NinkiNotFilledColor => PluginConfiguration.MiscColorMap["partial"];
 
         protected override void Draw(bool _) {
             if (HutonGaugeEnabled) {

--- a/DelvUI/Interface/PaladinHudWindow.cs
+++ b/DelvUI/Interface/PaladinHudWindow.cs
@@ -65,7 +65,7 @@ namespace DelvUI.Interface {
         private Dictionary<string, uint> EmptyColor => PluginConfiguration.JobColorMap[Jobs.PLD * 1000 + 4];
         private Dictionary<string, uint> AtonementColor => PluginConfiguration.JobColorMap[Jobs.PLD * 1000 + 5];
         private Dictionary<string, uint> DoTColor => PluginConfiguration.JobColorMap[Jobs.PLD * 1000 + 6];
-        private Dictionary<string, uint> OathNotFullColor => PluginConfiguration.JobColorMap[Jobs.PLD * 1000 + 7];
+        private Dictionary<string, uint> OathNotFullColor => PluginConfiguration.MiscColorMap["partial"];
 
         protected override void Draw(bool _) {
             if (ManaEnabled) {


### PR DESCRIPTION
Create configurable color for partially filled bars where the resource is not yet useable.

Apply to DRK, NIN, and PLD.

Resolves #250 