### PR TITLE
Feat/import export

### DIFF
--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -135,4 +135,15 @@ namespace DelvUI.Config.Attributes
             this.id = id;
         }
     }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class PortableAttribute : Attribute
+    {
+        public bool portable;
+
+        public PortableAttribute(bool portable)
+        {
+            this.portable = portable;
+        }
+    }
 }

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -109,7 +109,7 @@ namespace DelvUI.Config
         public static string GenerateExportString(PluginConfigObject configObject)
         {
             var jsonString = JsonConvert.SerializeObject(configObject, Formatting.Indented,
-                new JsonSerializerSettings { TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,TypeNameHandling = TypeNameHandling.Objects });
+                new JsonSerializerSettings { TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple, TypeNameHandling = TypeNameHandling.Objects });
 
             return CompressAndBase64Encode(jsonString);
         }
@@ -123,7 +123,7 @@ namespace DelvUI.Config
             }
             catch (Exception ex)
             {
-                PluginLog.Log(ex.Message + "\n" +ex.StackTrace);
+                PluginLog.Log(ex.Message + "\n" + ex.StackTrace);
 
                 return default;
             }

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -2,6 +2,11 @@ using Dalamud.Plugin;
 using DelvUI.Config.Tree;
 using DelvUI.Interface;
 using ImGuiScene;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
 
 namespace DelvUI.Config
 {
@@ -75,5 +80,53 @@ namespace DelvUI.Config
         public void SaveConfigurations() { ConfigBaseNode.Save(ConfigDirectory); }
 
         public PluginConfigObject GetConfiguration(PluginConfigObject configObject) => ConfigBaseNode.GetOrAddConfig(configObject).ConfigObject;
+
+        public static string CompressAndBase64Encode(string jsonString)
+        {
+            using MemoryStream output = new();
+
+            using (DeflateStream gzip = new(output, CompressionLevel.Fastest))
+            {
+                using StreamWriter writer = new(gzip, Encoding.UTF8);
+                writer.Write(jsonString);
+            }
+
+            return Convert.ToBase64String(output.ToArray());
+        }
+
+        public static string Base64DecodeAndDecompress(string base64String)
+        {
+            var base64EncodedBytes = Convert.FromBase64String(base64String);
+
+            using MemoryStream inputStream = new(base64EncodedBytes);
+            using DeflateStream gzip = new(inputStream, CompressionMode.Decompress);
+            using StreamReader reader = new(gzip, Encoding.UTF8);
+            var decodedString = reader.ReadToEnd();
+
+            return decodedString;
+        }
+
+        public static string GenerateExportString(PluginConfigObject configObject)
+        {
+            var jsonString = JsonConvert.SerializeObject(configObject, Formatting.Indented,
+                new JsonSerializerSettings { TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,TypeNameHandling = TypeNameHandling.Objects });
+
+            return CompressAndBase64Encode(jsonString);
+        }
+
+        public static T LoadImportString<T>(string importString) where T : PluginConfigObject
+        {
+            try
+            {
+                var jsonString = Base64DecodeAndDecompress(importString);
+                return JsonConvert.DeserializeObject<T>(jsonString);
+            }
+            catch (Exception ex)
+            {
+                PluginLog.Log(ex.Message + "\n" +ex.StackTrace);
+
+                return default;
+            }
+        }
     }
 }

--- a/DelvUI/Config/PluginConfigObject.cs
+++ b/DelvUI/Config/PluginConfigObject.cs
@@ -9,7 +9,6 @@ namespace DelvUI.Config
     [Serializable]
     public abstract class PluginConfigObject
     {
-        public bool portable { get; set; } = true;
 
         protected bool ColorEdit4(string label, ref PluginConfigColor color)
         {

--- a/DelvUI/Config/PluginConfigObject.cs
+++ b/DelvUI/Config/PluginConfigObject.cs
@@ -9,6 +9,8 @@ namespace DelvUI.Config
     [Serializable]
     public abstract class PluginConfigObject
     {
+        public bool portable { get; set; } = true;
+
         protected bool ColorEdit4(string label, ref PluginConfigColor color)
         {
             var vector = color.Vector;

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -516,7 +516,7 @@ namespace DelvUI.Config.Tree
                 pair.Value.Draw(ref changed);
             }
 
-            if(ConfigObject.portable)
+            if (ConfigObject.portable)
             {
                 DrawImportExportGeneralConfig();
             }

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -516,7 +516,10 @@ namespace DelvUI.Config.Tree
                 pair.Value.Draw(ref changed);
             }
 
-            DrawImportExportGeneralConfig();
+            if(ConfigObject.portable)
+            {
+                DrawImportExportGeneralConfig();
+            }
         }
 
         private void DrawImportExportGeneralConfig()

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -516,7 +516,10 @@ namespace DelvUI.Config.Tree
                 pair.Value.Draw(ref changed);
             }
 
-            if (ConfigObject.portable)
+            // if the config object is not marked with [Portable(false)], or is marked with [Portable(true)],
+            // draw the import/export UI
+            PortableAttribute portableAttribute = (PortableAttribute) ConfigObject.GetType().GetCustomAttribute((typeof(PortableAttribute)), false);
+            if (portableAttribute == null || portableAttribute.portable)
             {
                 DrawImportExportGeneralConfig();
             }

--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -1308,6 +1308,11 @@ namespace DelvUI.Interface
     [SubSection("General##Tank", 1)]
     public class TankHudConfig : PluginConfigObject
     {
+        public TankHudConfig()
+        {
+            portable = false;
+        }
+
         [Checkbox("Tank Stance Indicator Enabled")]
         public bool TankStanceIndicatorEnabled = true;
 

--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -1303,16 +1303,12 @@ namespace DelvUI.Interface
     }
 
     [Serializable]
+    [Portable(false)]
     [Section("Job Specific Bars")]
     [SubSection("Tank", 0)]
     [SubSection("General##Tank", 1)]
     public class TankHudConfig : PluginConfigObject
     {
-        public TankHudConfig()
-        {
-            portable = false;
-        }
-
         [Checkbox("Tank Stance Indicator Enabled")]
         public bool TankStanceIndicatorEnabled = true;
 

--- a/DelvUI/Interface/NinjaHudWindow.cs
+++ b/DelvUI/Interface/NinjaHudWindow.cs
@@ -339,7 +339,7 @@ namespace DelvUI.Interface
 
         [Checkbox("Show Suiton Bar")]
         [CollapseControl(20, 3)]
-        public bool ShowSuitonBar = true;
+        public bool ShowSuitonBar = false;
 
         [Checkbox("Show Suiton Bar Text")]
         [CollapseWith(0, 3)]

--- a/DelvUI/Interface/NinjaHudWindow.cs
+++ b/DelvUI/Interface/NinjaHudWindow.cs
@@ -339,7 +339,7 @@ namespace DelvUI.Interface
 
         [Checkbox("Show Suiton Bar")]
         [CollapseControl(20, 3)]
-        public bool ShowSuitonBar = false;
+        public bool ShowSuitonBar = true;
 
         [Checkbox("Show Suiton Bar Text")]
         [CollapseWith(0, 3)]


### PR DESCRIPTION
Added functionality to the new config window for importing and export base 64 strings. Let me emphasize that the UI is a WIP -- I will let others more familiar with ImGui make it look good.

The way import/export is done is by adding the functionality to `ConfigPageNode` (the lowest nodes of the config tree). If the import/export GUI is not desired for a given `PluginConfigObject`, simply set `portable = false` in its constructor (see `TankHudConfig`, for example). As a consequence there is not yet a way to export all jobs at once. This could be added later as a new `SelectionNode` under `Job Specific Bars`, which would contain a `ConfigPageNode` (with `portable = false`). But I refrained from doing so, since I'm not sure what the plan is for that.

A quick note on import/export. Because there are currently two different configuration windows, there are two different import/export systems (and reading/writing of configs to file). As the old window gets refactored to the new window, the new import/export should work automatically (given that the refactoring is done correctly).

![image](https://user-images.githubusercontent.com/741529/132558443-a2ccb1a6-69d0-457f-abe8-4334a7d6b2f6.png)

