### PR TITLE
[DO NOT MERGE] Complete configuration refactor

### DIFF
--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using ImGuiNET;
+
+namespace DelvUI.Config.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class CheckboxAttribute : Attribute
+    {
+        public string friendlyName;
+
+        public CheckboxAttribute(string friendlyName)
+        {
+            this.friendlyName = friendlyName;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class DragFloatAttribute : Attribute
+    {
+        public string friendlyName;
+        public float min;
+        public float max;
+        public float velocity;
+
+        public DragFloatAttribute(string friendlyName)
+        {
+            this.friendlyName = friendlyName;
+            min = 1f;
+            max = 1000f;
+            velocity = 1f;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class DragIntAttribute : Attribute
+    {
+        public string friendlyName;
+        public int min;
+        public int max;
+        public int velocity;
+
+        public DragIntAttribute(string friendlyName)
+        {
+            this.friendlyName = friendlyName;
+            min = 1;
+            max = 1000;
+            velocity = 1;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class DragFloat2Attribute : Attribute
+    {
+        public string friendlyName;
+        public float min;
+        public float max;
+        public float velocity;
+
+        public DragFloat2Attribute(string friendlyName)
+        {
+            this.friendlyName = friendlyName;
+            min = 1f;
+            max = 1000f;
+            velocity = 1f;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class DragInt2Attribute : Attribute
+    {
+        public string friendlyName;
+        public int min;
+        public int max;
+        public int velocity;
+
+        public DragInt2Attribute(string friendlyName)
+        {
+            this.friendlyName = friendlyName;
+            min = 1;
+            max = 1000;
+            velocity = 1;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class InputTextAttribute : Attribute
+    {
+        public string friendlyName;
+        public uint maxLength;
+
+        public InputTextAttribute(string friendlyName)
+        {
+            this.friendlyName = friendlyName;
+            maxLength = 999;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class ColorEdit4Attribute : Attribute
+    {
+        public string friendlyName;
+
+        public ColorEdit4Attribute(string friendlyName)
+        {
+            this.friendlyName = friendlyName;
+        }
+    }
+}

--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -1,22 +1,25 @@
 ﻿using System;
-using ImGuiNET;
 
-namespace DelvUI.Config.Attributes {
+namespace DelvUI.Config.Attributes
+{
     [AttributeUsage(AttributeTargets.Field)]
-    public class CheckboxAttribute : Attribute {
+    public class CheckboxAttribute : Attribute
+    {
         public string friendlyName;
 
         public CheckboxAttribute(string friendlyName) { this.friendlyName = friendlyName; }
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragFloatAttribute : Attribute {
+    public class DragFloatAttribute : Attribute
+    {
         public string friendlyName;
         public float min;
         public float max;
         public float velocity;
 
-        public DragFloatAttribute(string friendlyName) {
+        public DragFloatAttribute(string friendlyName)
+        {
             this.friendlyName = friendlyName;
             min = 1f;
             max = 1000f;
@@ -25,13 +28,15 @@ namespace DelvUI.Config.Attributes {
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragIntAttribute : Attribute {
+    public class DragIntAttribute : Attribute
+    {
         public string friendlyName;
         public int min;
         public int max;
         public int velocity;
 
-        public DragIntAttribute(string friendlyName) {
+        public DragIntAttribute(string friendlyName)
+        {
             this.friendlyName = friendlyName;
             min = 1;
             max = 1000;
@@ -40,13 +45,15 @@ namespace DelvUI.Config.Attributes {
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragFloat2Attribute : Attribute {
+    public class DragFloat2Attribute : Attribute
+    {
         public string friendlyName;
         public float min;
         public float max;
         public float velocity;
 
-        public DragFloat2Attribute(string friendlyName) {
+        public DragFloat2Attribute(string friendlyName)
+        {
             this.friendlyName = friendlyName;
             min = 1f;
             max = 1000f;
@@ -55,13 +62,15 @@ namespace DelvUI.Config.Attributes {
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragInt2Attribute : Attribute {
+    public class DragInt2Attribute : Attribute
+    {
         public string friendlyName;
         public int min;
         public int max;
         public int velocity;
 
-        public DragInt2Attribute(string friendlyName) {
+        public DragInt2Attribute(string friendlyName)
+        {
             this.friendlyName = friendlyName;
             min = 1;
             max = 1000;
@@ -70,18 +79,21 @@ namespace DelvUI.Config.Attributes {
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class InputTextAttribute : Attribute {
+    public class InputTextAttribute : Attribute
+    {
         public string friendlyName;
         public uint maxLength;
 
-        public InputTextAttribute(string friendlyName) {
+        public InputTextAttribute(string friendlyName)
+        {
             this.friendlyName = friendlyName;
             maxLength = 999;
         }
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class ColorEdit4Attribute : Attribute {
+    public class ColorEdit4Attribute : Attribute
+    {
         public string friendlyName;
 
         public ColorEdit4Attribute(string friendlyName) { this.friendlyName = friendlyName; }

--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -1,29 +1,22 @@
 ﻿using System;
 using ImGuiNET;
 
-namespace DelvUI.Config.Attributes
-{
+namespace DelvUI.Config.Attributes {
     [AttributeUsage(AttributeTargets.Field)]
-    public class CheckboxAttribute : Attribute
-    {
+    public class CheckboxAttribute : Attribute {
         public string friendlyName;
 
-        public CheckboxAttribute(string friendlyName)
-        {
-            this.friendlyName = friendlyName;
-        }
+        public CheckboxAttribute(string friendlyName) { this.friendlyName = friendlyName; }
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragFloatAttribute : Attribute
-    {
+    public class DragFloatAttribute : Attribute {
         public string friendlyName;
         public float min;
         public float max;
         public float velocity;
 
-        public DragFloatAttribute(string friendlyName)
-        {
+        public DragFloatAttribute(string friendlyName) {
             this.friendlyName = friendlyName;
             min = 1f;
             max = 1000f;
@@ -32,15 +25,13 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragIntAttribute : Attribute
-    {
+    public class DragIntAttribute : Attribute {
         public string friendlyName;
         public int min;
         public int max;
         public int velocity;
 
-        public DragIntAttribute(string friendlyName)
-        {
+        public DragIntAttribute(string friendlyName) {
             this.friendlyName = friendlyName;
             min = 1;
             max = 1000;
@@ -49,15 +40,13 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragFloat2Attribute : Attribute
-    {
+    public class DragFloat2Attribute : Attribute {
         public string friendlyName;
         public float min;
         public float max;
         public float velocity;
 
-        public DragFloat2Attribute(string friendlyName)
-        {
+        public DragFloat2Attribute(string friendlyName) {
             this.friendlyName = friendlyName;
             min = 1f;
             max = 1000f;
@@ -66,15 +55,13 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragInt2Attribute : Attribute
-    {
+    public class DragInt2Attribute : Attribute {
         public string friendlyName;
         public int min;
         public int max;
         public int velocity;
 
-        public DragInt2Attribute(string friendlyName)
-        {
+        public DragInt2Attribute(string friendlyName) {
             this.friendlyName = friendlyName;
             min = 1;
             max = 1000;
@@ -83,26 +70,20 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class InputTextAttribute : Attribute
-    {
+    public class InputTextAttribute : Attribute {
         public string friendlyName;
         public uint maxLength;
 
-        public InputTextAttribute(string friendlyName)
-        {
+        public InputTextAttribute(string friendlyName) {
             this.friendlyName = friendlyName;
             maxLength = 999;
         }
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class ColorEdit4Attribute : Attribute
-    {
+    public class ColorEdit4Attribute : Attribute {
         public string friendlyName;
 
-        public ColorEdit4Attribute(string friendlyName)
-        {
-            this.friendlyName = friendlyName;
-        }
+        public ColorEdit4Attribute(string friendlyName) { this.friendlyName = friendlyName; }
     }
 }

--- a/DelvUI/Config/Attributes/SectionAttributes.cs
+++ b/DelvUI/Config/Attributes/SectionAttributes.cs
@@ -1,26 +1,19 @@
 ﻿using System;
 
-namespace DelvUI.Config.Attributes
-{
+namespace DelvUI.Config.Attributes {
     [AttributeUsage(AttributeTargets.Class)]
-    public class SectionAttribute : Attribute
-    {
+    public class SectionAttribute : Attribute {
         public string SectionName;
 
-        public SectionAttribute(string name)
-        {
-            SectionName = name;
-        }
+        public SectionAttribute(string name) { SectionName = name; }
     }
-    
+
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class SubSectionAttribute : Attribute
-    {
+    public class SubSectionAttribute : Attribute {
         public string SubSectionName;
         public int Depth;
 
-        public SubSectionAttribute(string subSectionName, int depth)
-        {
+        public SubSectionAttribute(string subSectionName, int depth) {
             SubSectionName = subSectionName;
             Depth = depth;
         }

--- a/DelvUI/Config/Attributes/SectionAttributes.cs
+++ b/DelvUI/Config/Attributes/SectionAttributes.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace DelvUI.Config.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class SectionAttribute : Attribute
+    {
+        public string SectionName;
+
+        public SectionAttribute(string name)
+        {
+            SectionName = name;
+        }
+    }
+    
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class SubSectionAttribute : Attribute
+    {
+        public string SubSectionName;
+        public int Depth;
+
+        public SubSectionAttribute(string subSectionName, int depth)
+        {
+            SubSectionName = subSectionName;
+            Depth = depth;
+        }
+    }
+}

--- a/DelvUI/Config/Attributes/SectionAttributes.cs
+++ b/DelvUI/Config/Attributes/SectionAttributes.cs
@@ -1,19 +1,23 @@
 ﻿using System;
 
-namespace DelvUI.Config.Attributes {
+namespace DelvUI.Config.Attributes
+{
     [AttributeUsage(AttributeTargets.Class)]
-    public class SectionAttribute : Attribute {
+    public class SectionAttribute : Attribute
+    {
         public string SectionName;
 
         public SectionAttribute(string name) { SectionName = name; }
     }
 
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class SubSectionAttribute : Attribute {
+    public class SubSectionAttribute : Attribute
+    {
         public string SubSectionName;
         public int Depth;
 
-        public SubSectionAttribute(string subSectionName, int depth) {
+        public SubSectionAttribute(string subSectionName, int depth)
+        {
             SubSectionName = subSectionName;
             Depth = depth;
         }

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -8,7 +8,7 @@ using DelvUI.Interface;
 using ImGuiScene;
 
 namespace DelvUI.Config {
-    public class ConfigurationManager : IDisposable {
+    public class ConfigurationManager {
         private static ConfigurationManager _instance;
 
         public TextureWrap BannerImage;
@@ -16,7 +16,6 @@ namespace DelvUI.Config {
         public string ConfigDirectory;
 
         public BaseNode ConfigBaseNode;
-
         public bool DrawConfigWindow;
 
         public ConfigurationManager(TextureWrap bannerImage, string configDirectory, BaseNode configBaseNode) {
@@ -25,19 +24,6 @@ namespace DelvUI.Config {
             ConfigBaseNode = configBaseNode;
             _instance = this;
             LoadConfigurations();
-        }
-
-        public void Dispose() {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        public virtual void Dispose(bool disposing) {
-            if (!disposing) {
-                return;
-            }
-
-            _instance = null;
         }
 
         public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface) {

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -7,10 +7,8 @@ using DelvUI.Config.Tree;
 using DelvUI.Interface;
 using ImGuiScene;
 
-namespace DelvUI.Config
-{
-    public class ConfigurationManager : IDisposable
-    {
+namespace DelvUI.Config {
+    public class ConfigurationManager : IDisposable {
         private static ConfigurationManager _instance;
 
         public TextureWrap BannerImage;
@@ -21,8 +19,7 @@ namespace DelvUI.Config
 
         public bool DrawConfigWindow;
 
-        public ConfigurationManager(TextureWrap bannerImage, string configDirectory, BaseNode configBaseNode)
-        {
+        public ConfigurationManager(TextureWrap bannerImage, string configDirectory, BaseNode configBaseNode) {
             BannerImage = bannerImage;
             ConfigDirectory = configDirectory;
             ConfigBaseNode = configBaseNode;
@@ -30,14 +27,12 @@ namespace DelvUI.Config
             LoadConfigurations();
         }
 
-        public void Dispose()
-        {
+        public void Dispose() {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        public virtual void Dispose(bool disposing)
-        {
+        public virtual void Dispose(bool disposing) {
             if (!disposing) {
                 return;
             }
@@ -45,30 +40,27 @@ namespace DelvUI.Config
             _instance = null;
         }
 
-        public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface)
-        {
+        public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface) {
             BlackMageHudConfig blmConfig = new BlackMageHudConfig();
+
             return Initialize(pluginInterface, blmConfig);
         }
 
-        public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface, params PluginConfigObject[] configObjects)
-        {
+        public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface, params PluginConfigObject[] configObjects) {
             var node = new BaseNode();
-            foreach (var configObject in configObjects)
-            {
+
+            foreach (var configObject in configObjects) {
                 node.GetOrAddConfig(configObject);
             }
+
             var banner = BuildBanner(pluginInterface);
+
             return new ConfigurationManager(banner, pluginInterface.GetPluginConfigDirectory(), node);
         }
 
-        public static ConfigurationManager GetInstance()
-        {
-            return _instance;
-        }
+        public static ConfigurationManager GetInstance() { return _instance; }
 
-        private static TextureWrap BuildBanner(DalamudPluginInterface pluginInterface)
-        {
+        private static TextureWrap BuildBanner(DalamudPluginInterface pluginInterface) {
             // var bannerImage = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "Media", "Images", "banner_short_x150.png");
             //
             // if (File.Exists(bannerImage)) {
@@ -85,26 +77,16 @@ namespace DelvUI.Config
             return null;
         }
 
-        public void Draw()
-        {
+        public void Draw() {
             if (DrawConfigWindow) {
                 ConfigBaseNode.Draw();
             }
         }
 
-        public void LoadConfigurations()
-        {
-            ConfigBaseNode.Load(ConfigDirectory);
-        }
+        public void LoadConfigurations() { ConfigBaseNode.Load(ConfigDirectory); }
 
-        public void SaveConfigurations()
-        {
-            ConfigBaseNode.Save(ConfigDirectory);
-        }
+        public void SaveConfigurations() { ConfigBaseNode.Save(ConfigDirectory); }
 
-        public PluginConfigObject GetConfiguration(PluginConfigObject configObject)
-        {
-            return ConfigBaseNode.GetOrAddConfig(configObject).ConfigObject;
-        }
+        public PluginConfigObject GetConfiguration(PluginConfigObject configObject) { return ConfigBaseNode.GetOrAddConfig(configObject).ConfigObject; }
     }
 }

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Dalamud.Plugin;
+using DelvUI.Config.Tree;
+using DelvUI.Interface;
+using ImGuiScene;
+
+namespace DelvUI.Config
+{
+    public class ConfigurationManager : IDisposable
+    {
+        private static ConfigurationManager _instance;
+
+        public TextureWrap BannerImage;
+
+        public string ConfigDirectory;
+
+        public BaseNode ConfigBaseNode;
+
+        public bool DrawConfigWindow;
+
+        public ConfigurationManager(TextureWrap bannerImage, string configDirectory, BaseNode configBaseNode)
+        {
+            BannerImage = bannerImage;
+            ConfigDirectory = configDirectory;
+            ConfigBaseNode = configBaseNode;
+            _instance = this;
+            LoadConfigurations();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public virtual void Dispose(bool disposing)
+        {
+            if (!disposing) {
+                return;
+            }
+
+            _instance = null;
+        }
+
+        public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface)
+        {
+            BlackMageHudConfig blmConfig = new BlackMageHudConfig();
+            return Initialize(pluginInterface, blmConfig);
+        }
+
+        public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface, params PluginConfigObject[] configObjects)
+        {
+            var node = new BaseNode();
+            foreach (var configObject in configObjects)
+            {
+                node.GetOrAddConfig(configObject);
+            }
+            var banner = BuildBanner(pluginInterface);
+            return new ConfigurationManager(banner, pluginInterface.GetPluginConfigDirectory(), node);
+        }
+
+        public static ConfigurationManager GetInstance()
+        {
+            return _instance;
+        }
+
+        private static TextureWrap BuildBanner(DalamudPluginInterface pluginInterface)
+        {
+            // var bannerImage = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "Media", "Images", "banner_short_x150.png");
+            //
+            // if (File.Exists(bannerImage)) {
+            //     try {
+            //         return pluginInterface.UiBuilder.LoadImage(bannerImage);
+            //     } catch (Exception ex) {
+            //         PluginLog.Log($"Image failed to load. {bannerImage}");
+            //         PluginLog.Log(ex.ToString());
+            //     }
+            // } else {
+            //     PluginLog.Log($"Image doesn't exist. {bannerImage}");
+            // }
+
+            return null;
+        }
+
+        public void Draw()
+        {
+            if (DrawConfigWindow)
+                ConfigBaseNode.Draw();
+        }
+
+        public void LoadConfigurations()
+        {
+            ConfigBaseNode.Load(ConfigDirectory);
+        }
+
+        public void SaveConfigurations()
+        {
+            ConfigBaseNode.Save(ConfigDirectory);
+        }
+
+        public PluginConfigObject GetConfiguration(PluginConfigObject configObject)
+        {
+            return ConfigBaseNode.GetOrAddConfig(configObject).ConfigObject;
+        }
+    }
+}

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -87,8 +87,9 @@ namespace DelvUI.Config
 
         public void Draw()
         {
-            if (DrawConfigWindow)
+            if (DrawConfigWindow) {
                 ConfigBaseNode.Draw();
+            }
         }
 
         public void LoadConfigurations()

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using Dalamud.Plugin;
+﻿using Dalamud.Plugin;
 using DelvUI.Config.Tree;
 using DelvUI.Interface;
 using ImGuiScene;
 
-namespace DelvUI.Config {
-    public class ConfigurationManager {
+namespace DelvUI.Config
+{
+    public class ConfigurationManager
+    {
         private static ConfigurationManager _instance;
 
         public TextureWrap BannerImage;
@@ -18,7 +16,8 @@ namespace DelvUI.Config {
         public BaseNode ConfigBaseNode;
         public bool DrawConfigWindow;
 
-        public ConfigurationManager(TextureWrap bannerImage, string configDirectory, BaseNode configBaseNode) {
+        public ConfigurationManager(TextureWrap bannerImage, string configDirectory, BaseNode configBaseNode)
+        {
             BannerImage = bannerImage;
             ConfigDirectory = configDirectory;
             ConfigBaseNode = configBaseNode;
@@ -26,16 +25,19 @@ namespace DelvUI.Config {
             LoadConfigurations();
         }
 
-        public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface) {
+        public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface)
+        {
             BlackMageHudConfig blmConfig = new BlackMageHudConfig();
 
             return Initialize(pluginInterface, blmConfig);
         }
 
-        public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface, params PluginConfigObject[] configObjects) {
+        public static ConfigurationManager Initialize(DalamudPluginInterface pluginInterface, params PluginConfigObject[] configObjects)
+        {
             var node = new BaseNode();
 
-            foreach (var configObject in configObjects) {
+            foreach (var configObject in configObjects)
+            {
                 node.GetOrAddConfig(configObject);
             }
 
@@ -46,7 +48,8 @@ namespace DelvUI.Config {
 
         public static ConfigurationManager GetInstance() { return _instance; }
 
-        private static TextureWrap BuildBanner(DalamudPluginInterface pluginInterface) {
+        private static TextureWrap BuildBanner(DalamudPluginInterface pluginInterface)
+        {
             // var bannerImage = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "Media", "Images", "banner_short_x150.png");
             //
             // if (File.Exists(bannerImage)) {
@@ -63,8 +66,10 @@ namespace DelvUI.Config {
             return null;
         }
 
-        public void Draw() {
-            if (DrawConfigWindow) {
+        public void Draw()
+        {
+            if (DrawConfigWindow)
+            {
                 ConfigBaseNode.Draw();
             }
         }

--- a/DelvUI/Config/ConfigurationWindow.cs
+++ b/DelvUI/Config/ConfigurationWindow.cs
@@ -5472,11 +5472,11 @@ namespace DelvUI.Config
                     ImGui.EndTabItem();
                 }
 
-                if (ImGui.BeginTabItem("Black Mage"))
-                {
-                    _changed |= _pluginConfiguration.BLMConfig.Draw();
-                    ImGui.EndTabItem();
-                }
+                // if (ImGui.BeginTabItem("Black Mage"))
+                // {
+                //     _changed |= _pluginConfiguration.BLMConfig.Draw();
+                //     ImGui.EndTabItem();
+                // }
             }
 
             ImGui.EndTabBar();

--- a/DelvUI/Config/ConfigurationWindow.cs
+++ b/DelvUI/Config/ConfigurationWindow.cs
@@ -9,12 +9,12 @@ namespace DelvUI.Config
 {
     public class ConfigurationWindow
     {
-        private readonly string[] _configColorMap = { "Tanks", "Healers", "Melee", "Ranged", "Casters", "NPC" };
+        private readonly string[] _configColorMap = {"Tanks", "Healers", "Melee", "Ranged", "Casters", "NPC"};
         private readonly Dictionary<string, Array> _configMap = new();
         private readonly PluginConfiguration _pluginConfiguration;
         private readonly DalamudPluginInterface _pluginInterface;
-        private readonly int _viewportHeight = (int)ImGui.GetMainViewport().Size.Y;
-        private readonly int _viewportWidth = (int)ImGui.GetMainViewport().Size.X;
+        private readonly int _viewportHeight = (int) ImGui.GetMainViewport().Size.Y;
+        private readonly int _viewportWidth = (int) ImGui.GetMainViewport().Size.X;
         private bool _changed;
         private string _exportString = "";
         private string _importString = "";
@@ -30,26 +30,26 @@ namespace DelvUI.Config
 
             _pluginConfiguration = pluginConfiguration;
             _pluginInterface = pluginInterface;
-            _configMap.Add("General", new[] { "General" });
+            _configMap.Add("General", new[] {"General"});
 
             _configMap.Add(
                 "Individual Unitframes",
-                new[] { "General", "Player", "Focus", "Target", "Target of Target" }
+                new[] {"General", "Player", "Focus", "Target", "Target of Target"}
             );
 
             //configMap.Add("Group Unitframes", new [] {"General", "Party", "8man", "24man", "Enemies"});
             _configMap.Add(
                 "Castbars",
-                new[] { "Player", "Target" }
+                new[] {"Player", "Target"}
             );
 
             _configMap.Add(
                 "Buffs and Debuffs",
-                new[] { "Player Buffs", "Player Debuffs", "Target Buffs", "Target Debuffs", "Raid/Job Buffs" }
+                new[] {"Player Buffs", "Player Debuffs", "Target Buffs", "Target Debuffs", "Raid/Job Buffs"}
             );
 
-            _configMap.Add("Job Specific Bars", new[] { "General", "Tank", "Healer", "Melee", "Ranged", "Caster" });
-            _configMap.Add("Import/Export", new[] { "General" });
+            _configMap.Add("Job Specific Bars", new[] {"General", "Tank", "Healer", "Melee", "Ranged", "Caster"});
+            _configMap.Add("Import/Export", new[] {"General"});
         }
 
         public void ToggleHud()
@@ -328,8 +328,10 @@ namespace DelvUI.Config
                             _changed |= _pluginConfiguration.TargetDebuffListConfig.Draw();
 
                             break;
+
                         case "Raid/Job Buffs":
                             DrawRaidJobBuffsConfig();
+
                             break;
                     }
 

--- a/DelvUI/Config/ConfigurationWindow.cs
+++ b/DelvUI/Config/ConfigurationWindow.cs
@@ -9,12 +9,12 @@ namespace DelvUI.Config
 {
     public class ConfigurationWindow
     {
-        private readonly string[] _configColorMap = {"Tanks", "Healers", "Melee", "Ranged", "Casters", "NPC"};
+        private readonly string[] _configColorMap = { "Tanks", "Healers", "Melee", "Ranged", "Casters", "NPC" };
         private readonly Dictionary<string, Array> _configMap = new();
         private readonly PluginConfiguration _pluginConfiguration;
         private readonly DalamudPluginInterface _pluginInterface;
-        private readonly int _viewportHeight = (int) ImGui.GetMainViewport().Size.Y;
-        private readonly int _viewportWidth = (int) ImGui.GetMainViewport().Size.X;
+        private readonly int _viewportHeight = (int)ImGui.GetMainViewport().Size.Y;
+        private readonly int _viewportWidth = (int)ImGui.GetMainViewport().Size.X;
         private bool _changed;
         private string _exportString = "";
         private string _importString = "";
@@ -30,26 +30,26 @@ namespace DelvUI.Config
 
             _pluginConfiguration = pluginConfiguration;
             _pluginInterface = pluginInterface;
-            _configMap.Add("General", new[] {"General"});
+            _configMap.Add("General", new[] { "General" });
 
             _configMap.Add(
                 "Individual Unitframes",
-                new[] {"General", "Player", "Focus", "Target", "Target of Target"}
+                new[] { "General", "Player", "Focus", "Target", "Target of Target" }
             );
 
             //configMap.Add("Group Unitframes", new [] {"General", "Party", "8man", "24man", "Enemies"});
             _configMap.Add(
                 "Castbars",
-                new[] {"Player", "Target"}
+                new[] { "Player", "Target" }
             );
 
             _configMap.Add(
                 "Buffs and Debuffs",
-                new[] {"Player Buffs", "Player Debuffs", "Target Buffs", "Target Debuffs", "Raid/Job Buffs"}
+                new[] { "Player Buffs", "Player Debuffs", "Target Buffs", "Target Debuffs", "Raid/Job Buffs" }
             );
 
-            _configMap.Add("Job Specific Bars", new[] {"General", "Tank", "Healer", "Melee", "Ranged", "Caster"});
-            _configMap.Add("Import/Export", new[] {"General"});
+            _configMap.Add("Job Specific Bars", new[] { "General", "Tank", "Healer", "Melee", "Ranged", "Caster" });
+            _configMap.Add("Import/Export", new[] { "General" });
         }
 
         public void ToggleHud()

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -15,14 +15,16 @@ namespace DelvUI.Config.Tree
 
         public virtual void Save(string path)
         {
-            foreach (var child in children)
+            foreach (var child in children) {
                 child.Save(ConfigurationManager.GetInstance().ConfigDirectory);
+            }
         }
 
         public virtual void Load(string path)
         {
-            foreach (var child in children)
+            foreach (var child in children) {
                 child.Load(ConfigurationManager.GetInstance().ConfigDirectory);
+            }
         }
     }
 
@@ -42,16 +44,19 @@ namespace DelvUI.Config.Tree
             ImGui.SetNextWindowSize(new Vector2(1050, 750), ImGuiCond.Appearing);
 
 
-            if (!ImGui.Begin("titlebarnew", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollWithMouse))
+            if (!ImGui.Begin("titlebarnew", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollWithMouse)) {
                 return;
-            
+            }
+
             ImGui.BeginGroup(); // Middle section
             {
                 ImGui.BeginGroup(); // Left
                 {
                     var delvUiBanner = ConfigurationManager.GetInstance().BannerImage;
-                    if (delvUiBanner != null)
+                    if (delvUiBanner != null) {
                         ImGui.Image(delvUiBanner.ImGuiHandle, new Vector2(delvUiBanner.Width, delvUiBanner.Height));
+                    }
+
                     ImGui.BeginChild("left pane", new Vector2(150, -ImGui.GetFrameHeightWithSpacing()), true);
                     
                     foreach (var selectionNode in children)
@@ -59,8 +64,9 @@ namespace DelvUI.Config.Tree
                         if (ImGui.Selectable(selectionNode.Name, selectionNode.Selected))
                         {
                             selectionNode.Selected = true;
-                            foreach (var otherNode in children.FindAll(x => x != selectionNode))
+                            foreach (var otherNode in children.FindAll(x => x != selectionNode)) {
                                 otherNode.Selected = false;
+                            }
                         }
                     }
                     
@@ -123,14 +129,16 @@ namespace DelvUI.Config.Tree
 
         public override void Load(string path)
         {
-            foreach (var child in children)
+            foreach (var child in children) {
                 child.Load(path);
+            }
         }
 
         public override void Save(string path)
         {
-            foreach (var child in children)
+            foreach (var child in children) {
                 child.Save(path);
+            }
         }
 
         public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
@@ -173,8 +181,9 @@ namespace DelvUI.Config.Tree
 
         public void Draw(ref bool changed)
         {
-            if (!Selected)
+            if (!Selected) {
                 return;
+            }
 
             ImGui.BeginChild("item view",new Vector2(0, -ImGui.GetFrameHeightWithSpacing())); // Leave room for 1 line below us
             {
@@ -182,7 +191,10 @@ namespace DelvUI.Config.Tree
                 {
                     foreach (var subSectionNode in children)
                     {
-                        if (!ImGui.BeginTabItem(subSectionNode.Name)) continue;
+                        if (!ImGui.BeginTabItem(subSectionNode.Name)) {
+                            continue;
+                        }
+
                         ImGui.BeginChild("subconfig value", new Vector2(0, 0), true);
                         subSectionNode.Draw(ref changed);
                         ImGui.EndChild();
@@ -271,7 +283,10 @@ namespace DelvUI.Config.Tree
                     {
                         if (subSectionNode is NestedSubSectionNode)
                         {
-                            if (!ImGui.BeginTabItem(subSectionNode.Name)) continue;
+                            if (!ImGui.BeginTabItem(subSectionNode.Name)) {
+                                continue;
+                            }
+
                             ImGui.BeginChild("subconfig" + Depth + " value", new Vector2(0, 0), true);
                             subSectionNode.Draw(ref changed);
                             ImGui.EndChild();
@@ -311,9 +326,10 @@ namespace DelvUI.Config.Tree
             {
                 if (attribute is SubSectionAttribute subSectionAttribute)
                 {
-                    if (subSectionAttribute.Depth != Depth + 1)
+                    if (subSectionAttribute.Depth != Depth + 1) {
                         continue;
-                    
+                    }
+
                     foreach (var subSectionNode in children)
                     {
                         if (subSectionNode.Name == subSectionAttribute.SubSectionName)
@@ -332,8 +348,9 @@ namespace DelvUI.Config.Tree
             
             foreach (var subSectionNode in children)
             {
-                if (subSectionNode.Name == configObject.GetType().FullName && subSectionNode is ConfigPageNode node)
+                if (subSectionNode.Name == configObject.GetType().FullName && subSectionNode is ConfigPageNode node) {
                     return node;
+                }
             }
             ConfigPageNode configPageNode = new ConfigPageNode();
             configPageNode.ConfigObject = configObject;

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -7,151 +7,130 @@ using DelvUI.Config.Attributes;
 using ImGuiNET;
 using Newtonsoft.Json;
 
-namespace DelvUI.Config.Tree
-{
-    public abstract class Node
-    {
+namespace DelvUI.Config.Tree {
+    public abstract class Node {
         public List<Node> children;
 
-        public virtual void Save(string path)
-        {
+        public virtual void Save(string path) {
             foreach (var child in children) {
                 child.Save(ConfigurationManager.GetInstance().ConfigDirectory);
             }
         }
 
-        public virtual void Load(string path)
-        {
+        public virtual void Load(string path) {
             foreach (var child in children) {
                 child.Load(ConfigurationManager.GetInstance().ConfigDirectory);
             }
         }
     }
 
-    public class BaseNode : Node
-    {
+    public class BaseNode : Node {
         public new List<SectionNode> children;
 
-        public BaseNode()
-        {
-            children = new List<SectionNode>();
-        }
+        public BaseNode() { children = new List<SectionNode>(); }
 
-        public void Draw()
-        {
+        public void Draw() {
             var changed = false;
-            
-            ImGui.SetNextWindowSize(new Vector2(1050, 750), ImGuiCond.Appearing);
 
+            ImGui.SetNextWindowSize(new Vector2(1050, 750), ImGuiCond.Appearing);
 
             if (!ImGui.Begin("titlebarnew", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollWithMouse)) {
                 return;
             }
 
             ImGui.BeginGroup(); // Middle section
+
             {
                 ImGui.BeginGroup(); // Left
+
                 {
                     var delvUiBanner = ConfigurationManager.GetInstance().BannerImage;
+
                     if (delvUiBanner != null) {
                         ImGui.Image(delvUiBanner.ImGuiHandle, new Vector2(delvUiBanner.Width, delvUiBanner.Height));
                     }
 
                     ImGui.BeginChild("left pane", new Vector2(150, -ImGui.GetFrameHeightWithSpacing()), true);
-                    
-                    foreach (var selectionNode in children)
-                    {
-                        if (ImGui.Selectable(selectionNode.Name, selectionNode.Selected))
-                        {
+
+                    foreach (var selectionNode in children) {
+                        if (ImGui.Selectable(selectionNode.Name, selectionNode.Selected)) {
                             selectionNode.Selected = true;
+
                             foreach (var otherNode in children.FindAll(x => x != selectionNode)) {
                                 otherNode.Selected = false;
                             }
                         }
                     }
-                    
+
                     ImGui.EndChild();
                 }
+
                 ImGui.EndGroup(); // Left
-                
+
                 ImGui.SameLine();
-                
+
                 ImGui.BeginGroup(); // Right
+
                 {
-                    foreach (var selectionNode in children)
-                    {
+                    foreach (var selectionNode in children) {
                         selectionNode.Draw(ref changed);
                     }
                 }
+
                 ImGui.EndGroup(); // Right
             }
+
             ImGui.EndGroup(); // Middle section
-            
+
             ImGui.Separator();
-            
+
             ImGui.BeginGroup(); // Bottom Bar
+
             {
                 if (ImGui.Button("Lock HUD")) // TODO: Functioning buttons
-                {
-                    
-                }
-                
+                { }
+
                 ImGui.SameLine();
 
-                if (ImGui.Button("Hide/Show HUD"))
-                {
-                    
-                }
-                
+                if (ImGui.Button("Hide/Show HUD")) { }
+
                 ImGui.SameLine();
 
-                if (ImGui.Button("Reset HUD"))
-                {
-                    
-                }
-                
+                if (ImGui.Button("Reset HUD")) { }
+
                 ImGui.SameLine();
 
-                if (ImGui.Button("Donate!"))
-                {
-                    
-                }
+                if (ImGui.Button("Donate!")) { }
             }
+
             ImGui.EndGroup(); // Bottom Bar
-            
+
             ImGui.End();
 
-            if (changed)
-            {
+            if (changed) {
                 ConfigurationManager.GetInstance().SaveConfigurations();
             }
         }
 
-        public override void Load(string path)
-        {
+        public override void Load(string path) {
             foreach (var child in children) {
                 child.Load(path);
             }
         }
 
-        public override void Save(string path)
-        {
+        public override void Save(string path) {
             foreach (var child in children) {
                 child.Save(path);
             }
         }
 
-        public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
-        {
+        public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject) {
             var attributes = configObject.GetType().GetCustomAttributes(false);
-            foreach (var attribute in attributes)
-            {
-                if (attribute is SectionAttribute sectionAttribute)
-                {
-                    foreach (var sectionNode in children)
-                    {
-                        if (sectionNode.Name == sectionAttribute.SectionName)
-                        {
+
+            foreach (var attribute in attributes) {
+                if (attribute is SectionAttribute sectionAttribute) {
+                    foreach (var sectionNode in children) {
+                        if (sectionNode.Name == sectionAttribute.SectionName) {
                             return sectionNode.GetOrAddConfig(configObject);
                         }
                     }
@@ -159,6 +138,7 @@ namespace DelvUI.Config.Tree
                     SectionNode newNode = new SectionNode();
                     newNode.Name = sectionAttribute.SectionName;
                     children.Add(newNode);
+
                     return newNode.GetOrAddConfig(configObject);
                 }
             }
@@ -167,30 +147,24 @@ namespace DelvUI.Config.Tree
         }
     }
 
-    public class SectionNode : Node
-    {
+    public class SectionNode : Node {
         public new List<SubSectionNode> children;
-        
+
         public bool Selected;
         public string Name;
 
-        public SectionNode()
-        {
-            children = new List<SubSectionNode>();
-        }
+        public SectionNode() { children = new List<SubSectionNode>(); }
 
-        public void Draw(ref bool changed)
-        {
+        public void Draw(ref bool changed) {
             if (!Selected) {
                 return;
             }
 
-            ImGui.BeginChild("item view",new Vector2(0, -ImGui.GetFrameHeightWithSpacing())); // Leave room for 1 line below us
+            ImGui.BeginChild("item view", new Vector2(0, -ImGui.GetFrameHeightWithSpacing())); // Leave room for 1 line below us
+
             {
-                if (ImGui.BeginTabBar("##Tabs", ImGuiTabBarFlags.None))
-                {
-                    foreach (var subSectionNode in children)
-                    {
+                if (ImGui.BeginTabBar("##Tabs", ImGuiTabBarFlags.None)) {
+                    foreach (var subSectionNode in children) {
                         if (!ImGui.BeginTabItem(subSectionNode.Name)) {
                             continue;
                         }
@@ -200,51 +174,45 @@ namespace DelvUI.Config.Tree
                         ImGui.EndChild();
                         ImGui.EndTabItem();
                     }
-                    ImGui.EndTabBar(); 
-                    
+
+                    ImGui.EndTabBar();
+
                     // TODO: Close Button - Maybe better suited elsewhere
                 }
             }
+
             ImGui.EndChild();
         }
 
-        public override void Save(string path)
-        {
-            foreach (var child in children)
-            {
+        public override void Save(string path) {
+            foreach (var child in children) {
                 child.Save(Path.Combine(path, Name));
             }
         }
 
-        public override void Load(string path)
-        {
-            foreach (var child in children)
-            {
+        public override void Load(string path) {
+            foreach (var child in children) {
                 child.Load(Path.Combine(path, Name));
             }
         }
 
-        public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
-        {
+        public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject) {
             var attributes = configObject.GetType().GetCustomAttributes(false);
-            foreach (var attribute in attributes)
-            {
-                if (attribute is SubSectionAttribute subSectionAttribute)
-                {
-                    foreach (var subSectionNode in children)
-                    {
-                        if (subSectionNode.Name == subSectionAttribute.SubSectionName)
-                        {
+
+            foreach (var attribute in attributes) {
+                if (attribute is SubSectionAttribute subSectionAttribute) {
+                    foreach (var subSectionNode in children) {
+                        if (subSectionNode.Name == subSectionAttribute.SubSectionName) {
                             return subSectionNode.GetOrAddConfig(configObject);
                         }
                     }
 
-                    if (subSectionAttribute.Depth == 0)
-                    {
+                    if (subSectionAttribute.Depth == 0) {
                         NestedSubSectionNode newNode = new NestedSubSectionNode();
                         newNode.Name = subSectionAttribute.SubSectionName;
                         newNode.Depth = 0;
                         children.Add(newNode);
+
                         return newNode.GetOrAddConfig(configObject);
                     }
                 }
@@ -254,8 +222,7 @@ namespace DelvUI.Config.Tree
         }
     }
 
-    public abstract class SubSectionNode : Node
-    {
+    public abstract class SubSectionNode : Node {
         public string Name;
         public int Depth;
 
@@ -264,25 +231,18 @@ namespace DelvUI.Config.Tree
         public abstract ConfigPageNode GetOrAddConfig(PluginConfigObject configObject);
     }
 
-    public class NestedSubSectionNode : SubSectionNode
-    {
+    public class NestedSubSectionNode : SubSectionNode {
         public new List<SubSectionNode> children;
 
-        public NestedSubSectionNode()
-        {
-            children = new List<SubSectionNode>();
-        }
+        public NestedSubSectionNode() { children = new List<SubSectionNode>(); }
 
-        public override void Draw(ref bool changed)
-        {
-            ImGui.BeginChild("item" + Depth + " view",new Vector2(0, -ImGui.GetFrameHeightWithSpacing())); // Leave room for 1 line below us
+        public override void Draw(ref bool changed) {
+            ImGui.BeginChild("item" + Depth + " view", new Vector2(0, -ImGui.GetFrameHeightWithSpacing())); // Leave room for 1 line below us
+
             {
-                if (ImGui.BeginTabBar("##tabs" + Depth, ImGuiTabBarFlags.None))
-                {
-                    foreach (var subSectionNode in children)
-                    {
-                        if (subSectionNode is NestedSubSectionNode)
-                        {
+                if (ImGui.BeginTabBar("##tabs" + Depth, ImGuiTabBarFlags.None)) {
+                    foreach (var subSectionNode in children) {
+                        if (subSectionNode is NestedSubSectionNode) {
                             if (!ImGui.BeginTabItem(subSectionNode.Name)) {
                                 continue;
                             }
@@ -292,48 +252,41 @@ namespace DelvUI.Config.Tree
                             ImGui.EndChild();
                             ImGui.EndTabItem();
                         }
-                        else
-                        {
+                        else {
                             subSectionNode.Draw(ref changed);
                         }
                     }
-                    ImGui.EndTabBar(); 
+
+                    ImGui.EndTabBar();
                 }
             }
+
             ImGui.EndChild();
         }
-        
-        public override void Save(string path)
-        {
-            foreach (var child in children)
-            {
+
+        public override void Save(string path) {
+            foreach (var child in children) {
                 child.Save(Path.Combine(path, Name));
             }
         }
 
-        public override void Load(string path)
-        {
-            foreach (var child in children)
-            {
+        public override void Load(string path) {
+            foreach (var child in children) {
                 child.Load(Path.Combine(path, Name));
             }
         }
-        
-        public override ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
-        {
+
+        public override ConfigPageNode GetOrAddConfig(PluginConfigObject configObject) {
             var attributes = configObject.GetType().GetCustomAttributes(false);
-            foreach (var attribute in attributes)
-            {
-                if (attribute is SubSectionAttribute subSectionAttribute)
-                {
+
+            foreach (var attribute in attributes) {
+                if (attribute is SubSectionAttribute subSectionAttribute) {
                     if (subSectionAttribute.Depth != Depth + 1) {
                         continue;
                     }
 
-                    foreach (var subSectionNode in children)
-                    {
-                        if (subSectionNode.Name == subSectionAttribute.SubSectionName)
-                        {
+                    foreach (var subSectionNode in children) {
+                        if (subSectionNode.Name == subSectionAttribute.SubSectionName) {
                             return subSectionNode.GetOrAddConfig(configObject);
                         }
                     }
@@ -342,94 +295,87 @@ namespace DelvUI.Config.Tree
                     nestedSubSectionNode.Name = subSectionAttribute.SubSectionName;
                     nestedSubSectionNode.Depth = Depth + 1;
                     children.Add(nestedSubSectionNode);
+
                     return nestedSubSectionNode.GetOrAddConfig(configObject);
                 }
             }
-            
-            foreach (var subSectionNode in children)
-            {
+
+            foreach (var subSectionNode in children) {
                 if (subSectionNode.Name == configObject.GetType().FullName && subSectionNode is ConfigPageNode node) {
                     return node;
                 }
             }
+
             ConfigPageNode configPageNode = new ConfigPageNode();
             configPageNode.ConfigObject = configObject;
             configPageNode.Name = configObject.GetType().FullName;
             children.Add(configPageNode);
+
             return configPageNode;
         }
     }
 
-    public class ConfigPageNode : SubSectionNode
-    {
+    public class ConfigPageNode : SubSectionNode {
         public PluginConfigObject ConfigObject;
 
-        public override void Draw(ref bool changed)
-        {
+        public override void Draw(ref bool changed) {
             var fields = ConfigObject.GetType().GetFields();
-            foreach (var field in fields)
-            {
+
+            foreach (var field in fields) {
                 object fieldVal = field.GetValue(ConfigObject);
-                foreach (var attribute in field.GetCustomAttributes(true))
-                {
-                    if (attribute is CheckboxAttribute checkboxAttribute)
-                    {
+
+                foreach (var attribute in field.GetCustomAttributes(true)) {
+                    if (attribute is CheckboxAttribute checkboxAttribute) {
                         bool boolVal = (bool) fieldVal;
-                        if (ImGui.Checkbox(checkboxAttribute.friendlyName, ref boolVal))
-                        {
+
+                        if (ImGui.Checkbox(checkboxAttribute.friendlyName, ref boolVal)) {
                             field.SetValue(ConfigObject, boolVal);
                             changed = true;
                         }
                     }
-                    else if (attribute is DragFloatAttribute dragFloatAttribute)
-                    {
+                    else if (attribute is DragFloatAttribute dragFloatAttribute) {
                         float floatVal = (float) fieldVal;
-                        if (ImGui.DragFloat(dragFloatAttribute.friendlyName, ref floatVal, dragFloatAttribute.velocity, dragFloatAttribute.min, dragFloatAttribute.max))
-                        {
+
+                        if (ImGui.DragFloat(dragFloatAttribute.friendlyName, ref floatVal, dragFloatAttribute.velocity, dragFloatAttribute.min, dragFloatAttribute.max)) {
                             field.SetValue(ConfigObject, floatVal);
                             changed = true;
                         }
                     }
-                    else if (attribute is DragIntAttribute dragIntAttribute)
-                    {
+                    else if (attribute is DragIntAttribute dragIntAttribute) {
                         int intVal = (int) fieldVal;
-                        if (ImGui.DragInt(dragIntAttribute.friendlyName, ref intVal, dragIntAttribute.velocity, dragIntAttribute.min, dragIntAttribute.max))
-                        {
+
+                        if (ImGui.DragInt(dragIntAttribute.friendlyName, ref intVal, dragIntAttribute.velocity, dragIntAttribute.min, dragIntAttribute.max)) {
                             field.SetValue(ConfigObject, intVal);
                             changed = true;
                         }
                     }
-                    else if (attribute is DragFloat2Attribute dragFloat2Attribute)
-                    {
+                    else if (attribute is DragFloat2Attribute dragFloat2Attribute) {
                         Vector2 floatVal = (Vector2) fieldVal;
-                        if (ImGui.DragFloat2(dragFloat2Attribute.friendlyName, ref floatVal, dragFloat2Attribute.velocity, dragFloat2Attribute.min, dragFloat2Attribute.max))
-                        {
+
+                        if (ImGui.DragFloat2(dragFloat2Attribute.friendlyName, ref floatVal, dragFloat2Attribute.velocity, dragFloat2Attribute.min, dragFloat2Attribute.max)) {
                             field.SetValue(ConfigObject, floatVal);
                             changed = true;
                         }
                     }
-                    else if (attribute is DragInt2Attribute dragInt2Attribute)
-                    {
+                    else if (attribute is DragInt2Attribute dragInt2Attribute) {
                         Vector2 intVal = (Vector2) fieldVal;
-                        if (ImGui.DragFloat2(dragInt2Attribute.friendlyName, ref intVal, dragInt2Attribute.velocity, dragInt2Attribute.min, dragInt2Attribute.max))
-                        {
+
+                        if (ImGui.DragFloat2(dragInt2Attribute.friendlyName, ref intVal, dragInt2Attribute.velocity, dragInt2Attribute.min, dragInt2Attribute.max)) {
                             field.SetValue(ConfigObject, intVal);
                         }
                     }
-                    else if (attribute is InputTextAttribute inputTextAttribute)
-                    {
+                    else if (attribute is InputTextAttribute inputTextAttribute) {
                         string stringVal = (string) fieldVal;
-                        if (ImGui.InputText(inputTextAttribute.friendlyName, ref stringVal, inputTextAttribute.maxLength))
-                        {
+
+                        if (ImGui.InputText(inputTextAttribute.friendlyName, ref stringVal, inputTextAttribute.maxLength)) {
                             field.SetValue(ConfigObject, stringVal);
                         }
                     }
-                    else if (attribute is ColorEdit4Attribute colorEdit4Attribute)
-                    {
+                    else if (attribute is ColorEdit4Attribute colorEdit4Attribute) {
                         PluginConfigColor colorVal = (PluginConfigColor) fieldVal;
                         var vector = colorVal.Vector;
-                        if (ImGui.ColorEdit4(colorEdit4Attribute.friendlyName, ref vector))
-                        {
+
+                        if (ImGui.ColorEdit4(colorEdit4Attribute.friendlyName, ref vector)) {
                             colorVal.Vector = vector;
                             field.SetValue(ConfigObject, colorVal);
                         }
@@ -438,31 +384,33 @@ namespace DelvUI.Config.Tree
             }
         }
 
-        public override void Save(string path)
-        {
+        public override void Save(string path) {
             Directory.CreateDirectory(path);
             string finalPath = path + ".json";
-            File.WriteAllText(finalPath, JsonConvert.SerializeObject(ConfigObject, Formatting.Indented, new JsonSerializerSettings
-            {
-                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
-                TypeNameHandling = TypeNameHandling.Objects,
-            }));
+
+            File.WriteAllText(
+                finalPath,
+                JsonConvert.SerializeObject(
+                    ConfigObject,
+                    Formatting.Indented,
+                    new JsonSerializerSettings {TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple, TypeNameHandling = TypeNameHandling.Objects,}
+                )
+            );
         }
 
-        public override void Load(string path)
-        {
+        public override void Load(string path) {
             var finalPath = new FileInfo(path + ".json");
-            var configObject =  !finalPath.Exists ? ConfigObject : JsonConvert.DeserializeObject<PluginConfigObject>(File.ReadAllText(finalPath.FullName), new JsonSerializerSettings
-            {
-                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
-                TypeNameHandling = TypeNameHandling.Objects,
-            });
+
+            var configObject = !finalPath.Exists
+                ? ConfigObject
+                : JsonConvert.DeserializeObject<PluginConfigObject>(
+                    File.ReadAllText(finalPath.FullName),
+                    new JsonSerializerSettings {TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple, TypeNameHandling = TypeNameHandling.Objects,}
+                );
+
             ConfigObject = configObject;
         }
 
-        public override ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
-        {
-            return this;
-        }
+        public override ConfigPageNode GetOrAddConfig(PluginConfigObject configObject) { return this; }
     }
 }

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -362,6 +362,7 @@ namespace DelvUI.Config.Tree {
 
                         if (ImGui.DragFloat2(dragInt2Attribute.friendlyName, ref intVal, dragInt2Attribute.velocity, dragInt2Attribute.min, dragInt2Attribute.max)) {
                             field.SetValue(ConfigObject, intVal);
+                            changed = true;
                         }
                     }
                     else if (attribute is InputTextAttribute inputTextAttribute) {
@@ -369,6 +370,7 @@ namespace DelvUI.Config.Tree {
 
                         if (ImGui.InputText(inputTextAttribute.friendlyName, ref stringVal, inputTextAttribute.maxLength)) {
                             field.SetValue(ConfigObject, stringVal);
+                            changed = true;
                         }
                     }
                     else if (attribute is ColorEdit4Attribute colorEdit4Attribute) {
@@ -378,6 +380,7 @@ namespace DelvUI.Config.Tree {
                         if (ImGui.ColorEdit4(colorEdit4Attribute.friendlyName, ref vector)) {
                             colorVal.Vector = vector;
                             field.SetValue(ConfigObject, colorVal);
+                            changed = true;
                         }
                     }
                 }

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -405,6 +405,10 @@ namespace DelvUI.Config.Tree {
                 return;
             }
 
+            // Use reflection to call the LoadForType method, this allows us to specify a type at runtime.
+            // While in general use this is important as the conversion from the superclass 'PluginConfigObject' to a specific subclass (e.g. 'BlackMageHudConfig') would
+            // be handled by Json.NET, when the plugin is reloaded with a different assembly (as is the case when using LivePluginLoader, or updating the plugin in-game)
+            // it fails. In order to fix this we need to specify the specific subclass, in order to do this during runtime we must use reflection to set the generic.
             if (ConfigObject.GetType().GetInterface(typeof(PluginConfigObject).FullName) != null) {
                 var methodInfo = GetType().GetMethod("LoadForType");
                 var function = methodInfo.MakeGenericMethod(ConfigObject.GetType());

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -1,0 +1,451 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using DelvUI.Config.Attributes;
+using ImGuiNET;
+using Newtonsoft.Json;
+
+namespace DelvUI.Config.Tree
+{
+    public abstract class Node
+    {
+        public List<Node> children;
+
+        public virtual void Save(string path)
+        {
+            foreach (var child in children)
+                child.Save(ConfigurationManager.GetInstance().ConfigDirectory);
+        }
+
+        public virtual void Load(string path)
+        {
+            foreach (var child in children)
+                child.Load(ConfigurationManager.GetInstance().ConfigDirectory);
+        }
+    }
+
+    public class BaseNode : Node
+    {
+        public new List<SectionNode> children;
+
+        public BaseNode()
+        {
+            children = new List<SectionNode>();
+        }
+
+        public void Draw()
+        {
+            var changed = false;
+            
+            ImGui.SetNextWindowSize(new Vector2(1050, 750), ImGuiCond.Appearing);
+
+
+            if (!ImGui.Begin("titlebarnew", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollWithMouse))
+                return;
+            
+            ImGui.BeginGroup(); // Middle section
+            {
+                ImGui.BeginGroup(); // Left
+                {
+                    var delvUiBanner = ConfigurationManager.GetInstance().BannerImage;
+                    if (delvUiBanner != null)
+                        ImGui.Image(delvUiBanner.ImGuiHandle, new Vector2(delvUiBanner.Width, delvUiBanner.Height));
+                    ImGui.BeginChild("left pane", new Vector2(150, -ImGui.GetFrameHeightWithSpacing()), true);
+                    
+                    foreach (var selectionNode in children)
+                    {
+                        if (ImGui.Selectable(selectionNode.Name, selectionNode.Selected))
+                        {
+                            selectionNode.Selected = true;
+                            foreach (var otherNode in children.FindAll(x => x != selectionNode))
+                                otherNode.Selected = false;
+                        }
+                    }
+                    
+                    ImGui.EndChild();
+                }
+                ImGui.EndGroup(); // Left
+                
+                ImGui.SameLine();
+                
+                ImGui.BeginGroup(); // Right
+                {
+                    foreach (var selectionNode in children)
+                    {
+                        selectionNode.Draw(ref changed);
+                    }
+                }
+                ImGui.EndGroup(); // Right
+            }
+            ImGui.EndGroup(); // Middle section
+            
+            ImGui.Separator();
+            
+            ImGui.BeginGroup(); // Bottom Bar
+            {
+                if (ImGui.Button("Lock HUD")) // TODO: Functioning buttons
+                {
+                    
+                }
+                
+                ImGui.SameLine();
+
+                if (ImGui.Button("Hide/Show HUD"))
+                {
+                    
+                }
+                
+                ImGui.SameLine();
+
+                if (ImGui.Button("Reset HUD"))
+                {
+                    
+                }
+                
+                ImGui.SameLine();
+
+                if (ImGui.Button("Donate!"))
+                {
+                    
+                }
+            }
+            ImGui.EndGroup(); // Bottom Bar
+            
+            ImGui.End();
+
+            if (changed)
+            {
+                ConfigurationManager.GetInstance().SaveConfigurations();
+            }
+        }
+
+        public override void Load(string path)
+        {
+            foreach (var child in children)
+                child.Load(path);
+        }
+
+        public override void Save(string path)
+        {
+            foreach (var child in children)
+                child.Save(path);
+        }
+
+        public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
+        {
+            var attributes = configObject.GetType().GetCustomAttributes(false);
+            foreach (var attribute in attributes)
+            {
+                if (attribute is SectionAttribute sectionAttribute)
+                {
+                    foreach (var sectionNode in children)
+                    {
+                        if (sectionNode.Name == sectionAttribute.SectionName)
+                        {
+                            return sectionNode.GetOrAddConfig(configObject);
+                        }
+                    }
+
+                    SectionNode newNode = new SectionNode();
+                    newNode.Name = sectionAttribute.SectionName;
+                    children.Add(newNode);
+                    return newNode.GetOrAddConfig(configObject);
+                }
+            }
+
+            throw new ArgumentException("The provided configuration object does not specify a section");
+        }
+    }
+
+    public class SectionNode : Node
+    {
+        public new List<SubSectionNode> children;
+        
+        public bool Selected;
+        public string Name;
+
+        public SectionNode()
+        {
+            children = new List<SubSectionNode>();
+        }
+
+        public void Draw(ref bool changed)
+        {
+            if (!Selected)
+                return;
+
+            ImGui.BeginChild("item view",new Vector2(0, -ImGui.GetFrameHeightWithSpacing())); // Leave room for 1 line below us
+            {
+                if (ImGui.BeginTabBar("##Tabs", ImGuiTabBarFlags.None))
+                {
+                    foreach (var subSectionNode in children)
+                    {
+                        if (!ImGui.BeginTabItem(subSectionNode.Name)) continue;
+                        ImGui.BeginChild("subconfig value", new Vector2(0, 0), true);
+                        subSectionNode.Draw(ref changed);
+                        ImGui.EndChild();
+                        ImGui.EndTabItem();
+                    }
+                    ImGui.EndTabBar(); 
+                    
+                    // TODO: Close Button - Maybe better suited elsewhere
+                }
+            }
+            ImGui.EndChild();
+        }
+
+        public override void Save(string path)
+        {
+            foreach (var child in children)
+            {
+                child.Save(Path.Combine(path, Name));
+            }
+        }
+
+        public override void Load(string path)
+        {
+            foreach (var child in children)
+            {
+                child.Load(Path.Combine(path, Name));
+            }
+        }
+
+        public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
+        {
+            var attributes = configObject.GetType().GetCustomAttributes(false);
+            foreach (var attribute in attributes)
+            {
+                if (attribute is SubSectionAttribute subSectionAttribute)
+                {
+                    foreach (var subSectionNode in children)
+                    {
+                        if (subSectionNode.Name == subSectionAttribute.SubSectionName)
+                        {
+                            return subSectionNode.GetOrAddConfig(configObject);
+                        }
+                    }
+
+                    if (subSectionAttribute.Depth == 0)
+                    {
+                        NestedSubSectionNode newNode = new NestedSubSectionNode();
+                        newNode.Name = subSectionAttribute.SubSectionName;
+                        newNode.Depth = 0;
+                        children.Add(newNode);
+                        return newNode.GetOrAddConfig(configObject);
+                    }
+                }
+            }
+
+            throw new ArgumentException("The provided configuration object does not specify a sub-section");
+        }
+    }
+
+    public abstract class SubSectionNode : Node
+    {
+        public string Name;
+        public int Depth;
+
+        public abstract void Draw(ref bool changed);
+
+        public abstract ConfigPageNode GetOrAddConfig(PluginConfigObject configObject);
+    }
+
+    public class NestedSubSectionNode : SubSectionNode
+    {
+        public new List<SubSectionNode> children;
+
+        public NestedSubSectionNode()
+        {
+            children = new List<SubSectionNode>();
+        }
+
+        public override void Draw(ref bool changed)
+        {
+            ImGui.BeginChild("item" + Depth + " view",new Vector2(0, -ImGui.GetFrameHeightWithSpacing())); // Leave room for 1 line below us
+            {
+                if (ImGui.BeginTabBar("##tabs" + Depth, ImGuiTabBarFlags.None))
+                {
+                    foreach (var subSectionNode in children)
+                    {
+                        if (subSectionNode is NestedSubSectionNode)
+                        {
+                            if (!ImGui.BeginTabItem(subSectionNode.Name)) continue;
+                            ImGui.BeginChild("subconfig" + Depth + " value", new Vector2(0, 0), true);
+                            subSectionNode.Draw(ref changed);
+                            ImGui.EndChild();
+                            ImGui.EndTabItem();
+                        }
+                        else
+                        {
+                            subSectionNode.Draw(ref changed);
+                        }
+                    }
+                    ImGui.EndTabBar(); 
+                }
+            }
+            ImGui.EndChild();
+        }
+        
+        public override void Save(string path)
+        {
+            foreach (var child in children)
+            {
+                child.Save(Path.Combine(path, Name));
+            }
+        }
+
+        public override void Load(string path)
+        {
+            foreach (var child in children)
+            {
+                child.Load(Path.Combine(path, Name));
+            }
+        }
+        
+        public override ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
+        {
+            var attributes = configObject.GetType().GetCustomAttributes(false);
+            foreach (var attribute in attributes)
+            {
+                if (attribute is SubSectionAttribute subSectionAttribute)
+                {
+                    if (subSectionAttribute.Depth != Depth + 1)
+                        continue;
+                    
+                    foreach (var subSectionNode in children)
+                    {
+                        if (subSectionNode.Name == subSectionAttribute.SubSectionName)
+                        {
+                            return subSectionNode.GetOrAddConfig(configObject);
+                        }
+                    }
+
+                    NestedSubSectionNode nestedSubSectionNode = new NestedSubSectionNode();
+                    nestedSubSectionNode.Name = subSectionAttribute.SubSectionName;
+                    nestedSubSectionNode.Depth = Depth + 1;
+                    children.Add(nestedSubSectionNode);
+                    return nestedSubSectionNode.GetOrAddConfig(configObject);
+                }
+            }
+            
+            foreach (var subSectionNode in children)
+            {
+                if (subSectionNode.Name == configObject.GetType().FullName && subSectionNode is ConfigPageNode node)
+                    return node;
+            }
+            ConfigPageNode configPageNode = new ConfigPageNode();
+            configPageNode.ConfigObject = configObject;
+            configPageNode.Name = configObject.GetType().FullName;
+            children.Add(configPageNode);
+            return configPageNode;
+        }
+    }
+
+    public class ConfigPageNode : SubSectionNode
+    {
+        public PluginConfigObject ConfigObject;
+
+        public override void Draw(ref bool changed)
+        {
+            var fields = ConfigObject.GetType().GetFields();
+            foreach (var field in fields)
+            {
+                object fieldVal = field.GetValue(ConfigObject);
+                foreach (var attribute in field.GetCustomAttributes(true))
+                {
+                    if (attribute is CheckboxAttribute checkboxAttribute)
+                    {
+                        bool boolVal = (bool) fieldVal;
+                        if (ImGui.Checkbox(checkboxAttribute.friendlyName, ref boolVal))
+                        {
+                            field.SetValue(ConfigObject, boolVal);
+                            changed = true;
+                        }
+                    }
+                    else if (attribute is DragFloatAttribute dragFloatAttribute)
+                    {
+                        float floatVal = (float) fieldVal;
+                        if (ImGui.DragFloat(dragFloatAttribute.friendlyName, ref floatVal, dragFloatAttribute.velocity, dragFloatAttribute.min, dragFloatAttribute.max))
+                        {
+                            field.SetValue(ConfigObject, floatVal);
+                            changed = true;
+                        }
+                    }
+                    else if (attribute is DragIntAttribute dragIntAttribute)
+                    {
+                        int intVal = (int) fieldVal;
+                        if (ImGui.DragInt(dragIntAttribute.friendlyName, ref intVal, dragIntAttribute.velocity, dragIntAttribute.min, dragIntAttribute.max))
+                        {
+                            field.SetValue(ConfigObject, intVal);
+                            changed = true;
+                        }
+                    }
+                    else if (attribute is DragFloat2Attribute dragFloat2Attribute)
+                    {
+                        Vector2 floatVal = (Vector2) fieldVal;
+                        if (ImGui.DragFloat2(dragFloat2Attribute.friendlyName, ref floatVal, dragFloat2Attribute.velocity, dragFloat2Attribute.min, dragFloat2Attribute.max))
+                        {
+                            field.SetValue(ConfigObject, floatVal);
+                            changed = true;
+                        }
+                    }
+                    else if (attribute is DragInt2Attribute dragInt2Attribute)
+                    {
+                        Vector2 intVal = (Vector2) fieldVal;
+                        if (ImGui.DragFloat2(dragInt2Attribute.friendlyName, ref intVal, dragInt2Attribute.velocity, dragInt2Attribute.min, dragInt2Attribute.max))
+                        {
+                            field.SetValue(ConfigObject, intVal);
+                        }
+                    }
+                    else if (attribute is InputTextAttribute inputTextAttribute)
+                    {
+                        string stringVal = (string) fieldVal;
+                        if (ImGui.InputText(inputTextAttribute.friendlyName, ref stringVal, inputTextAttribute.maxLength))
+                        {
+                            field.SetValue(ConfigObject, stringVal);
+                        }
+                    }
+                    else if (attribute is ColorEdit4Attribute colorEdit4Attribute)
+                    {
+                        PluginConfigColor colorVal = (PluginConfigColor) fieldVal;
+                        var vector = colorVal.Vector;
+                        if (ImGui.ColorEdit4(colorEdit4Attribute.friendlyName, ref vector))
+                        {
+                            colorVal.Vector = vector;
+                            field.SetValue(ConfigObject, colorVal);
+                        }
+                    }
+                }
+            }
+        }
+
+        public override void Save(string path)
+        {
+            Directory.CreateDirectory(path);
+            string finalPath = path + ".json";
+            File.WriteAllText(finalPath, JsonConvert.SerializeObject(ConfigObject, Formatting.Indented, new JsonSerializerSettings
+            {
+                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
+                TypeNameHandling = TypeNameHandling.Objects,
+            }));
+        }
+
+        public override void Load(string path)
+        {
+            var finalPath = new FileInfo(path + ".json");
+            var configObject =  !finalPath.Exists ? ConfigObject : JsonConvert.DeserializeObject<PluginConfigObject>(File.ReadAllText(finalPath.FullName), new JsonSerializerSettings
+            {
+                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
+                TypeNameHandling = TypeNameHandling.Objects,
+            });
+            ConfigObject = configObject;
+        }
+
+        public override ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
+        {
+            return this;
+        }
+    }
+}

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -1,40 +1,48 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Numerics;
-using DelvUI.Config.Attributes;
+﻿using DelvUI.Config.Attributes;
 using ImGuiNET;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
 
-namespace DelvUI.Config.Tree {
-    public abstract class Node {
+namespace DelvUI.Config.Tree
+{
+    public abstract class Node
+    {
         public List<Node> children;
 
-        public virtual void Save(string path) {
-            foreach (var child in children) {
+        public virtual void Save(string path)
+        {
+            foreach (var child in children)
+            {
                 child.Save(ConfigurationManager.GetInstance().ConfigDirectory);
             }
         }
 
-        public virtual void Load(string path) {
-            foreach (var child in children) {
+        public virtual void Load(string path)
+        {
+            foreach (var child in children)
+            {
                 child.Load(ConfigurationManager.GetInstance().ConfigDirectory);
             }
         }
     }
 
-    public class BaseNode : Node {
+    public class BaseNode : Node
+    {
         public new List<SectionNode> children;
 
         public BaseNode() { children = new List<SectionNode>(); }
 
-        public void Draw() {
+        public void Draw()
+        {
             var changed = false;
 
             ImGui.SetNextWindowSize(new Vector2(1050, 750), ImGuiCond.Appearing);
 
-            if (!ImGui.Begin("titlebarnew", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollWithMouse)) {
+            if (!ImGui.Begin("titlebarnew", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollWithMouse))
+            {
                 return;
             }
 
@@ -46,17 +54,21 @@ namespace DelvUI.Config.Tree {
                 {
                     var delvUiBanner = ConfigurationManager.GetInstance().BannerImage;
 
-                    if (delvUiBanner != null) {
+                    if (delvUiBanner != null)
+                    {
                         ImGui.Image(delvUiBanner.ImGuiHandle, new Vector2(delvUiBanner.Width, delvUiBanner.Height));
                     }
 
                     ImGui.BeginChild("left pane", new Vector2(150, -ImGui.GetFrameHeightWithSpacing()), true);
 
-                    foreach (var selectionNode in children) {
-                        if (ImGui.Selectable(selectionNode.Name, selectionNode.Selected)) {
+                    foreach (var selectionNode in children)
+                    {
+                        if (ImGui.Selectable(selectionNode.Name, selectionNode.Selected))
+                        {
                             selectionNode.Selected = true;
 
-                            foreach (var otherNode in children.FindAll(x => x != selectionNode)) {
+                            foreach (var otherNode in children.FindAll(x => x != selectionNode))
+                            {
                                 otherNode.Selected = false;
                             }
                         }
@@ -72,7 +84,8 @@ namespace DelvUI.Config.Tree {
                 ImGui.BeginGroup(); // Right
 
                 {
-                    foreach (var selectionNode in children) {
+                    foreach (var selectionNode in children)
+                    {
                         selectionNode.Draw(ref changed);
                     }
                 }
@@ -107,30 +120,40 @@ namespace DelvUI.Config.Tree {
 
             ImGui.End();
 
-            if (changed) {
+            if (changed)
+            {
                 ConfigurationManager.GetInstance().SaveConfigurations();
             }
         }
 
-        public override void Load(string path) {
-            foreach (var child in children) {
+        public override void Load(string path)
+        {
+            foreach (var child in children)
+            {
                 child.Load(path);
             }
         }
 
-        public override void Save(string path) {
-            foreach (var child in children) {
+        public override void Save(string path)
+        {
+            foreach (var child in children)
+            {
                 child.Save(path);
             }
         }
 
-        public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject) {
+        public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
+        {
             var attributes = configObject.GetType().GetCustomAttributes(false);
 
-            foreach (var attribute in attributes) {
-                if (attribute is SectionAttribute sectionAttribute) {
-                    foreach (var sectionNode in children) {
-                        if (sectionNode.Name == sectionAttribute.SectionName) {
+            foreach (var attribute in attributes)
+            {
+                if (attribute is SectionAttribute sectionAttribute)
+                {
+                    foreach (var sectionNode in children)
+                    {
+                        if (sectionNode.Name == sectionAttribute.SectionName)
+                        {
                             return sectionNode.GetOrAddConfig(configObject);
                         }
                     }
@@ -147,7 +170,8 @@ namespace DelvUI.Config.Tree {
         }
     }
 
-    public class SectionNode : Node {
+    public class SectionNode : Node
+    {
         public new List<SubSectionNode> children;
 
         public bool Selected;
@@ -155,17 +179,22 @@ namespace DelvUI.Config.Tree {
 
         public SectionNode() { children = new List<SubSectionNode>(); }
 
-        public void Draw(ref bool changed) {
-            if (!Selected) {
+        public void Draw(ref bool changed)
+        {
+            if (!Selected)
+            {
                 return;
             }
 
             ImGui.BeginChild("item view", new Vector2(0, -ImGui.GetFrameHeightWithSpacing())); // Leave room for 1 line below us
 
             {
-                if (ImGui.BeginTabBar("##Tabs", ImGuiTabBarFlags.None)) {
-                    foreach (var subSectionNode in children) {
-                        if (!ImGui.BeginTabItem(subSectionNode.Name)) {
+                if (ImGui.BeginTabBar("##Tabs", ImGuiTabBarFlags.None))
+                {
+                    foreach (var subSectionNode in children)
+                    {
+                        if (!ImGui.BeginTabItem(subSectionNode.Name))
+                        {
                             continue;
                         }
 
@@ -184,30 +213,40 @@ namespace DelvUI.Config.Tree {
             ImGui.EndChild();
         }
 
-        public override void Save(string path) {
-            foreach (var child in children) {
+        public override void Save(string path)
+        {
+            foreach (var child in children)
+            {
                 child.Save(Path.Combine(path, Name));
             }
         }
 
-        public override void Load(string path) {
-            foreach (var child in children) {
+        public override void Load(string path)
+        {
+            foreach (var child in children)
+            {
                 child.Load(Path.Combine(path, Name));
             }
         }
 
-        public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject) {
+        public ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
+        {
             var attributes = configObject.GetType().GetCustomAttributes(false);
 
-            foreach (var attribute in attributes) {
-                if (attribute is SubSectionAttribute subSectionAttribute) {
-                    foreach (var subSectionNode in children) {
-                        if (subSectionNode.Name == subSectionAttribute.SubSectionName) {
+            foreach (var attribute in attributes)
+            {
+                if (attribute is SubSectionAttribute subSectionAttribute)
+                {
+                    foreach (var subSectionNode in children)
+                    {
+                        if (subSectionNode.Name == subSectionAttribute.SubSectionName)
+                        {
                             return subSectionNode.GetOrAddConfig(configObject);
                         }
                     }
 
-                    if (subSectionAttribute.Depth == 0) {
+                    if (subSectionAttribute.Depth == 0)
+                    {
                         NestedSubSectionNode newNode = new NestedSubSectionNode();
                         newNode.Name = subSectionAttribute.SubSectionName;
                         newNode.Depth = 0;
@@ -222,7 +261,8 @@ namespace DelvUI.Config.Tree {
         }
     }
 
-    public abstract class SubSectionNode : Node {
+    public abstract class SubSectionNode : Node
+    {
         public string Name;
         public int Depth;
 
@@ -231,19 +271,25 @@ namespace DelvUI.Config.Tree {
         public abstract ConfigPageNode GetOrAddConfig(PluginConfigObject configObject);
     }
 
-    public class NestedSubSectionNode : SubSectionNode {
+    public class NestedSubSectionNode : SubSectionNode
+    {
         public new List<SubSectionNode> children;
 
         public NestedSubSectionNode() { children = new List<SubSectionNode>(); }
 
-        public override void Draw(ref bool changed) {
+        public override void Draw(ref bool changed)
+        {
             ImGui.BeginChild("item" + Depth + " view", new Vector2(0, -ImGui.GetFrameHeightWithSpacing())); // Leave room for 1 line below us
 
             {
-                if (ImGui.BeginTabBar("##tabs" + Depth, ImGuiTabBarFlags.None)) {
-                    foreach (var subSectionNode in children) {
-                        if (subSectionNode is NestedSubSectionNode) {
-                            if (!ImGui.BeginTabItem(subSectionNode.Name)) {
+                if (ImGui.BeginTabBar("##tabs" + Depth, ImGuiTabBarFlags.None))
+                {
+                    foreach (var subSectionNode in children)
+                    {
+                        if (subSectionNode is NestedSubSectionNode)
+                        {
+                            if (!ImGui.BeginTabItem(subSectionNode.Name))
+                            {
                                 continue;
                             }
 
@@ -252,7 +298,8 @@ namespace DelvUI.Config.Tree {
                             ImGui.EndChild();
                             ImGui.EndTabItem();
                         }
-                        else {
+                        else
+                        {
                             subSectionNode.Draw(ref changed);
                         }
                     }
@@ -264,29 +311,39 @@ namespace DelvUI.Config.Tree {
             ImGui.EndChild();
         }
 
-        public override void Save(string path) {
-            foreach (var child in children) {
+        public override void Save(string path)
+        {
+            foreach (var child in children)
+            {
                 child.Save(Path.Combine(path, Name));
             }
         }
 
-        public override void Load(string path) {
-            foreach (var child in children) {
+        public override void Load(string path)
+        {
+            foreach (var child in children)
+            {
                 child.Load(Path.Combine(path, Name));
             }
         }
 
-        public override ConfigPageNode GetOrAddConfig(PluginConfigObject configObject) {
+        public override ConfigPageNode GetOrAddConfig(PluginConfigObject configObject)
+        {
             var attributes = configObject.GetType().GetCustomAttributes(false);
 
-            foreach (var attribute in attributes) {
-                if (attribute is SubSectionAttribute subSectionAttribute) {
-                    if (subSectionAttribute.Depth != Depth + 1) {
+            foreach (var attribute in attributes)
+            {
+                if (attribute is SubSectionAttribute subSectionAttribute)
+                {
+                    if (subSectionAttribute.Depth != Depth + 1)
+                    {
                         continue;
                     }
 
-                    foreach (var subSectionNode in children) {
-                        if (subSectionNode.Name == subSectionAttribute.SubSectionName) {
+                    foreach (var subSectionNode in children)
+                    {
+                        if (subSectionNode.Name == subSectionAttribute.SubSectionName)
+                        {
                             return subSectionNode.GetOrAddConfig(configObject);
                         }
                     }
@@ -300,8 +357,10 @@ namespace DelvUI.Config.Tree {
                 }
             }
 
-            foreach (var subSectionNode in children) {
-                if (subSectionNode.Name == configObject.GetType().FullName && subSectionNode is ConfigPageNode node) {
+            foreach (var subSectionNode in children)
+            {
+                if (subSectionNode.Name == configObject.GetType().FullName && subSectionNode is ConfigPageNode node)
+                {
                     return node;
                 }
             }
@@ -315,69 +374,87 @@ namespace DelvUI.Config.Tree {
         }
     }
 
-    public class ConfigPageNode : SubSectionNode {
+    public class ConfigPageNode : SubSectionNode
+    {
         public PluginConfigObject ConfigObject;
 
-        public override void Draw(ref bool changed) {
+        public override void Draw(ref bool changed)
+        {
             var fields = ConfigObject.GetType().GetFields();
 
-            foreach (var field in fields) {
+            foreach (var field in fields)
+            {
                 object fieldVal = field.GetValue(ConfigObject);
 
-                foreach (var attribute in field.GetCustomAttributes(true)) {
-                    if (attribute is CheckboxAttribute checkboxAttribute) {
-                        bool boolVal = (bool) fieldVal;
+                foreach (var attribute in field.GetCustomAttributes(true))
+                {
+                    if (attribute is CheckboxAttribute checkboxAttribute)
+                    {
+                        bool boolVal = (bool)fieldVal;
 
-                        if (ImGui.Checkbox(checkboxAttribute.friendlyName, ref boolVal)) {
+                        if (ImGui.Checkbox(checkboxAttribute.friendlyName, ref boolVal))
+                        {
                             field.SetValue(ConfigObject, boolVal);
                             changed = true;
                         }
                     }
-                    else if (attribute is DragFloatAttribute dragFloatAttribute) {
-                        float floatVal = (float) fieldVal;
+                    else if (attribute is DragFloatAttribute dragFloatAttribute)
+                    {
+                        float floatVal = (float)fieldVal;
 
-                        if (ImGui.DragFloat(dragFloatAttribute.friendlyName, ref floatVal, dragFloatAttribute.velocity, dragFloatAttribute.min, dragFloatAttribute.max)) {
+                        if (ImGui.DragFloat(dragFloatAttribute.friendlyName, ref floatVal, dragFloatAttribute.velocity, dragFloatAttribute.min, dragFloatAttribute.max))
+                        {
                             field.SetValue(ConfigObject, floatVal);
                             changed = true;
                         }
                     }
-                    else if (attribute is DragIntAttribute dragIntAttribute) {
-                        int intVal = (int) fieldVal;
+                    else if (attribute is DragIntAttribute dragIntAttribute)
+                    {
+                        int intVal = (int)fieldVal;
 
-                        if (ImGui.DragInt(dragIntAttribute.friendlyName, ref intVal, dragIntAttribute.velocity, dragIntAttribute.min, dragIntAttribute.max)) {
+                        if (ImGui.DragInt(dragIntAttribute.friendlyName, ref intVal, dragIntAttribute.velocity, dragIntAttribute.min, dragIntAttribute.max))
+                        {
                             field.SetValue(ConfigObject, intVal);
                             changed = true;
                         }
                     }
-                    else if (attribute is DragFloat2Attribute dragFloat2Attribute) {
-                        Vector2 floatVal = (Vector2) fieldVal;
+                    else if (attribute is DragFloat2Attribute dragFloat2Attribute)
+                    {
+                        Vector2 floatVal = (Vector2)fieldVal;
 
-                        if (ImGui.DragFloat2(dragFloat2Attribute.friendlyName, ref floatVal, dragFloat2Attribute.velocity, dragFloat2Attribute.min, dragFloat2Attribute.max)) {
+                        if (ImGui.DragFloat2(dragFloat2Attribute.friendlyName, ref floatVal, dragFloat2Attribute.velocity, dragFloat2Attribute.min, dragFloat2Attribute.max))
+                        {
                             field.SetValue(ConfigObject, floatVal);
                             changed = true;
                         }
                     }
-                    else if (attribute is DragInt2Attribute dragInt2Attribute) {
-                        Vector2 intVal = (Vector2) fieldVal;
+                    else if (attribute is DragInt2Attribute dragInt2Attribute)
+                    {
+                        Vector2 intVal = (Vector2)fieldVal;
 
-                        if (ImGui.DragFloat2(dragInt2Attribute.friendlyName, ref intVal, dragInt2Attribute.velocity, dragInt2Attribute.min, dragInt2Attribute.max)) {
+                        if (ImGui.DragFloat2(dragInt2Attribute.friendlyName, ref intVal, dragInt2Attribute.velocity, dragInt2Attribute.min, dragInt2Attribute.max))
+                        {
                             field.SetValue(ConfigObject, intVal);
                             changed = true;
                         }
                     }
-                    else if (attribute is InputTextAttribute inputTextAttribute) {
-                        string stringVal = (string) fieldVal;
+                    else if (attribute is InputTextAttribute inputTextAttribute)
+                    {
+                        string stringVal = (string)fieldVal;
 
-                        if (ImGui.InputText(inputTextAttribute.friendlyName, ref stringVal, inputTextAttribute.maxLength)) {
+                        if (ImGui.InputText(inputTextAttribute.friendlyName, ref stringVal, inputTextAttribute.maxLength))
+                        {
                             field.SetValue(ConfigObject, stringVal);
                             changed = true;
                         }
                     }
-                    else if (attribute is ColorEdit4Attribute colorEdit4Attribute) {
-                        PluginConfigColor colorVal = (PluginConfigColor) fieldVal;
+                    else if (attribute is ColorEdit4Attribute colorEdit4Attribute)
+                    {
+                        PluginConfigColor colorVal = (PluginConfigColor)fieldVal;
                         var vector = colorVal.Vector;
 
-                        if (ImGui.ColorEdit4(colorEdit4Attribute.friendlyName, ref vector)) {
+                        if (ImGui.ColorEdit4(colorEdit4Attribute.friendlyName, ref vector))
+                        {
                             colorVal.Vector = vector;
                             field.SetValue(ConfigObject, colorVal);
                             changed = true;
@@ -387,7 +464,8 @@ namespace DelvUI.Config.Tree {
             }
         }
 
-        public override void Save(string path) {
+        public override void Save(string path)
+        {
             Directory.CreateDirectory(path);
             string finalPath = path + ".json";
 
@@ -396,15 +474,17 @@ namespace DelvUI.Config.Tree {
                 JsonConvert.SerializeObject(
                     ConfigObject,
                     Formatting.Indented,
-                    new JsonSerializerSettings {TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple, TypeNameHandling = TypeNameHandling.Objects}
+                    new JsonSerializerSettings { TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple, TypeNameHandling = TypeNameHandling.Objects }
                 )
             );
         }
 
-        public override void Load(string path) {
+        public override void Load(string path)
+        {
             var finalPath = new FileInfo(path + ".json");
 
-            if (!finalPath.Exists) {
+            if (!finalPath.Exists)
+            {
                 return;
             }
 
@@ -412,14 +492,16 @@ namespace DelvUI.Config.Tree {
             // While in general use this is important as the conversion from the superclass 'PluginConfigObject' to a specific subclass (e.g. 'BlackMageHudConfig') would
             // be handled by Json.NET, when the plugin is reloaded with a different assembly (as is the case when using LivePluginLoader, or updating the plugin in-game)
             // it fails. In order to fix this we need to specify the specific subclass, in order to do this during runtime we must use reflection to set the generic.
-            if (ConfigObject.GetType().GetInterface(typeof(PluginConfigObject).FullName) != null) {
+            if (ConfigObject.GetType().GetInterface(typeof(PluginConfigObject).FullName) != null)
+            {
                 var methodInfo = GetType().GetMethod("LoadForType");
                 var function = methodInfo.MakeGenericMethod(ConfigObject.GetType());
-                ConfigObject = (PluginConfigObject) function.Invoke(this, new object[] {finalPath});
+                ConfigObject = (PluginConfigObject)function.Invoke(this, new object[] { finalPath });
             }
         }
 
-        public T LoadForType<T>(string path) where T : PluginConfigObject {
+        public T LoadForType<T>(string path) where T : PluginConfigObject
+        {
             var file = new FileInfo(path);
 
             return JsonConvert.DeserializeObject<T>(File.ReadAllText(file.FullName));

--- a/DelvUI/Interface/BlackMageHudWindow.cs
+++ b/DelvUI/Interface/BlackMageHudWindow.cs
@@ -9,10 +9,8 @@ using System.Linq;
 using System.Numerics;
 using DelvUI.Config.Attributes;
 
-namespace DelvUI.Interface
-{
-    public class BlackMageHudWindow : HudWindow
-    {
+namespace DelvUI.Interface {
+    public class BlackMageHudWindow : HudWindow {
         public override uint JobId => Jobs.BLM;
         
         private BlackMageHudConfig _config => (BlackMageHudConfig) ConfigurationManager.GetInstance().GetConfiguration(new BlackMageHudConfig());
@@ -21,36 +19,30 @@ namespace DelvUI.Interface
         private float OriginY => CenterY + YOffset + _config.Position.Y;
         private Dictionary<string, uint> EmptyColor => PluginConfiguration.MiscColorMap["empty"];
 
-        public BlackMageHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration) 
-            : base(pluginInterface, pluginConfiguration) 
-        {}
+        public BlackMageHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration)
+            : base(pluginInterface, pluginConfiguration) { }
 
-        protected override void Draw(bool _)
-        {
+        protected override void Draw(bool _) {
             DrawManaBar();
             DrawUmbralHeartStacks();
             DrawPolyglot();
 
-            if (_config.ShowTripleCast)
-            {
+            if (_config.ShowTripleCast) {
                 DrawTripleCast();
             }
 
-            if (_config.ShowFirestarterProcs || _config.ShowThundercloudProcs)
-            {
+            if (_config.ShowFirestarterProcs || _config.ShowThundercloudProcs) {
                 DrawProcs();
             }
 
-            if (_config.ShowDotTimer)
-            {
+            if (_config.ShowDotTimer) {
                 DrawDotTimer();
             }
         }
 
         protected override void DrawPrimaryResourceBar() { }
 
-        protected virtual void DrawManaBar()
-        {
+        protected virtual void DrawManaBar() {
             var gauge = PluginInterface.ClientState.JobGauges.Get<BLMGauge>();
 
             var actor = PluginInterface.ClientState.LocalPlayer;
@@ -59,25 +51,21 @@ namespace DelvUI.Interface
 
             var color = gauge.InAstralFire()
                 ? _config.ManaBarFireColor.Map
-                : gauge.InUmbralIce()
-                    ? _config.ManaBarIceColor.Map
-                    : _config.ManaBarNoElementColor.Map;
+                : gauge.InUmbralIce() ? _config.ManaBarIceColor.Map : _config.ManaBarNoElementColor.Map;
 
-            var builder = BarBuilder.Create(OriginX - barSize.X / 2, OriginY - barSize.Y, (int)barSize.Y, (int)barSize.X);
+            var builder = BarBuilder.Create(OriginX - barSize.X / 2, OriginY - barSize.Y, (int) barSize.Y, (int) barSize.X);
 
             builder.AddInnerBar(actor.CurrentMp, actor.MaxMp, color).SetBackgroundColor(EmptyColor["background"]);
 
             // element timer
-            if (gauge.InAstralFire() || gauge.InUmbralIce())
-            {
+            if (gauge.InAstralFire() || gauge.InUmbralIce()) {
                 var time = gauge.ElementTimeRemaining > 10 ? gauge.ElementTimeRemaining / 1000 + 1 : 0;
                 builder.SetTextMode(BarTextMode.Single);
                 builder.SetText(BarTextPosition.CenterMiddle, BarTextType.Custom, $"{time,0}");
             }
 
             // enochian
-            if (gauge.IsEnoActive())
-            {
+            if (gauge.IsEnoActive()) {
                 builder.SetGlowSize(2);
                 builder.SetGlowColor(0x88FFFFFF);
             }
@@ -86,8 +74,7 @@ namespace DelvUI.Interface
             builder.Build().Draw(drawList, PluginConfiguration);
 
             // threshold marker
-            if (_config.ShowManaThresholdMarker && gauge.InAstralFire())
-            {
+            if (_config.ShowManaThresholdMarker && gauge.InAstralFire()) {
                 var position = new Vector2(OriginX - barSize.X / 2 + _config.ManaThresholdValue / 10000f * barSize.X, cursorPos.Y + barSize.Y);
                 var size = new Vector2(3, barSize.Y);
 
@@ -102,8 +89,7 @@ namespace DelvUI.Interface
             }
 
             // mana
-            if (_config.ShowManaValue)
-            {
+            if (_config.ShowManaValue) {
                 var mana = PluginInterface.ClientState.LocalPlayer.CurrentMp;
                 var text = $"{mana,0}";
                 var textSize = ImGui.CalcTextSize(text);
@@ -111,8 +97,7 @@ namespace DelvUI.Interface
             }
         }
 
-        protected virtual void DrawUmbralHeartStacks()
-        {
+        protected virtual void DrawUmbralHeartStacks() {
             var gauge = PluginInterface.ClientState.JobGauges.Get<BLMGauge>();
 
             var totalWidth = _config.UmbralHeartSize.X * 3 + _config.Padding.X * 2;
@@ -129,14 +114,12 @@ namespace DelvUI.Interface
             bar.Draw(drawList, PluginConfiguration);
         }
 
-        protected virtual void DrawPolyglot()
-        {
+        protected virtual void DrawPolyglot() {
             var gauge = PluginInterface.ClientState.JobGauges.Get<BLMGauge>();
             var totalWidth = _config.PolyglotSize.X * 2 + _config.Padding.X;
             var y = OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y - _config.Padding.Y - _config.PolyglotSize.Y;
 
-            if (_config.ShowTripleCast)
-            {
+            if (_config.ShowTripleCast) {
                 y = y - _config.Padding.Y - _config.TripleCastSize.Y;
             }
 
@@ -148,8 +131,7 @@ namespace DelvUI.Interface
                                     .AddInnerBar(gauge.NumPolyglotStacks < 1 ? scale : 1, 1, _config.PolyglotColor.Map)
                                     .SetBackgroundColor(EmptyColor["background"]);
 
-            if (gauge.NumPolyglotStacks >= 1)
-            {
+            if (gauge.NumPolyglotStacks >= 1) {
                 builder.SetGlowColor(0x88FFFFFF);
             }
 
@@ -168,16 +150,14 @@ namespace DelvUI.Interface
                                 )
                                 .SetBackgroundColor(EmptyColor["background"]);
 
-            if (gauge.NumPolyglotStacks == 2)
-            {
+            if (gauge.NumPolyglotStacks == 2) {
                 builder.SetGlowColor(0x88FFFFFF);
             }
 
             builder.Build().Draw(drawList, PluginConfiguration);
         }
 
-        protected virtual void DrawTripleCast()
-        {
+        protected virtual void DrawTripleCast() {
             var tripleStackBuff = PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 1211);
 
             var totalWidth = _config.TripleCastSize.X * 3 + _config.Padding.X * 2;
@@ -198,18 +178,17 @@ namespace DelvUI.Interface
             bar.Draw(drawList, PluginConfiguration);
         }
 
-        protected virtual void DrawProcs()
-        {
+        protected virtual void DrawProcs() {
             var firestarterTimer = _config.ShowFirestarterProcs
                 ? Math.Abs(PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 165).Duration)
+               
                 : 0;
 
             var thundercloudTimer = _config.ShowThundercloudProcs
                 ? Math.Abs(PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 164).Duration)
                 : 0;
 
-            if (firestarterTimer == 0 && thundercloudTimer == 0)
-            {
+            if (firestarterTimer == 0 && thundercloudTimer == 0) {
                 return;
             }
 
@@ -217,14 +196,12 @@ namespace DelvUI.Interface
             var x = OriginX - _config.Padding.X * 2f - _config.PolyglotSize.X;
             var y = OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y - _config.Padding.Y - _config.PolyglotSize.Y / 2f + _config.ProcsHeight;
 
-            if (_config.ShowTripleCast)
-            {
+            if (_config.ShowTripleCast) {
                 y = y - _config.Padding.Y - _config.TripleCastSize.Y;
             }
 
             // fire starter
-            if (firestarterTimer > 0)
-            {
+            if (firestarterTimer > 0) {
                 var position = new Vector2(x, y - totalHeight / 2f);
                 var scale = firestarterTimer / 18f;
 
@@ -232,8 +209,7 @@ namespace DelvUI.Interface
             }
 
             // thundercloud
-            if (thundercloudTimer > 0)
-            {
+            if (thundercloudTimer > 0) {
                 var position = new Vector2(x, firestarterTimer == 0 ? y - totalHeight / 2f : y + _config.Padding.Y / 2f);
                 var scale = thundercloudTimer / 18f;
 
@@ -241,44 +217,38 @@ namespace DelvUI.Interface
             }
         }
 
-        protected virtual void DrawDotTimer()
-        {
+        protected virtual void DrawDotTimer() {
             var target = PluginInterface.ClientState.Targets.SoftTarget ?? PluginInterface.ClientState.Targets.CurrentTarget;
 
-            if (target is null)
-            {
+            if (target is null) {
                 return;
             }
 
             // thunder 1 to 4
-            int[] dotIDs = { 161, 162, 163, 1210 };
-            float[] dotDurations = { 12, 18, 24, 18 };
+            int[] dotIDs = {161, 162, 163, 1210};
+            float[] dotDurations = {12, 18, 24, 18};
 
             float timer = 0;
             float maxDuration = 1;
 
-            for (var i = 0; i < 4; i++)
-            {
+            for (var i = 0; i < 4; i++) {
                 timer = target.StatusEffects.FirstOrDefault(o => o.EffectId == dotIDs[i] && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId).Duration;
 
-                if (timer > 0)
-                {
+                if (timer > 0) {
                     maxDuration = dotDurations[i];
 
                     break;
                 }
             }
 
-            if (timer == 0)
-            {
+            if (timer == 0) {
                 return;
             }
 
             var x = OriginX + _config.Padding.X * 2f + _config.PolyglotSize.X;
             var y = OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y - _config.Padding.Y - _config.PolyglotSize.Y / 2f - _config.DotTimerHeight;
 
-            if (_config.ShowTripleCast)
-            {
+            if (_config.ShowTripleCast) {
                 y = y - _config.Padding.Y - _config.TripleCastSize.Y;
             }
 
@@ -288,8 +258,7 @@ namespace DelvUI.Interface
             DrawTimerBar(position, scale, _config.DotTimerHeight, _config.DotColor.Map, false);
         }
 
-        private void DrawTimerBar(Vector2 position, float scale, float height, Dictionary<string, uint> colorMap, bool inverted)
-        {
+        private void DrawTimerBar(Vector2 position, float scale, float height, Dictionary<string, uint> colorMap, bool inverted) {
             var drawList = ImGui.GetWindowDrawList();
             var size = new Vector2((_config.ManaBarSize.X / 2f - _config.PolyglotSize.X - _config.Padding.X * 2f) * scale, height);
             size.X = Math.Max(1, size.X);
@@ -313,35 +282,53 @@ namespace DelvUI.Interface
     [Section("Job Specific Bars")]
     [SubSection("Caster", 0)]
     [SubSection("Black Mage", 1)]
-    public class BlackMageHudConfig : PluginConfigObject
-    {
-        [DragFloat2("Base Offset", min = -4000f, max = 4000f)] public Vector2 Position = new Vector2(0, -2);
-        [DragFloat2("Padding", min = -100f, max = 100f)] public Vector2 Padding = new Vector2(2, 2);
-        [DragFloat2("Mana Bar Size", max = 2000f)] public Vector2 ManaBarSize = new Vector2(253, 20);
-        [DragFloat2("Umbra Heart Size", max = 2000f)] public Vector2 UmbralHeartSize = new Vector2(83, 16);
-        [DragFloat2("Polyglot Size", max = 2000f)] public Vector2 PolyglotSize = new Vector2(18, 18);
-        
+    public class BlackMageHudConfig : PluginConfigObject {
+        [DragFloat2("Base Offset", min = -4000f, max = 4000f)]
+        public Vector2 Position = new Vector2(0, -2);
+
+        [DragFloat2("Padding", min = -100f, max = 100f)]
+        public Vector2 Padding = new Vector2(2, 2);
+
+        [DragFloat2("Mana Bar Size", max = 2000f)]
+        public Vector2 ManaBarSize = new Vector2(253, 20);
+
+        [DragFloat2("Umbra Heart Size", max = 2000f)]
+        public Vector2 UmbralHeartSize = new Vector2(83, 16);
+
+        [DragFloat2("Polyglot Size", max = 2000f)]
+        public Vector2 PolyglotSize = new Vector2(18, 18);
         [Checkbox("Show Mana Value")] public bool ShowManaValue = false;
-        [Checkbox("Show Mana Threshold Marker During Astral Fire")] public bool ShowManaThresholdMarker = true;
-        [DragInt("Mana Threshold Marker Value", max = 10000)] public int ManaThresholdValue = 2600;
+
+        [Checkbox("Show Mana Threshold Marker During Astral Fire")]
+        public bool ShowManaThresholdMarker = true;
+
+        [DragInt("Mana Threshold Marker Value", max = 10000)]
+        public int ManaThresholdValue = 2600;
 
         [Checkbox("Show Triplecast")] public bool ShowTripleCast = true;
-        [DragFloat2("Triplecast Size", max = 2000)] public Vector2 TripleCastSize = new Vector2(83, 16);
-        
+
+        [DragFloat2("Triplecast Size", max = 2000)]
+        public Vector2 TripleCastSize = new Vector2(83, 16);
+
         [Checkbox("Show Firestarter Procs")] public bool ShowFirestarterProcs = true;
         [Checkbox("Show Thundercloud Procs")] public bool ShowThundercloudProcs = true;
         [DragInt("Procs Height", max = 2000)] public int ProcsHeight = 7;
         [Checkbox("Show DoT Timer")] public bool ShowDotTimer = true;
-        [DragInt("DoT Timer Height", max = 2000)]public int DotTimerHeight = 10;
+
+        [DragInt("DoT Timer Height", max = 2000)]
+        public int DotTimerHeight = 10;
 
         [ColorEdit4("Mana Bar Color")] public PluginConfigColor ManaBarNoElementColor = new PluginConfigColor(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
         [ColorEdit4("Mana Bar Ice Color")] public PluginConfigColor ManaBarIceColor = new PluginConfigColor(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 100f / 100f));
         [ColorEdit4("Mana Bar Fire Color")] public PluginConfigColor ManaBarFireColor = new PluginConfigColor(new Vector4(204f / 255f, 40f / 255f, 40f / 255f, 100f / 100f));
         [ColorEdit4("Umbral Heart Color")] public PluginConfigColor UmbralHeartColor = new PluginConfigColor(new Vector4(125f / 255f, 195f / 255f, 205f / 255f, 100f / 100f));
         [ColorEdit4("Polyglot Color Color")] public PluginConfigColor PolyglotColor = new PluginConfigColor(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
-        [ColorEdit4("Triplecast Color")]  public PluginConfigColor TriplecastColor = new PluginConfigColor(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
+        [ColorEdit4("Triplecast Color")] public PluginConfigColor TriplecastColor = new PluginConfigColor(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
         [ColorEdit4("Firestarter Proc Color")] public PluginConfigColor FirestarterColor = new PluginConfigColor(new Vector4(255f / 255f, 136f / 255f, 0 / 255f, 90f / 100f));
-        [ColorEdit4("Thundercloud Proc Color")] public PluginConfigColor ThundercloudColor = new PluginConfigColor(new Vector4(240f / 255f, 163f / 255f, 255f / 255f, 90f / 100f));
+
+        [ColorEdit4("Thundercloud Proc Color")]
+        public PluginConfigColor ThundercloudColor = new PluginConfigColor(new Vector4(240f / 255f, 163f / 255f, 255f / 255f, 90f / 100f));
+
         [ColorEdit4("DoT Timer Color")] public PluginConfigColor DotColor = new PluginConfigColor(new Vector4(67f / 255f, 187 / 255f, 255f / 255f, 90f / 100f));
 
         // public bool Draw()

--- a/DelvUI/Interface/BlackMageHudWindow.cs
+++ b/DelvUI/Interface/BlackMageHudWindow.cs
@@ -7,24 +7,23 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using DelvUI.Config.Attributes;
 
 namespace DelvUI.Interface
 {
     public class BlackMageHudWindow : HudWindow
     {
-        private readonly BlackMageHudConfig _config;
-
-        public BlackMageHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration, BlackMageHudConfig config)
-            : base(pluginInterface, pluginConfiguration)
-        {
-            _config = config;
-        }
-
         public override uint JobId => Jobs.BLM;
+        
+        private BlackMageHudConfig _config => (BlackMageHudConfig) ConfigurationManager.GetInstance().GetConfiguration(new BlackMageHudConfig());
 
         private float OriginX => CenterX + _config.Position.X;
         private float OriginY => CenterY + YOffset + _config.Position.Y;
         private Dictionary<string, uint> EmptyColor => PluginConfiguration.MiscColorMap["empty"];
+
+        public BlackMageHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration) 
+            : base(pluginInterface, pluginConfiguration) 
+        {}
 
         protected override void Draw(bool _)
         {
@@ -311,73 +310,76 @@ namespace DelvUI.Interface
     }
 
     [Serializable]
+    [Section("Job Specific Bars")]
+    [SubSection("Caster", 0)]
+    [SubSection("Black Mage", 1)]
     public class BlackMageHudConfig : PluginConfigObject
     {
-        public PluginConfigColor DotColor = new(new Vector4(67f / 255f, 187 / 255f, 255f / 255f, 90f / 100f));
-        public int DotTimerHeight = 10;
-        public PluginConfigColor FirestarterColor = new(new Vector4(255f / 255f, 136f / 255f, 0 / 255f, 90f / 100f));
-        public PluginConfigColor ManaBarFireColor = new(new Vector4(204f / 255f, 40f / 255f, 40f / 255f, 100f / 100f));
-        public PluginConfigColor ManaBarIceColor = new(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 100f / 100f));
+        [DragFloat2("Base Offset", min = -4000f, max = 4000f)] public Vector2 Position = new Vector2(0, -2);
+        [DragFloat2("Padding", min = -100f, max = 100f)] public Vector2 Padding = new Vector2(2, 2);
+        [DragFloat2("Mana Bar Size", max = 2000f)] public Vector2 ManaBarSize = new Vector2(253, 20);
+        [DragFloat2("Umbra Heart Size", max = 2000f)] public Vector2 UmbralHeartSize = new Vector2(83, 16);
+        [DragFloat2("Polyglot Size", max = 2000f)] public Vector2 PolyglotSize = new Vector2(18, 18);
+        
+        [Checkbox("Show Mana Value")] public bool ShowManaValue = false;
+        [Checkbox("Show Mana Threshold Marker During Astral Fire")] public bool ShowManaThresholdMarker = true;
+        [DragInt("Mana Threshold Marker Value", max = 10000)] public int ManaThresholdValue = 2600;
 
-        public PluginConfigColor ManaBarNoElementColor = new(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
-        public Vector2 ManaBarSize = new(253, 20);
-        public int ManaThresholdValue = 2600;
-        public Vector2 Padding = new(2, 2);
-        public PluginConfigColor PolyglotColor = new(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
-        public Vector2 PolyglotSize = new(18, 18);
-        public Vector2 Position = new(0, -2);
-        public int ProcsHeight = 7;
-        public bool ShowDotTimer = true;
+        [Checkbox("Show Triplecast")] public bool ShowTripleCast = true;
+        [DragFloat2("Triplecast Size", max = 2000)] public Vector2 TripleCastSize = new Vector2(83, 16);
+        
+        [Checkbox("Show Firestarter Procs")] public bool ShowFirestarterProcs = true;
+        [Checkbox("Show Thundercloud Procs")] public bool ShowThundercloudProcs = true;
+        [DragInt("Procs Height", max = 2000)] public int ProcsHeight = 7;
+        [Checkbox("Show DoT Timer")] public bool ShowDotTimer = true;
+        [DragInt("DoT Timer Height", max = 2000)]public int DotTimerHeight = 10;
 
-        public bool ShowFirestarterProcs = true;
-        public bool ShowManaThresholdMarker = true;
+        [ColorEdit4("Mana Bar Color")] public PluginConfigColor ManaBarNoElementColor = new PluginConfigColor(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
+        [ColorEdit4("Mana Bar Ice Color")] public PluginConfigColor ManaBarIceColor = new PluginConfigColor(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 100f / 100f));
+        [ColorEdit4("Mana Bar Fire Color")] public PluginConfigColor ManaBarFireColor = new PluginConfigColor(new Vector4(204f / 255f, 40f / 255f, 40f / 255f, 100f / 100f));
+        [ColorEdit4("Umbral Heart Color")] public PluginConfigColor UmbralHeartColor = new PluginConfigColor(new Vector4(125f / 255f, 195f / 255f, 205f / 255f, 100f / 100f));
+        [ColorEdit4("Polyglot Color Color")] public PluginConfigColor PolyglotColor = new PluginConfigColor(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
+        [ColorEdit4("Triplecast Color")]  public PluginConfigColor TriplecastColor = new PluginConfigColor(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
+        [ColorEdit4("Firestarter Proc Color")] public PluginConfigColor FirestarterColor = new PluginConfigColor(new Vector4(255f / 255f, 136f / 255f, 0 / 255f, 90f / 100f));
+        [ColorEdit4("Thundercloud Proc Color")] public PluginConfigColor ThundercloudColor = new PluginConfigColor(new Vector4(240f / 255f, 163f / 255f, 255f / 255f, 90f / 100f));
+        [ColorEdit4("DoT Timer Color")] public PluginConfigColor DotColor = new PluginConfigColor(new Vector4(67f / 255f, 187 / 255f, 255f / 255f, 90f / 100f));
 
-        public bool ShowManaValue;
-        public bool ShowThundercloudProcs = true;
-
-        public bool ShowTripleCast = true;
-        public PluginConfigColor ThundercloudColor = new(new Vector4(240f / 255f, 163f / 255f, 255f / 255f, 90f / 100f));
-        public PluginConfigColor TriplecastColor = new(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
-        public Vector2 TripleCastSize = new(83, 16);
-        public PluginConfigColor UmbralHeartColor = new(new Vector4(125f / 255f, 195f / 255f, 205f / 255f, 100f / 100f));
-        public Vector2 UmbralHeartSize = new(83, 16);
-
-        public bool Draw()
-        {
-            var changed = false;
-
-            changed |= ImGui.DragFloat2("Base Offset", ref Position, 1f, -4000, 4000);
-            changed |= ImGui.DragFloat2("Padding", ref Padding, 1f, -100, 100);
-            changed |= ImGui.DragFloat2("Mana Bar Size", ref ManaBarSize, 1f, 1, 2000);
-            changed |= ImGui.DragFloat2("Umbral Heart Size", ref UmbralHeartSize, 1f, 1, 2000);
-            changed |= ImGui.DragFloat2("Polyglot Size", ref PolyglotSize, 1f, 1, 2000);
-
-            changed |= ImGui.Checkbox("Show Mana Value", ref ShowManaValue);
-            changed |= ImGui.Checkbox("Show Mana Threshold Marker During Astral Fire", ref ShowManaThresholdMarker);
-            changed |= ImGui.DragInt("Mana Threshold Marker Value", ref ManaThresholdValue, 1f, 1, 10000);
-
-            changed |= ImGui.Checkbox("Show Triplecast", ref ShowTripleCast);
-            changed |= ImGui.DragFloat2("Triplecast Size", ref TripleCastSize, 1f, 1, 2000);
-
-            changed |= ImGui.Checkbox("Show Firestarter Procs", ref ShowFirestarterProcs);
-            changed |= ImGui.Checkbox("Show Thundercloud Procs", ref ShowThundercloudProcs);
-
-            changed |= ImGui.DragInt("Procs Height", ref ProcsHeight, .1f, 1, 2000);
-
-            changed |= ImGui.Checkbox("Show DoT Timer", ref ShowDotTimer);
-            changed |= ImGui.DragInt("DoT Timer Height", ref DotTimerHeight, .1f, 1, 2000);
-
-            changed |= ColorEdit4("Mana Bar Color", ref ManaBarNoElementColor);
-            changed |= ColorEdit4("Mana Bar Ice Color", ref ManaBarIceColor);
-            changed |= ColorEdit4("Mana Bar Fire Color", ref ManaBarFireColor);
-            changed |= ColorEdit4("Umbral Heart Color", ref UmbralHeartColor);
-            changed |= ColorEdit4("Polyglot Color", ref PolyglotColor);
-            changed |= ColorEdit4("Triplecast Color", ref TriplecastColor);
-            changed |= ColorEdit4("Firestarter Proc Color", ref FirestarterColor);
-            changed |= ColorEdit4("Thundercloud Proc Color", ref ThundercloudColor);
-            changed |= ColorEdit4("DoT Timer Color", ref DotColor);
-
-            return changed;
-        }
+        // public bool Draw()
+        // {
+        //     var changed = false;
+        //
+        //     changed |= ImGui.DragFloat2("Base Offset", ref Position, 1f, -4000, 4000);
+        //     changed |= ImGui.DragFloat2("Padding", ref Padding, 1f, -100, 100);
+        //     changed |= ImGui.DragFloat2("Mana Bar Size", ref ManaBarSize, 1f, 1, 2000);
+        //     changed |= ImGui.DragFloat2("Umbral Heart Size", ref UmbralHeartSize, 1f, 1, 2000);
+        //     changed |= ImGui.DragFloat2("Polyglot Size", ref PolyglotSize, 1f, 1, 2000);
+        //
+        //     changed |= ImGui.Checkbox("Show Mana Value", ref ShowManaValue);
+        //     changed |= ImGui.Checkbox("Show Mana Threshold Marker During Astral Fire", ref ShowManaThresholdMarker);
+        //     changed |= ImGui.DragInt("Mana Threshold Marker Value", ref ManaThresholdValue, 1f, 1, 10000);
+        //     
+        //     changed |= ImGui.Checkbox("Show Triplecast", ref ShowTripleCast);
+        //     changed |= ImGui.DragFloat2("Triplecast Size", ref TripleCastSize, 1f, 1, 2000);
+        //     
+        //     changed |= ImGui.Checkbox("Show Firestarter Procs", ref ShowFirestarterProcs);
+        //     changed |= ImGui.Checkbox("Show Thundercloud Procs", ref ShowThundercloudProcs);
+        //
+        //     changed |= ImGui.DragInt("Procs Height", ref ProcsHeight, .1f, 1, 2000);
+        //
+        //     changed |= ImGui.Checkbox("Show DoT Timer", ref ShowDotTimer);
+        //     changed |= ImGui.DragInt("DoT Timer Height", ref DotTimerHeight, .1f, 1, 2000);
+        //
+        //     changed |= ColorEdit4("Mana Bar Color", ref ManaBarNoElementColor);
+        //     changed |= ColorEdit4("Mana Bar Ice Color", ref ManaBarIceColor);
+        //     changed |= ColorEdit4("Mana Bar Fire Color", ref ManaBarFireColor);
+        //     changed |= ColorEdit4("Umbral Heart Color", ref UmbralHeartColor);
+        //     changed |= ColorEdit4("Polyglot Color", ref PolyglotColor);
+        //     changed |= ColorEdit4("Triplecast Color", ref TriplecastColor);
+        //     changed |= ColorEdit4("Firestarter Proc Color", ref FirestarterColor);
+        //     changed |= ColorEdit4("Thundercloud Proc Color", ref ThundercloudColor);
+        //     changed |= ColorEdit4("DoT Timer Color", ref DotColor);
+        //
+        //     return changed;
+        // }
     }
 }

--- a/DelvUI/Interface/BlackMageHudWindow.cs
+++ b/DelvUI/Interface/BlackMageHudWindow.cs
@@ -1,19 +1,21 @@
 ﻿using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
 using DelvUI.Config;
+using DelvUI.Config.Attributes;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using DelvUI.Config.Attributes;
 
-namespace DelvUI.Interface {
-    public class BlackMageHudWindow : HudWindow {
+namespace DelvUI.Interface
+{
+    public class BlackMageHudWindow : HudWindow
+    {
         public override uint JobId => Jobs.BLM;
-        
-        private BlackMageHudConfig _config => (BlackMageHudConfig) ConfigurationManager.GetInstance().GetConfiguration(new BlackMageHudConfig());
+
+        private BlackMageHudConfig _config => (BlackMageHudConfig)ConfigurationManager.GetInstance().GetConfiguration(new BlackMageHudConfig());
 
         private float OriginX => CenterX + _config.Position.X;
         private float OriginY => CenterY + YOffset + _config.Position.Y;
@@ -22,27 +24,32 @@ namespace DelvUI.Interface {
         public BlackMageHudWindow(DalamudPluginInterface pluginInterface, PluginConfiguration pluginConfiguration)
             : base(pluginInterface, pluginConfiguration) { }
 
-        protected override void Draw(bool _) {
+        protected override void Draw(bool _)
+        {
             DrawManaBar();
             DrawUmbralHeartStacks();
             DrawPolyglot();
 
-            if (_config.ShowTripleCast) {
+            if (_config.ShowTripleCast)
+            {
                 DrawTripleCast();
             }
 
-            if (_config.ShowFirestarterProcs || _config.ShowThundercloudProcs) {
+            if (_config.ShowFirestarterProcs || _config.ShowThundercloudProcs)
+            {
                 DrawProcs();
             }
 
-            if (_config.ShowDotTimer) {
+            if (_config.ShowDotTimer)
+            {
                 DrawDotTimer();
             }
         }
 
         protected override void DrawPrimaryResourceBar() { }
 
-        protected virtual void DrawManaBar() {
+        protected virtual void DrawManaBar()
+        {
             var gauge = PluginInterface.ClientState.JobGauges.Get<BLMGauge>();
 
             var actor = PluginInterface.ClientState.LocalPlayer;
@@ -53,19 +60,21 @@ namespace DelvUI.Interface {
                 ? _config.ManaBarFireColor.Map
                 : gauge.InUmbralIce() ? _config.ManaBarIceColor.Map : _config.ManaBarNoElementColor.Map;
 
-            var builder = BarBuilder.Create(OriginX - barSize.X / 2, OriginY - barSize.Y, (int) barSize.Y, (int) barSize.X);
+            var builder = BarBuilder.Create(OriginX - barSize.X / 2, OriginY - barSize.Y, (int)barSize.Y, (int)barSize.X);
 
             builder.AddInnerBar(actor.CurrentMp, actor.MaxMp, color).SetBackgroundColor(EmptyColor["background"]);
 
             // element timer
-            if (gauge.InAstralFire() || gauge.InUmbralIce()) {
+            if (gauge.InAstralFire() || gauge.InUmbralIce())
+            {
                 var time = gauge.ElementTimeRemaining > 10 ? gauge.ElementTimeRemaining / 1000 + 1 : 0;
                 builder.SetTextMode(BarTextMode.Single);
                 builder.SetText(BarTextPosition.CenterMiddle, BarTextType.Custom, $"{time,0}");
             }
 
             // enochian
-            if (gauge.IsEnoActive()) {
+            if (gauge.IsEnoActive())
+            {
                 builder.SetGlowSize(2);
                 builder.SetGlowColor(0x88FFFFFF);
             }
@@ -74,7 +83,8 @@ namespace DelvUI.Interface {
             builder.Build().Draw(drawList, PluginConfiguration);
 
             // threshold marker
-            if (_config.ShowManaThresholdMarker && gauge.InAstralFire()) {
+            if (_config.ShowManaThresholdMarker && gauge.InAstralFire())
+            {
                 var position = new Vector2(OriginX - barSize.X / 2 + _config.ManaThresholdValue / 10000f * barSize.X, cursorPos.Y + barSize.Y);
                 var size = new Vector2(3, barSize.Y);
 
@@ -89,7 +99,8 @@ namespace DelvUI.Interface {
             }
 
             // mana
-            if (_config.ShowManaValue) {
+            if (_config.ShowManaValue)
+            {
                 var mana = PluginInterface.ClientState.LocalPlayer.CurrentMp;
                 var text = $"{mana,0}";
                 var textSize = ImGui.CalcTextSize(text);
@@ -97,7 +108,8 @@ namespace DelvUI.Interface {
             }
         }
 
-        protected virtual void DrawUmbralHeartStacks() {
+        protected virtual void DrawUmbralHeartStacks()
+        {
             var gauge = PluginInterface.ClientState.JobGauges.Get<BLMGauge>();
 
             var totalWidth = _config.UmbralHeartSize.X * 3 + _config.Padding.X * 2;
@@ -114,12 +126,14 @@ namespace DelvUI.Interface {
             bar.Draw(drawList, PluginConfiguration);
         }
 
-        protected virtual void DrawPolyglot() {
+        protected virtual void DrawPolyglot()
+        {
             var gauge = PluginInterface.ClientState.JobGauges.Get<BLMGauge>();
             var totalWidth = _config.PolyglotSize.X * 2 + _config.Padding.X;
             var y = OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y - _config.Padding.Y - _config.PolyglotSize.Y;
 
-            if (_config.ShowTripleCast) {
+            if (_config.ShowTripleCast)
+            {
                 y = y - _config.Padding.Y - _config.TripleCastSize.Y;
             }
 
@@ -131,7 +145,8 @@ namespace DelvUI.Interface {
                                     .AddInnerBar(gauge.NumPolyglotStacks < 1 ? scale : 1, 1, _config.PolyglotColor.Map)
                                     .SetBackgroundColor(EmptyColor["background"]);
 
-            if (gauge.NumPolyglotStacks >= 1) {
+            if (gauge.NumPolyglotStacks >= 1)
+            {
                 builder.SetGlowColor(0x88FFFFFF);
             }
 
@@ -150,14 +165,16 @@ namespace DelvUI.Interface {
                                 )
                                 .SetBackgroundColor(EmptyColor["background"]);
 
-            if (gauge.NumPolyglotStacks == 2) {
+            if (gauge.NumPolyglotStacks == 2)
+            {
                 builder.SetGlowColor(0x88FFFFFF);
             }
 
             builder.Build().Draw(drawList, PluginConfiguration);
         }
 
-        protected virtual void DrawTripleCast() {
+        protected virtual void DrawTripleCast()
+        {
             var tripleStackBuff = PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 1211);
 
             var totalWidth = _config.TripleCastSize.X * 3 + _config.Padding.X * 2;
@@ -178,17 +195,19 @@ namespace DelvUI.Interface {
             bar.Draw(drawList, PluginConfiguration);
         }
 
-        protected virtual void DrawProcs() {
+        protected virtual void DrawProcs()
+        {
             var firestarterTimer = _config.ShowFirestarterProcs
                 ? Math.Abs(PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 165).Duration)
-               
+
                 : 0;
 
             var thundercloudTimer = _config.ShowThundercloudProcs
                 ? Math.Abs(PluginInterface.ClientState.LocalPlayer.StatusEffects.FirstOrDefault(o => o.EffectId == 164).Duration)
                 : 0;
 
-            if (firestarterTimer == 0 && thundercloudTimer == 0) {
+            if (firestarterTimer == 0 && thundercloudTimer == 0)
+            {
                 return;
             }
 
@@ -196,12 +215,14 @@ namespace DelvUI.Interface {
             var x = OriginX - _config.Padding.X * 2f - _config.PolyglotSize.X;
             var y = OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y - _config.Padding.Y - _config.PolyglotSize.Y / 2f + _config.ProcsHeight;
 
-            if (_config.ShowTripleCast) {
+            if (_config.ShowTripleCast)
+            {
                 y = y - _config.Padding.Y - _config.TripleCastSize.Y;
             }
 
             // fire starter
-            if (firestarterTimer > 0) {
+            if (firestarterTimer > 0)
+            {
                 var position = new Vector2(x, y - totalHeight / 2f);
                 var scale = firestarterTimer / 18f;
 
@@ -209,7 +230,8 @@ namespace DelvUI.Interface {
             }
 
             // thundercloud
-            if (thundercloudTimer > 0) {
+            if (thundercloudTimer > 0)
+            {
                 var position = new Vector2(x, firestarterTimer == 0 ? y - totalHeight / 2f : y + _config.Padding.Y / 2f);
                 var scale = thundercloudTimer / 18f;
 
@@ -217,38 +239,44 @@ namespace DelvUI.Interface {
             }
         }
 
-        protected virtual void DrawDotTimer() {
+        protected virtual void DrawDotTimer()
+        {
             var target = PluginInterface.ClientState.Targets.SoftTarget ?? PluginInterface.ClientState.Targets.CurrentTarget;
 
-            if (target is null) {
+            if (target is null)
+            {
                 return;
             }
 
             // thunder 1 to 4
-            int[] dotIDs = {161, 162, 163, 1210};
-            float[] dotDurations = {12, 18, 24, 18};
+            int[] dotIDs = { 161, 162, 163, 1210 };
+            float[] dotDurations = { 12, 18, 24, 18 };
 
             float timer = 0;
             float maxDuration = 1;
 
-            for (var i = 0; i < 4; i++) {
+            for (var i = 0; i < 4; i++)
+            {
                 timer = target.StatusEffects.FirstOrDefault(o => o.EffectId == dotIDs[i] && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId).Duration;
 
-                if (timer > 0) {
+                if (timer > 0)
+                {
                     maxDuration = dotDurations[i];
 
                     break;
                 }
             }
 
-            if (timer == 0) {
+            if (timer == 0)
+            {
                 return;
             }
 
             var x = OriginX + _config.Padding.X * 2f + _config.PolyglotSize.X;
             var y = OriginY - _config.ManaBarSize.Y - _config.Padding.Y - _config.UmbralHeartSize.Y - _config.Padding.Y - _config.PolyglotSize.Y / 2f - _config.DotTimerHeight;
 
-            if (_config.ShowTripleCast) {
+            if (_config.ShowTripleCast)
+            {
                 y = y - _config.Padding.Y - _config.TripleCastSize.Y;
             }
 
@@ -258,7 +286,8 @@ namespace DelvUI.Interface {
             DrawTimerBar(position, scale, _config.DotTimerHeight, _config.DotColor.Map, false);
         }
 
-        private void DrawTimerBar(Vector2 position, float scale, float height, Dictionary<string, uint> colorMap, bool inverted) {
+        private void DrawTimerBar(Vector2 position, float scale, float height, Dictionary<string, uint> colorMap, bool inverted)
+        {
             var drawList = ImGui.GetWindowDrawList();
             var size = new Vector2((_config.ManaBarSize.X / 2f - _config.PolyglotSize.X - _config.Padding.X * 2f) * scale, height);
             size.X = Math.Max(1, size.X);
@@ -282,7 +311,8 @@ namespace DelvUI.Interface {
     [Section("Job Specific Bars")]
     [SubSection("Caster", 0)]
     [SubSection("Black Mage", 1)]
-    public class BlackMageHudConfig : PluginConfigObject {
+    public class BlackMageHudConfig : PluginConfigObject
+    {
         [DragFloat2("Base Offset", min = -4000f, max = 4000f)]
         public Vector2 Position = new Vector2(0, -2);
 

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -159,7 +159,8 @@ namespace DelvUI
             }
         }
 
-        private void NewConfigMenuCommand(string command, string arguments) {
+        private void NewConfigMenuCommand(string command, string arguments) 
+        {
             ConfigurationManager.GetInstance().DrawConfigWindow = !ConfigurationManager.GetInstance().DrawConfigWindow;
         }
 

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -159,15 +159,11 @@ namespace DelvUI
             }
         }
 
-        private void NewConfigMenuCommand(string command, string arguments)
-        {
+        private void NewConfigMenuCommand(string command, string arguments) {
             ConfigurationManager.GetInstance().DrawConfigWindow = !ConfigurationManager.GetInstance().DrawConfigWindow;
         }
 
-        private void ReloadConfigCommand(string command, string arguments)
-        {
-            ConfigurationManager.GetInstance().LoadConfigurations();
-        }
+        private void ReloadConfigCommand(string command, string arguments) { ConfigurationManager.GetInstance().LoadConfigurations(); }
 
         private void Draw()
         {

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -159,7 +159,7 @@ namespace DelvUI
             }
         }
 
-        private void NewConfigMenuCommand(string command, string arguments) 
+        private void NewConfigMenuCommand(string command, string arguments)
         {
             ConfigurationManager.GetInstance().DrawConfigWindow = !ConfigurationManager.GetInstance().DrawConfigWindow;
         }

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -275,7 +275,6 @@ namespace DelvUI
             _configurationWindow.IsVisible = false;
 
             ConfigurationManager.GetInstance().DrawConfigWindow = false;
-            ConfigurationManager.GetInstance().Dispose();
 
             if (_hudWindow != null)
             {


### PR DESCRIPTION
Closes #105.
This PR aims to completely replace the current config system with a new system that will: 
1. Split the PluginConfiguration code into relevant sections 
2. Split the config file into individual json files on disk 
3. Dynamically draw the configuration window based upon the fields in each configuration object
4. Allow versioning of each config object to better support breaking config changes.
Of these four, currently the first three are implemented in the framework, but the vast majority of the configuration needs to be moved to the new system (only BLM is currently implemented).
Currently there is an issue where in configuration files can be loaded when the plugin is first loaded, however if the plugin is the unloaded and reloaded, Json.NET fails to read the configuration files. While this wouldn't be an issue for users, it would severely hurt developers.
Due to both the incompleteness of the current solution and the aforementioned bug this PR should not be merged and just used for review to see whether there is an agreement on using this approach.