### PR TITLE
Fix area for raid/job buffs

### DIFF
--- a/DelvUI/Config/PluginConfiguration.cs
+++ b/DelvUI/Config/PluginConfiguration.cs
@@ -30,7 +30,8 @@ namespace DelvUI.Config
             false,
             false,
             GrowthDirections.Out | GrowthDirections.Right,
-            new StatusEffectIconConfig(new Vector2(35, 35), true, true, false, false)
+            new StatusEffectIconConfig(new Vector2(35, 35), true, true, false, false),
+            new Vector2(1000, 0)
         );
 
         [JsonIgnore]

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -39,6 +39,16 @@ namespace DelvUI.Interface.StatusEffects
             GrowthDirections = growthDirections;
             IconConfig = iconConfig;
         }
+        public StatusEffectsListConfig(Vector2 position, bool showBuffs, bool showDebuffs, bool showPermanentEffects, GrowthDirections growthDirections, StatusEffectIconConfig iconConfig, Vector2 maxSize)
+        {
+            Position = position;
+            ShowBuffs = showBuffs;
+            ShowDebuffs = showDebuffs;
+            ShowPermanentEffects = showPermanentEffects;
+            GrowthDirections = growthDirections;
+            IconConfig = iconConfig;
+            MaxSize = maxSize;
+        }
 
         public bool Draw()
         {


### PR DESCRIPTION
This ensures they always stay in one row