### PR TITLE
Feat: Configuration collapsible categories

### DIFF
--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -98,4 +98,41 @@ namespace DelvUI.Config.Attributes
 
         public ColorEdit4Attribute(string friendlyName) { this.friendlyName = friendlyName; }
     }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class OrderAttribute : Attribute
+    {
+        public int pos;
+
+        public OrderAttribute(int pos)
+        {
+            this.pos = pos;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class CollapseControlAttribute : Attribute
+    {
+        public int pos;
+        public int id;
+
+        public CollapseControlAttribute(int pos, int id)
+        {
+            this.pos = pos;
+            this.id = id;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class CollapseWithAttribute : Attribute
+    {
+        public int pos;
+        public int id;
+
+        public CollapseWithAttribute(int pos, int id)
+        {
+            this.pos = pos;
+            this.id = id;
+        }
+    }
 }

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -1,13 +1,12 @@
+using DelvUI.Config.Attributes;
+using ImGuiNET;
+using ImGuiScene;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Numerics;
-using System.Reflection;
-using DelvUI.Config.Attributes;
-using ImGuiNET;
-using ImGuiScene;
-using Newtonsoft.Json;
 using System.Reflection;
 
 namespace DelvUI.Config.Tree
@@ -488,7 +487,8 @@ namespace DelvUI.Config.Tree
             // While in general use this is important as the conversion from the superclass 'PluginConfigObject' to a specific subclass (e.g. 'BlackMageHudConfig') would
             // be handled by Json.NET, when the plugin is reloaded with a different assembly (as is the case when using LivePluginLoader, or updating the plugin in-game)
             // it fails. In order to fix this we need to specify the specific subclass, in order to do this during runtime we must use reflection to set the generic.
-            if (ConfigObject.GetType().BaseType == typeof(PluginConfigObject)) {
+            if (ConfigObject.GetType().BaseType == typeof(PluginConfigObject))
+            {
                 var methodInfo = GetType().GetMethod("LoadForType");
                 var function = methodInfo.MakeGenericMethod(ConfigObject.GetType());
                 ConfigObject = (PluginConfigObject)function.Invoke(this, new object[] { finalPath.FullName });
@@ -528,7 +528,7 @@ namespace DelvUI.Config.Tree
         public void Draw(ref bool changed)
         {
             Draw(ref changed, MainField, 0);
-            if (CategoryId != -1 && (bool) MainField.GetValue(ConfigObject))
+            if (CategoryId != -1 && (bool)MainField.GetValue(ConfigObject))
             {
                 ImGui.BeginGroup();
                 ImGui.SetCursorPos(ImGui.GetCursorPos() + new Vector2(0, 2));

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -8,6 +8,7 @@ using DelvUI.Config.Attributes;
 using ImGuiNET;
 using ImGuiScene;
 using Newtonsoft.Json;
+using System.Reflection;
 
 namespace DelvUI.Config.Tree
 {
@@ -400,94 +401,69 @@ namespace DelvUI.Config.Tree
 
         public override void Draw(ref bool changed)
         {
-            FieldInfo[] fields = ConfigObject.GetType().GetFields();
+            var fields = ConfigObject.GetType().GetFields();
+            var drawList = new List<KeyValuePair<int, CategoryField>>();
+            var collapseWithList = new List<FieldInfo>();
 
             foreach (FieldInfo field in fields)
             {
-                var fieldVal = field.GetValue(ConfigObject);
-
+                var hasOrderAttribute = false;
                 foreach (var attribute in field.GetCustomAttributes(true))
                 {
-                    if (attribute is CheckboxAttribute checkboxAttribute)
+                    if (attribute is OrderAttribute orderAttribute)
                     {
-                        var boolVal = (bool)fieldVal;
-
-                        if (ImGui.Checkbox(checkboxAttribute.friendlyName, ref boolVal))
-                        {
-                            field.SetValue(ConfigObject, boolVal);
-                            changed = true;
-                        }
+                        drawList.Add(new KeyValuePair<int, CategoryField>(orderAttribute.pos, new CategoryField(field, ConfigObject)));
+                        hasOrderAttribute = true;
                     }
-                    else if (attribute is DragFloatAttribute dragFloatAttribute)
+                    else if (attribute is CollapseControlAttribute collapseControlAtrribute)
                     {
-                        var floatVal = (float)fieldVal;
-
-                        if (ImGui.DragFloat(dragFloatAttribute.friendlyName, ref floatVal, dragFloatAttribute.velocity, dragFloatAttribute.min, dragFloatAttribute.max))
-                        {
-                            field.SetValue(ConfigObject, floatVal);
-                            changed = true;
-                        }
+                        CategoryField categoryField = new CategoryField(field, ConfigObject);
+                        categoryField.CategoryId = collapseControlAtrribute.id;
+                        drawList.Add(new KeyValuePair<int, CategoryField>(collapseControlAtrribute.pos, categoryField));
+                        hasOrderAttribute = true;
                     }
-                    else if (attribute is DragIntAttribute dragIntAttribute)
+                    else if (attribute is CollapseWithAttribute collapseWithAttribute)
                     {
-                        var intVal = (int)fieldVal;
-
-                        if (ImGui.DragInt(dragIntAttribute.friendlyName, ref intVal, dragIntAttribute.velocity, dragIntAttribute.min, dragIntAttribute.max))
-                        {
-                            field.SetValue(ConfigObject, intVal);
-                            changed = true;
-                        }
-                    }
-                    else if (attribute is DragFloat2Attribute dragFloat2Attribute)
-                    {
-                        Vector2 floatVal = (Vector2)fieldVal;
-
-                        if (ImGui.DragFloat2(dragFloat2Attribute.friendlyName, ref floatVal, dragFloat2Attribute.velocity, dragFloat2Attribute.min, dragFloat2Attribute.max))
-                        {
-                            field.SetValue(ConfigObject, floatVal);
-                            changed = true;
-                        }
-                    }
-                    else if (attribute is DragInt2Attribute dragInt2Attribute)
-                    {
-                        Vector2 intVal = (Vector2)fieldVal;
-
-                        if (ImGui.DragFloat2(dragInt2Attribute.friendlyName, ref intVal, dragInt2Attribute.velocity, dragInt2Attribute.min, dragInt2Attribute.max))
-                        {
-                            field.SetValue(ConfigObject, intVal);
-                            changed = true;
-                        }
-                    }
-                    else if (attribute is InputTextAttribute inputTextAttribute)
-                    {
-                        var stringVal = (string)fieldVal;
-
-                        if (ImGui.InputText(inputTextAttribute.friendlyName, ref stringVal, inputTextAttribute.maxLength))
-                        {
-                            field.SetValue(ConfigObject, stringVal);
-                            changed = true;
-                        }
-                    }
-                    else if (attribute is ColorEdit4Attribute colorEdit4Attribute)
-                    {
-                        PluginConfigColor colorVal = (PluginConfigColor)fieldVal;
-                        Vector4 vector = colorVal.Vector;
-
-                        if (ImGui.ColorEdit4(colorEdit4Attribute.friendlyName, ref vector))
-                        {
-                            colorVal.Vector = vector;
-                            field.SetValue(ConfigObject, colorVal);
-                            changed = true;
-                        }
+                        collapseWithList.Add(field);
+                        hasOrderAttribute = true;
                     }
                 }
+                if (!hasOrderAttribute)
+                {
+                    drawList.Add(new KeyValuePair<int, CategoryField>(int.MaxValue, new CategoryField(field, ConfigObject)));
+                }
+            }
+
+            foreach (var field in collapseWithList)
+            {
+                foreach (var attribute in field.GetCustomAttributes(true))
+                {
+                    if (attribute is CollapseWithAttribute collapseWithAttribute)
+                    {
+                        foreach (var categoryField in drawList)
+                        {
+                            if (categoryField.Value.CategoryId == collapseWithAttribute.id)
+                            {
+                                categoryField.Value.AddChild(collapseWithAttribute.pos, field);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+
+            drawList.Sort((x, y) => x.Key - y.Key);
+            foreach (var pair in drawList)
+            {
+                pair.Value.Draw(ref changed);
             }
         }
 
         public override void Save(string path)
         {
             Directory.CreateDirectory(path);
-            var finalPath = path + ".json";
+            string finalPath = path + ".json";
 
             File.WriteAllText(
                 finalPath,
@@ -501,7 +477,7 @@ namespace DelvUI.Config.Tree
 
         public override void Load(string path)
         {
-            FileInfo finalPath = new FileInfo(path + ".json");
+            var finalPath = new FileInfo(path + ".json");
 
             if (!finalPath.Exists)
             {
@@ -512,21 +488,140 @@ namespace DelvUI.Config.Tree
             // While in general use this is important as the conversion from the superclass 'PluginConfigObject' to a specific subclass (e.g. 'BlackMageHudConfig') would
             // be handled by Json.NET, when the plugin is reloaded with a different assembly (as is the case when using LivePluginLoader, or updating the plugin in-game)
             // it fails. In order to fix this we need to specify the specific subclass, in order to do this during runtime we must use reflection to set the generic.
-            if (ConfigObject.GetType().BaseType == typeof(PluginConfigObject))
-            {
-                MethodInfo methodInfo = GetType().GetMethod("LoadForType");
-                MethodInfo function = methodInfo.MakeGenericMethod(ConfigObject.GetType());
+            if (ConfigObject.GetType().BaseType == typeof(PluginConfigObject)) {
+                var methodInfo = GetType().GetMethod("LoadForType");
+                var function = methodInfo.MakeGenericMethod(ConfigObject.GetType());
                 ConfigObject = (PluginConfigObject)function.Invoke(this, new object[] { finalPath.FullName });
             }
         }
 
         public T LoadForType<T>(string path) where T : PluginConfigObject
         {
-            FileInfo file = new FileInfo(path);
+            var file = new FileInfo(path);
 
             return JsonConvert.DeserializeObject<T>(File.ReadAllText(file.FullName));
         }
 
         public override ConfigPageNode GetOrAddConfig(PluginConfigObject configObject) => this;
+    }
+
+    public class CategoryField
+    {
+        public SortedDictionary<int, FieldInfo> Children;
+        public FieldInfo MainField;
+        public PluginConfigObject ConfigObject;
+        public int CategoryId;
+
+        public CategoryField(FieldInfo mainField, PluginConfigObject configObject)
+        {
+            MainField = mainField;
+            ConfigObject = configObject;
+            CategoryId = -1;
+            Children = new SortedDictionary<int, FieldInfo>();
+        }
+
+        public void AddChild(int position, FieldInfo field)
+        {
+            Children.Add(position, field);
+        }
+
+        public void Draw(ref bool changed)
+        {
+            Draw(ref changed, MainField, 0);
+            if (CategoryId != -1 && (bool) MainField.GetValue(ConfigObject))
+            {
+                ImGui.BeginGroup();
+                ImGui.SetCursorPos(ImGui.GetCursorPos() + new Vector2(0, 2));
+                foreach (var child in Children.Values)
+                {
+                    Draw(ref changed, child, 4);
+                }
+                ImGui.EndGroup();
+                ImGui.GetWindowDrawList().AddRect(ImGui.GetItemRectMin() + new Vector2(0, -2), ImGui.GetItemRectMax() + new Vector2(ImGui.GetContentRegionAvail().X - ImGui.GetItemRectMax().X + ImGui.GetItemRectMin().X - 4, 4), 0xFF4A4141);
+                ImGui.SetCursorPos(ImGui.GetCursorPos() + new Vector2(0, 2));
+            }
+        }
+
+        public void Draw(ref bool changed, FieldInfo field, int xOffset)
+        {
+            ImGui.SetCursorPos(ImGui.GetCursorPos() + new Vector2(xOffset, 0));
+            object fieldVal = field.GetValue(ConfigObject);
+
+            foreach (var attribute in field.GetCustomAttributes(true))
+            {
+                if (attribute is CheckboxAttribute checkboxAttribute)
+                {
+                    bool boolVal = (bool)fieldVal;
+
+                    if (ImGui.Checkbox(checkboxAttribute.friendlyName, ref boolVal))
+                    {
+                        field.SetValue(ConfigObject, boolVal);
+                        changed = true;
+                    }
+                }
+                else if (attribute is DragFloatAttribute dragFloatAttribute)
+                {
+                    float floatVal = (float)fieldVal;
+
+                    if (ImGui.DragFloat(dragFloatAttribute.friendlyName, ref floatVal, dragFloatAttribute.velocity, dragFloatAttribute.min, dragFloatAttribute.max))
+                    {
+                        field.SetValue(ConfigObject, floatVal);
+                        changed = true;
+                    }
+                }
+                else if (attribute is DragIntAttribute dragIntAttribute)
+                {
+                    int intVal = (int)fieldVal;
+
+                    if (ImGui.DragInt(dragIntAttribute.friendlyName, ref intVal, dragIntAttribute.velocity, dragIntAttribute.min, dragIntAttribute.max))
+                    {
+                        field.SetValue(ConfigObject, intVal);
+                        changed = true;
+                    }
+                }
+                else if (attribute is DragFloat2Attribute dragFloat2Attribute)
+                {
+                    Vector2 floatVal = (Vector2)fieldVal;
+
+                    if (ImGui.DragFloat2(dragFloat2Attribute.friendlyName, ref floatVal, dragFloat2Attribute.velocity, dragFloat2Attribute.min, dragFloat2Attribute.max))
+                    {
+                        field.SetValue(ConfigObject, floatVal);
+                        changed = true;
+                    }
+                }
+                else if (attribute is DragInt2Attribute dragInt2Attribute)
+                {
+                    Vector2 intVal = (Vector2)fieldVal;
+
+                    if (ImGui.DragFloat2(dragInt2Attribute.friendlyName, ref intVal, dragInt2Attribute.velocity, dragInt2Attribute.min, dragInt2Attribute.max))
+                    {
+                        field.SetValue(ConfigObject, intVal);
+                        changed = true;
+                    }
+                }
+                else if (attribute is InputTextAttribute inputTextAttribute)
+                {
+                    string stringVal = (string)fieldVal;
+
+                    if (ImGui.InputText(inputTextAttribute.friendlyName, ref stringVal, inputTextAttribute.maxLength))
+                    {
+                        field.SetValue(ConfigObject, stringVal);
+                        changed = true;
+                    }
+                }
+                else if (attribute is ColorEdit4Attribute colorEdit4Attribute)
+                {
+                    PluginConfigColor colorVal = (PluginConfigColor)fieldVal;
+                    var vector = colorVal.Vector;
+
+                    if (ImGui.ColorEdit4(colorEdit4Attribute.friendlyName, ref vector))
+                    {
+                        colorVal.Vector = vector;
+                        field.SetValue(ConfigObject, colorVal);
+                        changed = true;
+                    }
+                }
+            }
+        }
     }
 }

--- a/DelvUI/Interface/AstrologianHudWindow.cs
+++ b/DelvUI/Interface/AstrologianHudWindow.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using Dalamud.Game.ClientState.Actors.Types;
+﻿using Dalamud.Game.ClientState.Actors.Types;
 using Dalamud.Game.ClientState.Structs;
 using Dalamud.Game.ClientState.Structs.JobGauge;
 using Dalamud.Plugin;
@@ -13,6 +7,12 @@ using DelvUI.Config.Attributes;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using Actor = Dalamud.Game.ClientState.Actors.Types.Actor;
 
 namespace DelvUI.Interface
@@ -592,7 +592,7 @@ namespace DelvUI.Interface
         [CollapseWith(20, 1)]
         public PluginConfigColor SealLunarColor = new(new Vector4(241f / 255f, 217f / 255f, 125f / 255f, 100f / 100f));
 
-        [ColorEdit4("Seal Celestial Color")] 
+        [ColorEdit4("Seal Celestial Color")]
         [CollapseWith(25, 1)]
         public PluginConfigColor SealCelestialColor = new(new Vector4(100f / 255f, 207f / 255f, 211f / 255f, 100f / 100f));
 

--- a/DelvUI/Interface/AstrologianHudWindow.cs
+++ b/DelvUI/Interface/AstrologianHudWindow.cs
@@ -485,6 +485,7 @@ namespace DelvUI.Interface
         #region Base Offset
 
         [DragFloat2("Base Offset Position", min = -2000f, max = 2000f)]
+        [Order(0)]
         public Vector2 BaseOffset = new(0, 0);
 
         #endregion
@@ -492,6 +493,7 @@ namespace DelvUI.Interface
         #region Primary Resource Bar
 
         [Checkbox("Show Primary Resource Bar")]
+        [Order(5)]
         public bool ShowPrimaryResourceBar = true;
 
         #endregion
@@ -499,51 +501,67 @@ namespace DelvUI.Interface
         #region Draw Bar
 
         [Checkbox("Show Draw Bar")]
+        [CollapseControl(10, 0)]
         public bool ShowDrawBar = true;
 
         [DragFloat2("Draw Bar Size", min = 1f, max = 200f)]
+        [CollapseWith(0, 0)]
         public Vector2 DrawBarSize = new(20, 254);
 
         [DragFloat2("Draw Bar Position", min = -2000f, max = 2000f)]
+        [CollapseWith(5, 0)]
         public Vector2 DrawBarPosition = new(33, -43);
 
         [ColorEdit4("Draw on CD Color")]
+        [CollapseWith(10, 0)]
         public PluginConfigColor DrawCdColor = new(new Vector4(26f / 255f, 167f / 255f, 109f / 255f, 100f / 100f));
 
         [ColorEdit4("Draw Ready Color")]
+        [CollapseWith(15, 0)]
         public PluginConfigColor DrawCdReadyColor = new(new Vector4(137f / 255f, 26f / 255f, 42f / 255f, 100f / 100f));
 
         [ColorEdit4("Draw Melee Glow Color")]
+        [CollapseWith(20, 0)]
         public PluginConfigColor DrawMeleeGlowColor = new(new Vector4(83f / 255f, 34f / 255f, 120f / 255f, 100f / 100f));
 
         [ColorEdit4("Draw Ranged Glow Color")]
+        [CollapseWith(25, 0)]
         public PluginConfigColor DrawRangedGlowColor = new(new Vector4(124f / 255f, 34f / 255f, 120f / 255f, 100f / 100f));
 
         [Checkbox("Show card preferred target with glow")]
+        [CollapseWith(30, 0)]
         public bool ShowDrawGlowBar;
 
         [Checkbox("Show card preferred target with text")]
+        [CollapseWith(35, 0)]
         public bool ShowDrawTextBar = true;
 
         [Checkbox("Show Draw Timer")]
+        [CollapseWith(40, 0)]
         public bool ShowDrawCooldownTextBar = true;
 
         [Checkbox("Enable Redraw Stacks & Cooldown")]
+        [CollapseWith(45, 0)]
         public bool ShowRedrawBar = true;
 
         [Checkbox("Show Redraw Timer")]
+        [CollapseWith(50, 0)]
         public bool ShowRedrawCooldownTextBar = true;
 
         [Checkbox("Show Redraw Stacks")]
+        [CollapseWith(55, 0)]
         public bool ShowRedrawTextBar = true;
 
         [Checkbox("Change next Redraw cooldown to total Redraw cooldown")]
+        [CollapseWith(60, 0)]
         public bool EnableRedrawCooldownCumulated;
 
         [Checkbox("Change Draw timer to decimal")]
+        [CollapseWith(65, 0)]
         public bool EnableDecimalDrawBar;
 
         [Checkbox("Change Redraw timer to decimal")]
+        [CollapseWith(70, 0)]
         public bool EnableDecimalRedrawBar;
 
         #endregion
@@ -551,33 +569,43 @@ namespace DelvUI.Interface
         #region Divination Bar
 
         [Checkbox("Show Divination Bar")]
+        [CollapseControl(15, 1)]
         public bool ShowDivinationBar = true;
 
         [DragFloat2("Divination Bar Size", min = 1f, max = 200f)]
+        [CollapseWith(0, 1)]
         public Vector2 DivinationBarSize = new(10, 254);
 
         [DragFloat2("Divination Bar Position", min = -2000f, max = 2000f)]
+        [CollapseWith(5, 1)]
         public Vector2 DivinationBarPosition = new(33, -77);
 
         [DragInt("Divination Bar Padding Offset", min = -1000, max = 1000)]
+        [CollapseWith(10, 1)]
         public int DivinationBarPad = 1;
 
         [ColorEdit4("Seal Sun Color")]
+        [CollapseWith(15, 1)]
         public PluginConfigColor SealSunColor = new(new Vector4(213f / 255f, 124f / 255f, 97f / 255f, 100f / 100f));
 
         [ColorEdit4("Seal Lunar Color")]
+        [CollapseWith(20, 1)]
         public PluginConfigColor SealLunarColor = new(new Vector4(241f / 255f, 217f / 255f, 125f / 255f, 100f / 100f));
 
-        [ColorEdit4("Seal Celestial Color")]
+        [ColorEdit4("Seal Celestial Color")] 
+        [CollapseWith(25, 1)]
         public PluginConfigColor SealCelestialColor = new(new Vector4(100f / 255f, 207f / 255f, 211f / 255f, 100f / 100f));
 
         [ColorEdit4("Divination Glow Color")]
+        [CollapseWith(30, 1)]
         public PluginConfigColor DivinationGlowColor = new(new Vector4(255f / 255f, 199f / 255f, 62f / 255f, 100f / 100f));
 
         [Checkbox("Show numbers of different seals for Divination with glow")]
+        [CollapseWith(35, 1)]
         public bool ShowDivinationGlowBar = true;
 
         [Checkbox("Show numbers of different seals for Divination with text")]
+        [CollapseWith(40, 1)]
         public bool ShowDivinationTextBar;
 
         #endregion
@@ -585,21 +613,27 @@ namespace DelvUI.Interface
         #region Dot Bar
 
         [Checkbox("Show Dot Bar")]
+        [CollapseControl(20, 2)]
         public bool ShowDotBar = true;
 
         [DragFloat2("Dot Bar Size", min = 1f, max = 200f)]
+        [CollapseWith(0, 2)]
         public Vector2 DotBarSize = new(20, 84);
 
         [DragFloat2("Dot Bar Position", min = -2000f, max = 2000f)]
+        [CollapseWith(5, 2)]
         public Vector2 DotBarPosition = new(118, -65);
 
         [ColorEdit4("Dot Color")]
+        [CollapseWith(10, 2)]
         public PluginConfigColor DotColor = new(new Vector4(20f / 255f, 80f / 255f, 168f / 255f, 100f / 100f));
 
         [Checkbox("Show Dot timer")]
+        [CollapseWith(15, 2)]
         public bool ShowDotTextBar = true;
 
         [Checkbox("Change Dot timer to decimal")]
+        [CollapseWith(20, 2)]
         public bool EnableDecimalDotBar;
 
         #endregion
@@ -607,30 +641,39 @@ namespace DelvUI.Interface
         #region Star Bar
 
         [Checkbox("Show Star Bar")]
+        [CollapseControl(25, 3)]
         public bool ShowStarBar = true;
 
         [DragFloat2("Star Bar Size", min = 1f, max = 200f)]
+        [CollapseWith(0, 3)]
         public Vector2 StarBarSize = new(20, 84);
 
         [DragFloat2("Star Bar Position", min = -2000f, max = 2000f)]
+        [CollapseWith(5, 3)]
         public Vector2 StarBarPosition = new(33, -65);
 
         [ColorEdit4("Star Earthly Color")]
+        [CollapseWith(10, 3)]
         public PluginConfigColor StarEarthlyColor = new(new Vector4(37f / 255f, 181f / 255f, 177f / 255f, 100f / 100f));
 
         [ColorEdit4("Star Giant Color")]
+        [CollapseWith(15, 3)]
         public PluginConfigColor StarGiantColor = new(new Vector4(198f / 255f, 154f / 255f, 199f / 255f, 100f / 100f));
 
         [ColorEdit4("Star Glow Color")]
+        [CollapseWith(20, 3)]
         public PluginConfigColor StarGlowColor = new(new Vector4(255f / 255f, 199f / 255f, 62f / 255f, 100f / 100f));
 
         [Checkbox("Show Star timer")]
+        [CollapseWith(25, 3)]
         public bool ShowStarTextBar = true;
 
         [Checkbox("Change Star timer to decimal")]
+        [CollapseWith(30, 3)]
         public bool EnableDecimalStarBar;
 
         [Checkbox("Enable Star bar glow when Giant Dominance is ready")]
+        [CollapseWith(35, 3)]
         public bool ShowStarGlowBar = true;
 
         #endregion
@@ -638,21 +681,27 @@ namespace DelvUI.Interface
         #region Lightspeed Bar
 
         [Checkbox("Show Lightspeed Bar")]
+        [CollapseControl(30, 4)]
         public bool ShowLightspeedBar = true;
 
         [DragFloat2("Lightspeed Bar Size", min = 1f, max = 200f)]
+        [CollapseWith(0, 4)]
         public Vector2 LightspeedBarSize = new(20, 84);
 
         [DragFloat2("Lightspeed Bar Position", min = -2000f, max = 2000f)]
+        [CollapseWith(5, 4)]
         public Vector2 LightspeedBarPosition = new(203, -65);
 
         [ColorEdit4("Lightspeed Color")]
+        [CollapseWith(10, 4)]
         public PluginConfigColor LightspeedColor = new(new Vector4(255f / 255f, 255f / 255f, 173f / 255f, 100f / 100f));
 
         [Checkbox("Show Lightspeed timer")]
+        [CollapseWith(15, 4)]
         public bool ShowLightspeedTextBar = true;
 
         [Checkbox("Change Lightspeed timer to decimal")]
+        [CollapseWith(20, 4)]
         public bool EnableDecimalLightspeedBar;
 
         #endregion

--- a/DelvUI/Interface/BardHudWindow.cs
+++ b/DelvUI/Interface/BardHudWindow.cs
@@ -228,96 +228,127 @@ namespace DelvUI.Interface
     public class BardHudConfig : PluginConfigObject
     {
         [DragFloat2("Base Offset", min = -4000f, max = 4000f)]
+        [Order(0)]
         public Vector2 Position = new(0, 0);
 
         [Checkbox("Song Gauge Enabled")]
+        [CollapseControl(5, 0)]
         public bool ShowSongGauge = true;
 
         [DragFloat2("Song Gauge Size", min = 1f, max = 2000f)]
+        [CollapseWith(0, 0)]
         public Vector2 SongGaugeSize = new(254, 20);
 
         [DragFloat2("Song Gauge Position", min = -4000f, max = 4000f)]
+        [CollapseWith(5, 0)]
         public Vector2 SongGaugePosition = new(0, -23);
 
         [ColorEdit4("Wanderer's Minuet Color")]
+        [CollapseWith(10, 0)]
         public PluginConfigColor WMColor = new(new Vector4(158f / 255f, 157f / 255f, 36f / 255f, 100f / 100f));
 
         [ColorEdit4("Mage's Ballad Color")]
+        [CollapseWith(15, 0)]
         public PluginConfigColor MBColor = new(new Vector4(143f / 255f, 90f / 255f, 143f / 255f, 100f / 100f));
 
         [ColorEdit4("Army's Paeon Color")]
+        [CollapseWith(20, 0)]
         public PluginConfigColor APColor = new(new Vector4(207f / 255f, 205f / 255f, 52f / 255f, 100f / 100f));
 
         [Checkbox("Soul Gauge Enabled")]
+        [CollapseControl(10, 1)]
         public bool ShowSoulGauge = true;
 
         [DragFloat2("Soul Gauge Size", min = 1f, max = 2000f)]
+        [CollapseWith(0, 1)]
         public Vector2 SoulGaugeSize = new(254, 10);
 
         [DragFloat2("Soul Gauge Position", min = -4000f, max = 4000f)]
+        [CollapseWith(5, 1)]
         public Vector2 SoulGaugePosition = new(0, -6);
 
         [ColorEdit4("Soul Gauge Color")]
+        [CollapseWith(10, 1)]
         public PluginConfigColor SoulGaugeColor = new(new Vector4(248f / 255f, 227f / 255f, 0f / 255f, 100f / 100f));
 
         [Checkbox("Wanderer's Minuet Stacks Enabled")]
+        [Order(15)]
         public bool ShowWMStacks = true;
 
         [Checkbox("Mage's Ballad Proc Enabled (n/a yet)")]
+        [Order(20)]
         public bool ShowMBProc = true;
 
         [Checkbox("Army's Paeon Stacks Enabled")]
+        [Order(25)]
         public bool ShowAPStacks = true;
 
         [DragFloat2("Stack Size", min = 1f, max = 2000f)]
+        [Order(30)]
         public Vector2 StackSize = new(254, 10);
 
         [DragFloat2("Stack Position", min = -4000f, max = 4000f)]
+        [Order(35)]
         public Vector2 StackPosition = new(0, -40);
 
         [DragInt("Stack Padding", max = 1000)]
+        [Order(40)]
         public int StackPadding = 2;
 
         [ColorEdit4("Wanderer's Minuet Stack Color")]
+        [Order(45)]
         public PluginConfigColor WMStackColor = new(new Vector4(150f / 255f, 215f / 255f, 232f / 255f, 100f / 100f));
 
         [ColorEdit4("Mage's Ballad Proc Color")]
+        [Order(50)]
         public PluginConfigColor MBProcColor = new(new Vector4(199f / 255f, 46f / 255f, 46f / 255f, 100f / 100f));
 
         [ColorEdit4("Army's Paeon Stack Color")]
+        [Order(55)]
         public PluginConfigColor APStackColor = new(new Vector4(0f / 255f, 222f / 255f, 177f / 255f, 100f / 100f));
 
         [Checkbox("Caustic Bite Enabled")]
+        [CollapseControl(60, 2)]
         public bool ShowCB = true;
 
         [Checkbox("Caustic Bite Inverted")]
+        [CollapseWith(0, 2)]
         public bool CBInverted = true;
 
         [DragFloat2("Caustic Bite Size", max = 2000f)]
+        [CollapseWith(5, 2)]
         public Vector2 CBSize = new(126, 10);
 
         [DragFloat2("Caustic Bite Position", min = -4000f, max = 4000f)]
+        [CollapseWith(10, 2)]
         public Vector2 CBPosition = new(-64, -52);
 
         [ColorEdit4("Caustic Bite Color")]
+        [CollapseWith(15, 2)]
         public PluginConfigColor CBColor = new(new Vector4(182f / 255f, 68f / 255f, 235f / 255f, 100f / 100f));
 
         [Checkbox("Stormbite Enabled")]
+        [CollapseControl(65, 3)]
         public bool ShowSB = true;
 
         [Checkbox("Stormbite Inverted")]
+        [CollapseWith(0, 3)]
         public bool SBInverted = false;
 
         [DragFloat2("Stormbite Size", max = 2000f)]
+        [CollapseWith(5, 3)]
         public Vector2 SBSize = new(126, 10);
 
         [DragFloat2("Stormbite Position", min = -4000f, max = 4000f)]
+        [CollapseWith(10, 3)]
         public Vector2 SBPosition = new(64, -52);
 
         [ColorEdit4("Stormbite Color")]
+        [CollapseWith(15, 3)]
         public PluginConfigColor SBColor = new(new Vector4(72f / 255f, 117f / 255f, 202f / 255f, 100f / 100f));
 
         [ColorEdit4("DoT Expire Color")]
+        [Order(70)]
         public PluginConfigColor ExpireColor = new(new Vector4(199f / 255f, 46f / 255f, 46f / 255f, 100f / 100f));
     }
 }

--- a/DelvUI/Interface/BlackMageHudWindow.cs
+++ b/DelvUI/Interface/BlackMageHudWindow.cs
@@ -314,89 +314,99 @@ namespace DelvUI.Interface
     public class BlackMageHudConfig : PluginConfigObject
     {
         [DragFloat2("Base Offset", min = -4000f, max = 4000f)]
+        [Order(0)]
         public Vector2 Position = new Vector2(0, -2);
 
         [DragFloat2("Padding", min = -100f, max = 100f)]
+        [Order(5)]
         public Vector2 Padding = new Vector2(2, 2);
 
         [DragFloat2("Mana Bar Size", max = 2000f)]
+        [Order(10)]
         public Vector2 ManaBarSize = new Vector2(253, 20);
 
+        [Checkbox("Show Mana Value")]
+        [Order(15)]
+        public bool ShowManaValue = false;
+
         [DragFloat2("Umbra Heart Size", max = 2000f)]
+        [Order(20)]
         public Vector2 UmbralHeartSize = new Vector2(83, 16);
 
         [DragFloat2("Polyglot Size", max = 2000f)]
+        [Order(25)]
         public Vector2 PolyglotSize = new Vector2(18, 18);
-        [Checkbox("Show Mana Value")] public bool ShowManaValue = false;
 
         [Checkbox("Show Mana Threshold Marker During Astral Fire")]
+        [CollapseControl(30, 0)]
         public bool ShowManaThresholdMarker = true;
 
         [DragInt("Mana Threshold Marker Value", max = 10000)]
+        [CollapseWith(0, 0)]
         public int ManaThresholdValue = 2600;
 
-        [Checkbox("Show Triplecast")] public bool ShowTripleCast = true;
+        [ColorEdit4("Mana Bar Color")]
+        [Order(35)]
+        public PluginConfigColor ManaBarNoElementColor = new PluginConfigColor(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
+
+        [ColorEdit4("Mana Bar Ice Color")]
+        [Order(40)]
+        public PluginConfigColor ManaBarIceColor = new PluginConfigColor(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 100f / 100f));
+
+        [ColorEdit4("Mana Bar Fire Color")]
+        [Order(45)]
+        public PluginConfigColor ManaBarFireColor = new PluginConfigColor(new Vector4(204f / 255f, 40f / 255f, 40f / 255f, 100f / 100f));
+
+        [Checkbox("Show Triplecast")] 
+        [CollapseControl(50, 1)]
+        public bool ShowTripleCast = true;
 
         [DragFloat2("Triplecast Size", max = 2000)]
+        [CollapseWith(0, 1)]
         public Vector2 TripleCastSize = new Vector2(83, 16);
 
-        [Checkbox("Show Firestarter Procs")] public bool ShowFirestarterProcs = true;
-        [Checkbox("Show Thundercloud Procs")] public bool ShowThundercloudProcs = true;
-        [DragInt("Procs Height", max = 2000)] public int ProcsHeight = 7;
-        [Checkbox("Show DoT Timer")] public bool ShowDotTimer = true;
+        [ColorEdit4("Triplecast Color")]
+        [CollapseWith(5, 1)]
+        public PluginConfigColor TriplecastColor = new PluginConfigColor(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
 
-        [DragInt("DoT Timer Height", max = 2000)]
-        public int DotTimerHeight = 10;
+        [DragInt("Procs Height", max = 2000)]
+        [Order(55)]
+        public int ProcsHeight = 7;
 
-        [ColorEdit4("Mana Bar Color")] public PluginConfigColor ManaBarNoElementColor = new PluginConfigColor(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
-        [ColorEdit4("Mana Bar Ice Color")] public PluginConfigColor ManaBarIceColor = new PluginConfigColor(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 100f / 100f));
-        [ColorEdit4("Mana Bar Fire Color")] public PluginConfigColor ManaBarFireColor = new PluginConfigColor(new Vector4(204f / 255f, 40f / 255f, 40f / 255f, 100f / 100f));
-        [ColorEdit4("Umbral Heart Color")] public PluginConfigColor UmbralHeartColor = new PluginConfigColor(new Vector4(125f / 255f, 195f / 255f, 205f / 255f, 100f / 100f));
-        [ColorEdit4("Polyglot Color Color")] public PluginConfigColor PolyglotColor = new PluginConfigColor(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
-        [ColorEdit4("Triplecast Color")] public PluginConfigColor TriplecastColor = new PluginConfigColor(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
-        [ColorEdit4("Firestarter Proc Color")] public PluginConfigColor FirestarterColor = new PluginConfigColor(new Vector4(255f / 255f, 136f / 255f, 0 / 255f, 90f / 100f));
+        [Checkbox("Show Firestarter Procs")]
+        [CollapseControl(60, 2)]
+        public bool ShowFirestarterProcs = true;
+
+        [ColorEdit4("Firestarter Proc Color")]
+        [CollapseWith(0, 2)]
+        public PluginConfigColor FirestarterColor = new PluginConfigColor(new Vector4(255f / 255f, 136f / 255f, 0 / 255f, 90f / 100f));
+
+        [Checkbox("Show Thundercloud Procs")]
+        [CollapseControl(65, 3)]
+        public bool ShowThundercloudProcs = true;
 
         [ColorEdit4("Thundercloud Proc Color")]
+        [CollapseWith(0, 3)]
         public PluginConfigColor ThundercloudColor = new PluginConfigColor(new Vector4(240f / 255f, 163f / 255f, 255f / 255f, 90f / 100f));
 
-        [ColorEdit4("DoT Timer Color")] public PluginConfigColor DotColor = new PluginConfigColor(new Vector4(67f / 255f, 187 / 255f, 255f / 255f, 90f / 100f));
+        [Checkbox("Show DoT Timer")]
+        [CollapseControl(70, 4)]
+        public bool ShowDotTimer = true;
 
-        // public bool Draw()
-        // {
-        //     var changed = false;
-        //
-        //     changed |= ImGui.DragFloat2("Base Offset", ref Position, 1f, -4000, 4000);
-        //     changed |= ImGui.DragFloat2("Padding", ref Padding, 1f, -100, 100);
-        //     changed |= ImGui.DragFloat2("Mana Bar Size", ref ManaBarSize, 1f, 1, 2000);
-        //     changed |= ImGui.DragFloat2("Umbral Heart Size", ref UmbralHeartSize, 1f, 1, 2000);
-        //     changed |= ImGui.DragFloat2("Polyglot Size", ref PolyglotSize, 1f, 1, 2000);
-        //
-        //     changed |= ImGui.Checkbox("Show Mana Value", ref ShowManaValue);
-        //     changed |= ImGui.Checkbox("Show Mana Threshold Marker During Astral Fire", ref ShowManaThresholdMarker);
-        //     changed |= ImGui.DragInt("Mana Threshold Marker Value", ref ManaThresholdValue, 1f, 1, 10000);
-        //     
-        //     changed |= ImGui.Checkbox("Show Triplecast", ref ShowTripleCast);
-        //     changed |= ImGui.DragFloat2("Triplecast Size", ref TripleCastSize, 1f, 1, 2000);
-        //     
-        //     changed |= ImGui.Checkbox("Show Firestarter Procs", ref ShowFirestarterProcs);
-        //     changed |= ImGui.Checkbox("Show Thundercloud Procs", ref ShowThundercloudProcs);
-        //
-        //     changed |= ImGui.DragInt("Procs Height", ref ProcsHeight, .1f, 1, 2000);
-        //
-        //     changed |= ImGui.Checkbox("Show DoT Timer", ref ShowDotTimer);
-        //     changed |= ImGui.DragInt("DoT Timer Height", ref DotTimerHeight, .1f, 1, 2000);
-        //
-        //     changed |= ColorEdit4("Mana Bar Color", ref ManaBarNoElementColor);
-        //     changed |= ColorEdit4("Mana Bar Ice Color", ref ManaBarIceColor);
-        //     changed |= ColorEdit4("Mana Bar Fire Color", ref ManaBarFireColor);
-        //     changed |= ColorEdit4("Umbral Heart Color", ref UmbralHeartColor);
-        //     changed |= ColorEdit4("Polyglot Color", ref PolyglotColor);
-        //     changed |= ColorEdit4("Triplecast Color", ref TriplecastColor);
-        //     changed |= ColorEdit4("Firestarter Proc Color", ref FirestarterColor);
-        //     changed |= ColorEdit4("Thundercloud Proc Color", ref ThundercloudColor);
-        //     changed |= ColorEdit4("DoT Timer Color", ref DotColor);
-        //
-        //     return changed;
-        // }
+        [DragInt("DoT Timer Height", max = 2000)]
+        [CollapseWith(0, 4)]
+        public int DotTimerHeight = 10;
+
+        [ColorEdit4("DoT Timer Color")]
+        [CollapseWith(5, 4)]
+        public PluginConfigColor DotColor = new PluginConfigColor(new Vector4(67f / 255f, 187 / 255f, 255f / 255f, 90f / 100f));
+
+        [ColorEdit4("Umbral Heart Color")]
+        [Order(75)]
+        public PluginConfigColor UmbralHeartColor = new PluginConfigColor(new Vector4(125f / 255f, 195f / 255f, 205f / 255f, 100f / 100f));
+
+        [ColorEdit4("Polyglot Color Color")]
+        [Order(80)]
+        public PluginConfigColor PolyglotColor = new PluginConfigColor(new Vector4(234f / 255f, 95f / 255f, 155f / 255f, 100f / 100f));
     }
 }

--- a/DelvUI/Interface/BlackMageHudWindow.cs
+++ b/DelvUI/Interface/BlackMageHudWindow.cs
@@ -357,7 +357,7 @@ namespace DelvUI.Interface
         [Order(45)]
         public PluginConfigColor ManaBarFireColor = new PluginConfigColor(new Vector4(204f / 255f, 40f / 255f, 40f / 255f, 100f / 100f));
 
-        [Checkbox("Show Triplecast")] 
+        [Checkbox("Show Triplecast")]
         [CollapseControl(50, 1)]
         public bool ShowTripleCast = true;
 

--- a/DelvUI/Interface/DancerHudWindow.cs
+++ b/DelvUI/Interface/DancerHudWindow.cs
@@ -317,163 +317,205 @@ namespace DelvUI.Interface
     public class DancerHudConfig : PluginConfigObject
     {
         [DragFloat2("Base Offset", min = -4000f, max = 4000f)]
+        [Order(0)]
         public Vector2 Position = new(0, 0);
 
         // Esprit Guage
         [Checkbox("Show Esprit Guage")]
+        [CollapseControl(5, 0)]
         public bool EspritGuageEnabled = true;
 
         [Checkbox("Show Esprit Guage Text")]
+        [CollapseWith(0, 0)]
         public bool EspritTextEnabled = true;
 
         [DragFloat2("Esprit Gauge Size", max = 2000f)]
+        [CollapseWith(5, 0)]
         public Vector2 EspritGaugeSize = new(254, 20);
 
         [DragFloat2("Esprit Gauge Offset", min = -4000f, max = 4000f)]
+        [CollapseWith(10, 0)]
         public Vector2 EspritGaugeOffset = new(127, 395);
 
         [DragFloat("Esprit Gauge Chunk Padding", min = -4000f, max = 4000f)]
+        [CollapseWith(15, 0)]
         public float EspritGaugeChunkPadding = 2;
 
-        // Feathers Guage
-        [Checkbox("Show Feather Guage")]
-        public bool FeatherGuageEnabled = true;
-
-        [Checkbox("Enable Flourishing Finish Glow")]
-        public bool FlourishingGlowEnabled = true;
-
-        [DragFloat2("Feather Guage Size")]
-        public Vector2 FeatherGaugeSize = new(254, 13);
-
-        [DragFloat2("Feather Gauge Offset", min = -4000f, max = 4000f)]
-        public Vector2 FeatherGaugeOffset = new(127, 380);
-
-        [DragFloat("Feather Gauge Chunk Padding", min = -4000f, max = 4000f)]
-        public float FeatherGaugeChunkPadding = 2;
-
-        // Buff Bars
-        [Checkbox("Show Buff Bar")]
-        public bool BuffBarEnabled = true;
-
-        [Checkbox("Show Technical Finish Bar")]
-        public bool TechnicalBarEnabled = true;
-
-        [Checkbox("Show Technical Finish Bar Text")]
-        public bool TechnicalTextEnabled = true;
-
-        [Checkbox("Show Devilment Bar")]
-        public bool DevilmentBarEnabled = true;
-
-        [Checkbox("Show Devilment Bar Text")]
-        public bool DevilmentTextEnabled = true;
-
-        [DragFloat2("Buff Bars Size")]
-        public Vector2 BuffBarSize = new(254, 20);
-
-        [DragFloat2("Buff Bars Offset")]
-        public Vector2 BuffBarOffset = new(127, 417);
-
-        // Standard Finish Bar
-        [Checkbox("Show Standard Finish Bar")]
-        public bool StandardBarEnabled = true;
-
-        [Checkbox("Show Standard Finish Bar Text")]
-        public bool StandardTextEnabled = true;
-
-        [DragFloat2("Standard Finish Bar Size")]
-        public Vector2 StandardBarSize = new(254, 20);
-
-        [DragFloat2("Standard Finish Bar Offset")]
-        public Vector2 StandardBarOffset = new(127, 439);
-
-        // Step Bars
-        [Checkbox("Show Step Bars")]
-        public bool StepBarEnabled = true;
-
-        [Checkbox("Show Step Glow")]
-        public bool StepGlowEnabled = true;
-
-        [Checkbox("Show Dance Ready Glow")]
-        public bool DanceReadyGlowEnabled = true;
-
-        [DragFloat2("Step Bars Size")]
-        public Vector2 StepBarSize = new(254, 13);
-
-        [DragFloat2("Step Bars Offset")]
-        public Vector2 StepBarOffset = new(127, 365);
-
-        [DragFloat("Step Bar Chunk Padding")]
-        public float StepBarChunkPadding = 2;
-
-        // Proc Bars
-        [Checkbox("Show Proc Bars")]
-        public bool ProcBarEnabled = true;
-
-        [Checkbox("Use Static Proc Bars")]
-        public bool StaticProcBarsEnabled = true;
-
-        [DragFloat2("Proc Bars Size")]
-        public Vector2 ProcBarSize = new(254, 13);
-
-        [DragFloat2("Proc Bars Offset")]
-        public Vector2 ProcBarOffset = new(127, 365);
-
-        [DragFloat("Proc Bar Chunk Padding")]
-        public float ProcBarChunkPadding = 2;
-
-        // ---Colors---
-        // Esprit Guage
         [ColorEdit4("Esprit Guage Color")]
+        [CollapseWith(20, 0)]
         public PluginConfigColor EspritGaugeColor = new(new Vector4(72f / 255f, 20f / 255f, 99f / 255f, 100f / 100f));
 
         // Feathers Guage
+        [Checkbox("Show Feather Guage")]
+        [CollapseControl(10, 1)]
+        public bool FeatherGuageEnabled = true;
+
+        [Checkbox("Enable Flourishing Finish Glow")]
+        [CollapseWith(0, 1)]
+        public bool FlourishingGlowEnabled = true;
+
+        [DragFloat2("Feather Guage Size")]
+        [CollapseWith(5, 1)]
+        public Vector2 FeatherGaugeSize = new(254, 13);
+
+        [DragFloat2("Feather Gauge Offset", min = -4000f, max = 4000f)]
+        [CollapseWith(10, 1)]
+        public Vector2 FeatherGaugeOffset = new(127, 380);
+
+        [DragFloat("Feather Gauge Chunk Padding", min = -4000f, max = 4000f)]
+        [CollapseWith(15, 1)]
+        public float FeatherGaugeChunkPadding = 2;
+
         [ColorEdit4("Feather Guage Color")]
+        [CollapseWith(20, 1)]
         public PluginConfigColor FeatherGaugeColor = new(new Vector4(175f / 255f, 229f / 255f, 29f / 255f, 100f / 100f));
 
         [ColorEdit4("Flourishing Finish Glow Color")]
+        [CollapseWith(25, 1)]
         public PluginConfigColor FlourishingProcColor = new(new Vector4(255f / 255f, 215f / 255f, 0f / 255f, 100f / 100f));
 
         // Buff Bars
+        [Checkbox("Show Buff Bar")]
+        [CollapseControl(15, 2)]
+        public bool BuffBarEnabled = true;
+
+        [Checkbox("Show Technical Finish Bar")]
+        [CollapseWith(0, 2)]
+        public bool TechnicalBarEnabled = true;
+
+        [Checkbox("Show Technical Finish Bar Text")]
+        [CollapseWith(5, 2)]
+        public bool TechnicalTextEnabled = true;
+
+        [Checkbox("Show Devilment Bar")]
+        [CollapseWith(10, 2)]
+        public bool DevilmentBarEnabled = true;
+
+        [Checkbox("Show Devilment Bar Text")]
+        [CollapseWith(15, 2)]
+        public bool DevilmentTextEnabled = true;
+
+        [DragFloat2("Buff Bars Size")]
+        [CollapseWith(20, 2)]
+        public Vector2 BuffBarSize = new(254, 20);
+
+        [DragFloat2("Buff Bars Offset")]
+        [CollapseWith(25, 2)]
+        public Vector2 BuffBarOffset = new(127, 417);
+
         [ColorEdit4("Technical Finish Bar Color")]
+        [CollapseWith(30, 2)]
         public PluginConfigColor TechnicalFinishBarColor = new(new Vector4(255f / 255f, 9f / 255f, 102f / 255f, 100f / 100f));
 
         [ColorEdit4("Devilment Bar Color")]
+        [CollapseWith(35, 2)]
         public PluginConfigColor DevilmentBarColor = new(new Vector4(52f / 255f, 78f / 255f, 29f / 255f, 100f / 100f));
 
-        //Standard Finish Bar
+        // Standard Finish Bar
+        [Checkbox("Show Standard Finish Bar")]
+        [CollapseControl(20, 3)]
+        public bool StandardBarEnabled = true;
+
+        [Checkbox("Show Standard Finish Bar Text")]
+        [CollapseWith(0, 3)]
+        public bool StandardTextEnabled = true;
+
+        [DragFloat2("Standard Finish Bar Size")]
+        [CollapseWith(5, 3)]
+        public Vector2 StandardBarSize = new(254, 20);
+
+        [DragFloat2("Standard Finish Bar Offset")]
+        [CollapseWith(10, 3)]
+        public Vector2 StandardBarOffset = new(127, 439);
+
         [ColorEdit4("Standard Finish Bar Color")]
+        [CollapseWith(15, 3)]
         public PluginConfigColor StandardFinishBarColor = new(new Vector4(0f / 255f, 193f / 255f, 95f / 255f, 100f / 100f));
 
         // Step Bars
+        [Checkbox("Show Step Bars")]
+        [CollapseControl(25, 4)]
+        public bool StepBarEnabled = true;
+
+        [Checkbox("Show Step Glow")]
+        [CollapseWith(0, 4)]
+        public bool StepGlowEnabled = true;
+
+        [Checkbox("Show Dance Ready Glow")]
+        [CollapseWith(5, 4)]
+        public bool DanceReadyGlowEnabled = true;
+
+        [DragFloat2("Step Bars Size")]
+        [CollapseWith(10, 4)]
+        public Vector2 StepBarSize = new(254, 13);
+
+        [DragFloat2("Step Bars Offset")]
+        [CollapseWith(15, 4)]
+        public Vector2 StepBarOffset = new(127, 365);
+
+        [DragFloat("Step Bar Chunk Padding")]
+        [CollapseWith(20, 4)]
+        public float StepBarChunkPadding = 2;
+
         [ColorEdit4("Current Step Glow Color")]
+        [CollapseWith(25, 4)]
         public PluginConfigColor CurrentStepGlowColor = new(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
 
         [ColorEdit4("Emboite Color")]
+        [CollapseWith(30, 4)]
         public PluginConfigColor EmboiteColor = new(new Vector4(255f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
 
         [ColorEdit4("Entrechat Color")]
+        [CollapseWith(35, 4)]
         public PluginConfigColor EntrechatColor = new(new Vector4(0f / 255f, 0f / 255f, 255f / 255f, 100f / 100f));
 
         [ColorEdit4("Jete Color")]
+        [CollapseWith(40, 4)]
         public PluginConfigColor JeteColor = new(new Vector4(0f / 255f, 255f / 255f, 0f / 255f, 100f / 100f));
 
         [ColorEdit4("Pirouette Color")]
+        [CollapseWith(45, 4)]
         public PluginConfigColor PirouetteColor = new(new Vector4(255f / 255f, 215f / 255f, 0f / 255f, 100f / 100f));
 
         [ColorEdit4("Dance Ready Color")]
+        [CollapseWith(50, 4)]
         public PluginConfigColor DanceReadyColor = new(new Vector4(255f / 255f, 215f / 255f, 0f / 255f, 100f / 100f));
 
         // Proc Bars
+        [Checkbox("Show Proc Bars")]
+        [CollapseControl(30, 5)]
+        public bool ProcBarEnabled = true;
+
+        [Checkbox("Use Static Proc Bars")]
+        [CollapseWith(0, 5)]
+        public bool StaticProcBarsEnabled = true;
+
+        [DragFloat2("Proc Bars Size")]
+        [CollapseWith(10, 5)]
+        public Vector2 ProcBarSize = new(254, 13);
+
+        [DragFloat2("Proc Bars Offset")]
+        [CollapseWith(15, 5)]
+        public Vector2 ProcBarOffset = new(127, 365);
+
+        [DragFloat("Proc Bar Chunk Padding")]
+        [CollapseWith(20, 5)]
+        public float ProcBarChunkPadding = 2;
+
         [ColorEdit4("Flourishing Cascade Color")]
+        [CollapseWith(25, 5)]
         public PluginConfigColor FlourishingCascadeColor = new(new Vector4(0f / 255f, 255f / 255f, 0f / 255f, 100f / 100f));
 
         [ColorEdit4("Flourishing Fountain Color")]
+        [CollapseWith(30, 5)]
         public PluginConfigColor FlourishingFountainColor = new(new Vector4(255f / 255f, 215f / 255f, 0f / 255f, 100f / 100f));
 
         [ColorEdit4("Flourishing Windmill Color")]
+        [CollapseWith(35, 5)]
         public PluginConfigColor FlourishingWindmillColor = new(new Vector4(0f / 255f, 215f / 255f, 215f / 255f, 100f / 100f));
 
         [ColorEdit4("Flourishing Shower Color")]
+        [CollapseWith(40, 5)]
         public PluginConfigColor FlourishingShowerColor = new(new Vector4(255f / 255f, 100f / 255f, 0f / 255f, 100f / 100f));
     }
 }

--- a/DelvUI/Interface/DancerHudWindow.cs
+++ b/DelvUI/Interface/DancerHudWindow.cs
@@ -48,6 +48,10 @@ namespace DelvUI.Interface
 
             if (_config.StepBarEnabled)
             {
+                DrawProcBar();
+            }
+            if (_config.StepBarEnabled)
+            {
                 DrawStepBar();
             }
 

--- a/DelvUI/Interface/DarkKnightHudWindow.cs
+++ b/DelvUI/Interface/DarkKnightHudWindow.cs
@@ -381,83 +381,115 @@ namespace DelvUI.Interface
     public class DarkKnightHudConfig : PluginConfigObject
     {
         [DragFloat2("Base offset", min = -4000f, max = 4000f)]
+        [Order(0)]
         public Vector2 Position = new Vector2(0, 415);
 
         /* Mana Bar */
         [Checkbox("Show Mana Bar")]
+        [CollapseControl(5, 0)]
         public bool ShowManaBar = true;
 
         [Checkbox("Show Mana Bar Overflow")]
+        [CollapseWith(0, 0)]
         public bool ShowManaBarOverflow = false;
 
         [DragFloat2("Mana Bar Position", min = -4000f, max = 4000f)]
+        [CollapseWith(5, 0)]
         public Vector2 ManaBarPosition = new Vector2(0, 0);
 
         [DragFloat2("Mana Bar Size", min = 0, max = 4000f)]
+        [CollapseWith(10, 0)]
         public Vector2 ManaBarSize = new Vector2(254, 10);
 
         [DragInt("Mana Bar Padding", min = 0)]
+        [CollapseWith(15, 0)]
         public int ManaBarSpacing = 1;
 
-        [ColorEdit4("Mana Color")] public PluginConfigColor ManaColor = new(new Vector4(0f / 255f, 142f / 255f, 254f / 255f, 100f / 100f));
+        [ColorEdit4("Mana Color")]
+        [CollapseWith(20, 0)]
+        public PluginConfigColor ManaColor = new(new Vector4(0f / 255f, 142f / 255f, 254f / 255f, 100f / 100f));
 
-        [ColorEdit4("Dark Arts Buff Color")] public PluginConfigColor DarkArtsColor = new(new Vector4(210f / 255f, 33f / 255f, 33f / 255f, 100f / 100f));
-
+        [ColorEdit4("Dark Arts Buff Color")]
+        [CollapseWith(25, 0)]
+        public PluginConfigColor DarkArtsColor = new(new Vector4(210f / 255f, 33f / 255f, 33f / 255f, 100f / 100f));
 
         /* Blood Gauge */
         [Checkbox("Show Blood Gauge")]
+        [CollapseControl(10, 1)]
         public bool ShowBloodGauge = true;
 
         [Checkbox("Split Blood Gauge")]
+        [CollapseWith(0, 1)]
         public bool BloodGaugeSplit = false;
 
         [Checkbox("Draw Blood Gauge Threshold")]
+        [CollapseWith(5, 1)]
         public bool DrawBloodGaugeThreshold = false;
 
         [DragFloat2("Blood Gauge Position", min = -4000f, max = 4000f)]
+        [CollapseWith(10, 1)]
         public Vector2 BloodGaugePosition = new Vector2(0, 12);
 
         [DragFloat2("Blood Gauge Size", min = 0, max = 4000f)]
+        [CollapseWith(15, 1)]
         public Vector2 BloodGaugeSize = new Vector2(254, 10);
 
         [DragInt("Blood Gauge Padding", min = 0)]
+        [CollapseWith(20, 1)]
         public int BloodGaugePadding = 2;
 
-        [ColorEdit4("Blood Color Left")] public PluginConfigColor BloodColorLeft = new(new Vector4(196f / 255f, 20f / 255f, 122f / 255f, 100f / 100f));
+        [ColorEdit4("Blood Color Left")]
+        [CollapseWith(25, 1)]
+        public PluginConfigColor BloodColorLeft = new(new Vector4(196f / 255f, 20f / 255f, 122f / 255f, 100f / 100f));
 
-        [ColorEdit4("Blood Color Right")] public PluginConfigColor BloodColorRight = new(new Vector4(216f / 255f, 0f / 255f, 73f / 255f, 100f / 100f));
-
+        [ColorEdit4("Blood Color Right")]
+        [CollapseWith(30, 1)]
+        public PluginConfigColor BloodColorRight = new(new Vector4(216f / 255f, 0f / 255f, 73f / 255f, 100f / 100f));
 
         /* Buff Bar */
         [Checkbox("Show Buff Bar")]
+        [CollapseControl(15, 2)]
         public bool ShowBuffBar = true;
 
         [DragFloat2("Buff Bar Position", min = -4000f, max = 4000f)]
+        [CollapseWith(0, 2)]
         public Vector2 BuffBarPosition = new Vector2(0, 24);
 
         [DragFloat2("Buff Bar Size", min = 0, max = 4000f)]
+        [CollapseWith(5, 2)]
         public Vector2 BuffBarSize = new Vector2(254, 20);
 
         [DragInt("Buff Bar Padding", min = 0)]
+        [CollapseWith(10, 2)]
         public int BuffBarPadding = 2;
 
-        [ColorEdit4("Blood Weapon Color")] public PluginConfigColor BloodWeaponColor = new(new Vector4(160f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
+        [ColorEdit4("Blood Weapon Color")]
+        [CollapseWith(15, 2)]
+        public PluginConfigColor BloodWeaponColor = new(new Vector4(160f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
 
-        [ColorEdit4("Delirium Color")] public PluginConfigColor DeliriumColor = new(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
+        [ColorEdit4("Delirium Color")]
+        [CollapseWith(20, 2)]
+        public PluginConfigColor DeliriumColor = new(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
 
         /* Living Shadow */
         [Checkbox("Show Living Shadow Bar")]
+        [CollapseControl(20, 3)]
         public bool ShowLivingShadowBar = true;
 
         [DragFloat2("Living Shadow Position", min = -4000f, max = 4000f)]
+        [CollapseWith(0, 3)]
         public Vector2 LivingShadowPosition = new Vector2(0, 46);
 
         [DragFloat2("Living Shadow Size", min = 0, max = 4000f)]
+        [CollapseWith(5, 3)]
         public Vector2 LivingShadowSize = new Vector2(254, 20);
 
         [DragInt("Living Shadow Padding", min = 0)]
+        [CollapseWith(10, 3)]
         public int LivingShadowPadding = 2;
 
-        [ColorEdit4("Living Shadow Color")] public PluginConfigColor LivingShadowColor = new(new Vector4(225f / 255f, 105f / 255f, 205f / 255f, 100f / 100f));
+        [ColorEdit4("Living Shadow Color")]
+        [CollapseWith(15, 3)]
+        public PluginConfigColor LivingShadowColor = new(new Vector4(225f / 255f, 105f / 255f, 205f / 255f, 100f / 100f));
     }
 }

--- a/DelvUI/Interface/GunbreakerHudWindow.cs
+++ b/DelvUI/Interface/GunbreakerHudWindow.cs
@@ -90,35 +90,45 @@ namespace DelvUI.Interface
     public class GunbreakerHudConfig : PluginConfigObject
     {
         [DragFloat2("Base Offset", min = -4000f, max = 4000f)]
+        [Order(0)]
         public Vector2 Position = new Vector2(0, 0);
 
         /* Powder Gauge Bar */
         [Checkbox("Show Powder Gauge")]
+        [CollapseControl(5, 0)]
         public bool ShowPowderGauge = true;
 
         [DragFloat2("Powder Gauge Position", min = -4000f, max = 4000f)]
+        [CollapseWith(0, 0)]
         public Vector2 PowderGaugeBarPosition = new(0, 428);
 
         [DragFloat2("Powder Gauge Size", min = 1f, max = 4000f)]
+        [CollapseWith(5, 0)]
         public Vector2 PowderGaugeBarSize = new(254, 20);
 
         [DragFloat("Powder Gauge Spacing", min = 0)]
+        [CollapseWith(10, 0)]
         public float PowderGaugeSpacing = 2.0f;
 
         [ColorEdit4("Powder Gauge Fill Color")]
+        [CollapseWith(15, 0)]
         public PluginConfigColor PowderGaugeFillColor = new(new Vector4(46f / 255f, 179f / 255f, 255f / 255f, 1f));
 
         /* No Mercy Bar*/
         [Checkbox("Show No Mercy Bar")]
+        [CollapseControl(10, 1)]
         public bool ShowNoMercyBar = true;
 
         [DragFloat2("No Mercy Bar Position", min = -4000f, max = 4000f)]
+        [CollapseWith(0, 1)]
         public Vector2 NoMercyBarPosition = new(0, 449);
 
         [DragFloat2("No Mercy Bar Size", min = 1f, max = 4000f)]
+        [CollapseWith(5, 1)]
         public Vector2 NoMercyBarSize = new(254, 20);
 
         [ColorEdit4("No Mercy Fill Color")]
+        [CollapseWith(10, 1)]
         public PluginConfigColor NoMercyFillColor = new(new Vector4(252f / 255f, 204f / 255f, 255f / 255f, 1f));
     }
 }

--- a/DelvUI/Interface/NinjaHudWindow.cs
+++ b/DelvUI/Interface/NinjaHudWindow.cs
@@ -148,63 +148,83 @@ namespace DelvUI.Interface
     public class NinjaHudConfig : PluginConfigObject
     {
         [DragFloat2("Base Offset", min = -4000f, max = 4000f)]
+        [Order(0)]
         public Vector2 Position = new(127, 417);
 
         [Checkbox("Show Huton Gauge")]
+        [CollapseControl(5, 0)]
         public bool ShowHutonGauge = true;
 
         [DragFloat2("Huton Gauge Size", max = 2000f)]
+        [CollapseWith(0, 0)]
         public Vector2 HutonGaugeSize = new(254, 20);
 
         [DragFloat2("Huton Gauge Offset", min = -4000f, max = 4000f)]
+        [CollapseWith(5, 0)]
         public Vector2 HutonGaugeOffset = new(0, 0);
 
+        [ColorEdit4("Huton Gauge Color")]
+        [CollapseWith(10, 0)]
+        public PluginConfigColor HutonGaugeColor = new(new Vector4(110f / 255f, 197f / 255f, 207f / 255f, 100f / 100f));
+
         [Checkbox("Show Ninki Gauge")]
+        [CollapseControl(10, 1)]
         public bool ShowNinkiGauge = true;
 
         [Checkbox("Show Ninki Gauge Text")]
+        [CollapseWith(0, 1)]
         public bool ShowNinkiGaugeText = true;
 
         [Checkbox("Chunk Ninki Gauge")]
+        [CollapseWith(5, 1)]
         public bool ChunkNinkiGauge = true;
 
         [DragFloat2("Ninki Gauge Size", max = 2000f)]
+        [CollapseWith(10, 1)]
         public Vector2 NinkiGaugeSize = new(254, 20);
 
         [DragFloat2("Ninki Gauge Offset", min = -4000f, max = 4000f)]
+        [CollapseWith(15, 1)]
         public Vector2 NinkiGaugeOffset = new(0, 22);
 
         [DragFloat("Ninki Gauge Chunk Padding", min = -4000f, max = 4000f)]
+        [CollapseWith(20, 1)]
         public float NinkiGaugeChunkPadding = 2;
 
+        [ColorEdit4("Ninki Gauge Color")]
+        [CollapseWith(25, 1)]
+        public PluginConfigColor NinkiGaugeColor = new(new Vector4(137f / 255f, 82f / 255f, 236f / 255f, 100f / 100f));
+
         [Checkbox("Show Trick Bar")]
+        [CollapseControl(15, 2)]
         public bool ShowTrickBar = false;
 
         [Checkbox("Show Trick Bar Text")]
+        [CollapseWith(0, 2)]
         public bool ShowTrickBarText = true;
 
+        [ColorEdit4("Trick Bar Color")]
+        [CollapseWith(5, 2)]
+        public PluginConfigColor TrickBarColor = new(new Vector4(191f / 255f, 40f / 255f, 0f / 255f, 100f / 100f));
+
         [Checkbox("Show Suiton Bar")]
+        [CollapseControl(20, 3)]
         public bool ShowSuitonBar = true;
 
         [Checkbox("Show Suiton Bar Text")]
+        [CollapseWith(0, 3)]
         public bool ShowSuitonBarText = true;
 
+        [ColorEdit4("Suiton Bar Color")]
+        [CollapseWith(5, 3)]
+        public PluginConfigColor SuitonBarColor = new(new Vector4(202f / 255f, 228f / 255f, 246f / 242f, 100f / 100f));
+
         [DragFloat2("Trick/Suiton Bar Size", max = 2000f)]
+        [Order(25)]
         public Vector2 TrickBarSize = new(254, 20);
 
         [DragFloat2("Trick/Suiton Bar Offset", min = -4000f, max = 4000f)]
+        [Order(30)]
         public Vector2 TrickBarOffset = new(0, 44);
-
-        [ColorEdit4("Huton Gauge Color")]
-        public PluginConfigColor HutonGaugeColor = new(new Vector4(110f / 255f, 197f / 255f, 207f / 255f, 100f / 100f));
-
-        [ColorEdit4("Ninki Gauge Color")]
-        public PluginConfigColor NinkiGaugeColor = new(new Vector4(137f / 255f, 82f / 255f, 236f / 255f, 100f / 100f));
-
-        [ColorEdit4("Trick Bar Color")]
-        public PluginConfigColor TrickBarColor = new(new Vector4(191f / 255f, 40f / 255f, 0f / 255f, 100f / 100f));
-
-        [ColorEdit4("Suiton Bar Color")]
-        public PluginConfigColor SuitonBarColor = new(new Vector4(202f / 255f, 228f / 255f, 246f / 242f, 100f / 100f));
     }
 }

--- a/DelvUI/Interface/PaladinHudWindow.cs
+++ b/DelvUI/Interface/PaladinHudWindow.cs
@@ -201,93 +201,123 @@ namespace DelvUI.Interface
     public class PaladinHudConfig : PluginConfigObject
     {
         [DragFloat2("Base Offset", min = -4000f, max = 4000f)]
+        [Order(0)]
         public Vector2 Position = new(0, 0);
 
         [Checkbox("Show Mana Bar")]
+        [CollapseControl(5, 0)]
         public bool ShowManaBar = true;
 
         [Checkbox("Show Mana Bar Text")]
+        [CollapseWith(0, 0)]
         public bool ShowManaBarText = true;
 
         [Checkbox("Chunk Mana Bar")]
+        [CollapseWith(5, 0)]
         public bool ChunkManaBar = true;
 
         [DragFloat2("Mana Bar Size", max = 2000f)]
+        [CollapseWith(10, 0)]
         public Vector2 ManaBarSize = new(254, 20);
 
         [DragInt("Mana Bar Padding", max = 100)]
+        [CollapseWith(15, 0)]
         public int ManaBarPadding = 2;
 
         [DragFloat2("Mana Bar Offset", min = -4000f, max = 4000f)]
+        [CollapseWith(20, 0)]
         public Vector2 ManaBarOffset = new(127, 373);
 
+        [ColorEdit4("Mana Bar Color")]
+        [CollapseWith(25, 0)]
+        public PluginConfigColor ManaBarColor = new(new Vector4(0f / 255f, 203f / 255f, 230f / 255f, 100f / 100f));
+
         [Checkbox("Show Oath Gauge")]
+        [CollapseControl(10, 1)]
         public bool ShowOathGauge = true;
 
         [Checkbox("Show Oath Gauge Text")]
+        [CollapseWith(0, 1)]
         public bool ShowOathGaugeText = true;
 
         [DragFloat2("Oath Gauge Size", min = -4000f, max = 4000f)]
+        [CollapseWith(5, 1)]
         public Vector2 OathGaugeSize = new(254, 20);
 
         [DragInt("Oath Gauge Padding", max = 100)]
+        [CollapseWith(10, 1)]
         public int OathGaugePadding = 2;
 
         [DragFloat2("Oath Gauge Offset", min = -4000f, max = 4000f)]
+        [CollapseWith(15, 1)]
         public Vector2 OathGaugeOffset = new(127, 395);
 
+        [ColorEdit4("Oath Gauge Color")]
+        [CollapseWith(20, 1)]
+        public PluginConfigColor OathGaugeColor = new(new Vector4(24f / 255f, 80f / 255f, 175f / 255f, 100f / 100f));
+
         [Checkbox("Show Buff Bar")]
+        [CollapseControl(15, 2)]
         public bool ShowBuffBar = true;
 
         [Checkbox("Show Buff Bar Text")]
+        [CollapseWith(0, 2)]
         public bool ShowBuffBarText = true;
 
         [DragFloat2("Buff Bar Size", min = -4000f, max = 4000f)]
+        [CollapseWith(5, 2)]
         public Vector2 BuffBarSize = new(254, 20);
 
         [DragFloat2("Buff Bar Offset", min = -4000f, max = 4000f)]
+        [CollapseWith(10, 2)]
         public Vector2 BuffBarOffset = new(127, 417);
 
-        [Checkbox("Show Atonement Bar")]
-        public bool ShowAtonementBar = true;
-
-        [DragFloat2("Atonement Bar Size", min = -4000f, max = 4000f)]
-        public Vector2 AtonementBarSize = new(254, 20);
-
-        [DragInt("Atonement Bar Padding", max = 100)]
-        public int AtonementBarPadding = 2;
-
-        [DragFloat2("Atonement Bar Offset", min = -4000f, max = 4000f)]
-        public Vector2 AtonementBarOffset = new(127, 439);
-
-        [Checkbox("Show Goring Blade Bar")]
-        public bool ShowGoringBladeBar = true;
-
-        [Checkbox("Show Goring Blade Bar Text")]
-        public bool ShowGoringBladeBarText = true;
-
-        [DragFloat2("Goring Blade Bar Size", min = -4000f, max = 4000f)]
-        public Vector2 GoringBladeBarSize = new(254, 20);
-
-        [DragFloat2("Goring Blade Bar Offset", min = -4000f, max = 4000f)]
-        public Vector2 GoringBladeBarOffset = new(127, 351);
-
-        [ColorEdit4("Mana Bar Color")]
-        public PluginConfigColor ManaBarColor = new(new Vector4(0f / 255f, 203f / 255f, 230f / 255f, 100f / 100f));
-
-        [ColorEdit4("Oath Gauge Color")]
-        public PluginConfigColor OathGaugeColor = new(new Vector4(24f / 255f, 80f / 255f, 175f / 255f, 100f / 100f));
-
         [ColorEdit4("Fight or Flight Bar Color")]
+        [CollapseWith(15, 2)]
         public PluginConfigColor FightOrFlightColor = new(new Vector4(240f / 255f, 50f / 255f, 0f / 255f, 100f / 100f));
 
         [ColorEdit4("Requiescat Bar Color")]
+        [CollapseWith(20, 2)]
         public PluginConfigColor RequiescatColor = new(new Vector4(61f / 255f, 61f / 255f, 255f / 255f, 100f / 100f));
 
+        [Checkbox("Show Atonement Bar")]
+        [CollapseControl(20, 3)]
+        public bool ShowAtonementBar = true;
+
+        [DragFloat2("Atonement Bar Size", min = -4000f, max = 4000f)]
+        [CollapseWith(0, 3)]
+        public Vector2 AtonementBarSize = new(254, 20);
+
+        [DragInt("Atonement Bar Padding", max = 100)]
+        [CollapseWith(5, 3)]
+        public int AtonementBarPadding = 2;
+
+        [DragFloat2("Atonement Bar Offset", min = -4000f, max = 4000f)]
+        [CollapseWith(10, 3)]
+        public Vector2 AtonementBarOffset = new(127, 439);
+
         [ColorEdit4("Atonement Bar Color")]
+        [CollapseWith(15, 3)]
         public PluginConfigColor AtonementColor = new(new Vector4(240f / 255f, 176f / 255f, 0f / 255f, 100f / 100f));
 
+        [Checkbox("Show Goring Blade Bar")]
+        [CollapseControl(25, 4)]
+        public bool ShowGoringBladeBar = true;
+
+        [Checkbox("Show Goring Blade Bar Text")]
+        [CollapseWith(0, 4)]
+        public bool ShowGoringBladeBarText = true;
+
+        [DragFloat2("Goring Blade Bar Size", min = -4000f, max = 4000f)]
+        [CollapseWith(5, 4)]
+        public Vector2 GoringBladeBarSize = new(254, 20);
+
+        [DragFloat2("Goring Blade Bar Offset", min = -4000f, max = 4000f)]
+        [CollapseWith(10, 4)]
+        public Vector2 GoringBladeBarOffset = new(127, 351);
+
         [ColorEdit4("Goring Blade Color")]
+        [CollapseWith(15, 4)]
         public PluginConfigColor GoringBladeColor = new(new Vector4(255f / 255f, 128f / 255f, 0f / 255f, 100f / 100f));
     }
 }

--- a/DelvUI/Interface/WarriorHudWindow.cs
+++ b/DelvUI/Interface/WarriorHudWindow.cs
@@ -110,47 +110,61 @@ namespace DelvUI.Interface
     public class WarriorHudConfig : PluginConfigObject
     {
         [DragFloat2("Base offset", min = -4000f, max = 4000f)]
+        [Order(0)]
         public Vector2 Position = new(0, 0);
 
         /* Storm's Eye */
         [Checkbox("Show Storm's Eye")]
+        [CollapseControl(5, 0)]
         public bool ShowStormsEye = true;
 
         [Checkbox("Show Storm's Eye Text")]
+        [CollapseWith(0, 0)]
         public bool ShowStormsEyeText = true;
 
         [DragFloat2("Storm's Eye Position", min = -4000f, max = 4000f)]
+        [CollapseWith(5, 0)]
         public Vector2 StormsEyePosition = new(0, 428);
 
         [DragFloat2("Storm's Eye Size", min = 1f, max = 4000f)]
+        [CollapseWith(10, 0)]
         public Vector2 StormsEyeSize = new(254, 20);
 
         [ColorEdit4("Inner Release Color")]
+        [CollapseWith(15, 0)]
         public PluginConfigColor InnerReleaseColor = new(new Vector4(255f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
 
         [ColorEdit4("Storm's Eye Color")]
+        [CollapseWith(20, 0)]
         public PluginConfigColor StormsEyeColor = new(new Vector4(255f / 255f, 136f / 255f, 146f / 255f, 100f / 100f));
 
         /* Beast Gauge*/
         [Checkbox("Show Beast Gauge")]
+        [CollapseControl(10, 1)]
         public bool ShowBeastGauge = true;
 
         [Checkbox("Show Beast Gauge Text")]
+        [CollapseWith(0, 1)]
         public bool ShowBeastGaugeText = false;
 
         [DragFloat2("Beast Gauge Position", min = -4000f, max = 4000f)]
+        [CollapseWith(5, 1)]
         public Vector2 BeastGaugePosition = new(0, 449);
 
         [DragFloat2("Beast Gauge Size", min = 1f, max = 4000f)]
+        [CollapseWith(10, 1)]
         public Vector2 BeastGaugeSize = new(254, 20);
 
         [DragFloat("Beast Gauge Spacing")]
+        [CollapseWith(15, 1)]
         public float BeastGaugePadding = 2.0f;
 
         [ColorEdit4("Beast Gauge Fill Color")]
+        [CollapseWith(20, 1)]
         public PluginConfigColor BeastGaugeFillColor = new(new Vector4(201f / 255f, 13f / 255f, 13f / 255f, 100f / 100f));
 
         [ColorEdit4("Nascent Chaos Color")]
+        [CollapseWith(25, 1)]
         public PluginConfigColor NascentChaosColor = new(new Vector4(240f / 255f, 176f / 255f, 0f / 255f, 100f / 100f));
     }
 }


### PR DESCRIPTION
Add the ability to define order for config options.
Add the ability to create collapsible categories for config options example:
![collapsiblegif](https://user-images.githubusercontent.com/7407004/132255707-979a9c4a-d696-403a-b4ef-bd598101654f.gif)
Note that this does lead to semi-random ordering for options where order is not specified, which is a change in behaviour from previously.