### PR TITLE
Added an overall Import/Export pane for the new config window

### DIFF
--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -146,4 +146,8 @@ namespace DelvUI.Config.Attributes
             this.portable = portable;
         }
     }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class ManualDrawAttribute : Attribute
+    { }
 }

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -3,6 +3,7 @@ using DelvUI.Config.Tree;
 using DelvUI.Interface;
 using ImGuiScene;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using System.IO.Compression;
@@ -45,7 +46,8 @@ namespace DelvUI.Config
                 new WhiteMageHudConfig(), new ScholarHudConfig(), new AstrologianHudConfig(),
                 new MonkHudConfig(), new DragoonHudConfig(), new NinjaHudConfig(), new SamuraiHudConfig(),
                 new BardHudConfig(), new MachinistHudConfig(), new DancerHudConfig(),
-                new BlackMageHudConfig(), new SummonerHudConfig(), new RedMageHudConfig()
+                new BlackMageHudConfig(), new SummonerHudConfig(), new RedMageHudConfig(),
+                new ImportExportHudConfig()
             };
 
             return Initialize(defaultConfig, configObjects);

--- a/DelvUI/Interface/ImportExportHudConfig.cs
+++ b/DelvUI/Interface/ImportExportHudConfig.cs
@@ -1,0 +1,81 @@
+﻿using Dalamud.Plugin;
+using DelvUI.Config;
+using DelvUI.Config.Attributes;
+using ImGuiNET;
+using System;
+using System.Numerics;
+
+namespace DelvUI.Interface
+{
+    [Portable(false)]
+    [Section("Import/Export")]
+    [SubSection("General", 0)]
+    public class ImportExportHudConfig : PluginConfigObject
+    {
+        private string _importString = "";
+        private string _exportString = "";
+
+        [ManualDraw]
+        public void DrawFullImportExport()
+        {
+            uint maxLength = 40000;
+            ImGui.BeginChild("importpane", new Vector2(0, ImGui.GetWindowHeight() / 6), false, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
+            {
+                ImGui.Text("Import string:");
+                ImGui.InputText("", ref _importString, maxLength);
+
+                if (ImGui.Button("Import configuration") && _importString != "")
+                {
+                    string[] importStrings = _importString.Trim().Split(new string[] { "|" }, StringSplitOptions.RemoveEmptyEntries);
+                    ConfigurationManager.GetInstance().ConfigBaseNode.LoadBase64String(importStrings);
+                }
+
+                ImGui.SameLine();
+
+                if (ImGui.Button("Paste from clipboard"))
+                {
+                    try
+                    {
+                        _importString = ImGui.GetClipboardText();
+                    }
+                    catch (Exception ex)
+                    {
+                        PluginLog.Log("Could not get clipboard text:\n" + ex.StackTrace);
+                    }
+
+                }
+            }
+
+            ImGui.EndChild();
+
+            ImGui.BeginChild("exportpane", new Vector2(0, ImGui.GetWindowHeight() / 6), false, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
+
+            {
+                ImGui.Text("Export string:");
+                ImGui.InputText("", ref _exportString, maxLength, ImGuiInputTextFlags.ReadOnly);
+
+                if (ImGui.Button("Export configuration"))
+                {
+                    _exportString = ConfigurationManager.GetInstance().ConfigBaseNode.GetBase64String();
+                }
+
+                ImGui.SameLine();
+
+                if (ImGui.Button("Copy to clipboard") && _exportString != "")
+                {
+                    try
+                    {
+                        ImGui.SetClipboardText(_exportString);
+                    }
+                    catch (Exception ex)
+                    {
+                        PluginLog.Log("Could not set clipboard text:\n" + ex.StackTrace);
+                    }
+
+                }
+            }
+
+            ImGui.EndChild();
+        }
+    }
+}


### PR DESCRIPTION
(as opposed to the per-job import/exports). See [here](https://media.discordapp.net/attachments/879308602328903680/885439830849376287/8gdwyirqdH.gif?width=932&height=676) for a visual explanation.

The main new thing to look out for in the code is the attribute `[ManualDraw]`. This is an attribute for methods in a `PluginConfigObject` that tells ConfigurationManager to call the method traversing the tree of `Node`s. This way we can draw things that aren't just configuration fields (such as UI to import/export, for example, which has nothing to do with configuration parameters).