### PR TITLE
Added BarTextType.Remaining, added suggested NIN bar tweaks

### DIFF
--- a/DelvUI/Interface/Bars/Bar.cs
+++ b/DelvUI/Interface/Bars/Bar.cs
@@ -119,6 +119,7 @@ namespace DelvUI.Interface.Bars
                 var strText = text.Type switch
                 {
                     BarTextType.Current => throw new InvalidOperationException("Full bar text must be 'Custom' type."),
+                    BarTextType.Remaining => throw new InvalidOperationException("Full bar text must be 'Custom' type."),
                     BarTextType.Maximum => throw new InvalidOperationException("Full bar text must be 'Custom' type."),
                     BarTextType.Percentage => throw new InvalidOperationException("Full bar text must be 'Custom' type."),
                     BarTextType.Custom => text.Text,
@@ -329,6 +330,7 @@ namespace DelvUI.Interface.Bars
                 var text = textObj.Type switch
                 {
                     BarTextType.Current => Math.Round(CurrentValue).ToString(CultureInfo.InvariantCulture),
+                    BarTextType.Remaining => Math.Round(MaximumValue - CurrentValue).ToString(CultureInfo.InvariantCulture),
                     BarTextType.Maximum => Math.Round(MaximumValue).ToString(CultureInfo.InvariantCulture),
                     BarTextType.Percentage => Math.Round(CurrentValue / MaximumValue * 100f).ToString(CultureInfo.InvariantCulture),
                     BarTextType.Custom => textObj.Text,
@@ -372,6 +374,7 @@ namespace DelvUI.Interface.Bars
                         var text = textObj.Type switch
                         {
                             BarTextType.Current => Math.Round(barValue).ToString(CultureInfo.InvariantCulture),
+                            BarTextType.Remaining => Math.Round(barMaximum - barValue).ToString(CultureInfo.InvariantCulture),
                             BarTextType.Maximum => Math.Round(barMaximum).ToString(CultureInfo.InvariantCulture),
                             BarTextType.Percentage => Math.Round(currentFill * 100f).ToString(CultureInfo.InvariantCulture),
                             BarTextType.Custom => textObj.Text,
@@ -422,6 +425,7 @@ namespace DelvUI.Interface.Bars
                         var text = textObj.Type switch
                         {
                             BarTextType.Current => Math.Round(barValue).ToString(CultureInfo.InvariantCulture),
+                            BarTextType.Remaining => Math.Round(barMaximum - barValue).ToString(CultureInfo.InvariantCulture),
                             BarTextType.Maximum => Math.Round(barMaximum).ToString(CultureInfo.InvariantCulture),
                             BarTextType.Percentage => Math.Round(currentFill * 100f).ToString(CultureInfo.InvariantCulture),
                             BarTextType.Custom => textObj.Text,
@@ -713,6 +717,7 @@ namespace DelvUI.Interface.Bars
     public enum BarTextType
     {
         Current,
+        Remaining,
         Maximum,
         Percentage,
         Custom

--- a/DelvUI/Interface/Jobs/NinjaHud.cs
+++ b/DelvUI/Interface/Jobs/NinjaHud.cs
@@ -87,7 +87,6 @@ namespace DelvUI.Interface.Jobs
             }
             else
             {
-                //PluginLog.Log($"NOT in ninjutsu with cd {mudraCooldownInfo} and old cd {_oldMudraCooldownInfo}");
                 _oldMudraCooldownInfo = mudraCooldownInfo;
             }
             // if we are casting ninjutsu then show ninjutsu info


### PR DESCRIPTION
Added a BarTextType.Remaining to show `max - current`.
Made a number of modifications to the NIN job based on suggestions from issues #358  and #365:
1. Kassatsu and TCJ bars drain while active
2. Mudra bar now shows remaining time until charge refresh
3. Mudra bars hide unnecessary text
4. Added options for hiding Huton bar text and an expiry color option

Note that the third suggestion from #365 has not yet been implemented due to some technical difficulties and will be implemented upon the resolution of said difficulties.