### PR TITLE
DragDropHorizontal Attribute and SAM examples

### DIFF
--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -155,7 +155,7 @@ namespace DelvUI.Config.Attributes
         public string friendlyName;
         public string[] names;
 
-        public DragDropHorizontalAttribute(string friendlyName, string[] names)
+        public DragDropHorizontalAttribute(string friendlyName, params string[] names)
         {
             this.friendlyName = friendlyName;
             this.names = names;

--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -149,6 +149,19 @@ namespace DelvUI.Config.Attributes
         }
     }
 
+    [AttributeUsage(AttributeTargets.Field)]
+    public class DragDropHorizontalAttribute : Attribute
+    {   
+        public string friendlyName;
+        public string[] names;
+
+        public DragDropHorizontalAttribute(string friendlyName, string[] names)
+        {
+            this.friendlyName = friendlyName;
+            this.names = names;
+        }
+    }
+
     [AttributeUsage(AttributeTargets.Class)]
     public class PortableAttribute : Attribute
     {
@@ -159,7 +172,6 @@ namespace DelvUI.Config.Attributes
             this.portable = portable;
         }
     }
-
     [AttributeUsage(AttributeTargets.Method)]
     public class ManualDrawAttribute : Attribute
     {

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -1115,6 +1115,7 @@ namespace DelvUI.Config.Tree
                     int[] order = (int[])fieldVal;
                     string[] names = dragDropHorizontalAttribute.names;
                     for(int i = 0; i < order.Count(); i++){
+                        ImGui.SameLine();
                         ImGui.Button(names[order[i]], new Vector2(100, 25));
                         if (ImGui.IsItemActive()){
                             float drag_dx = ImGui.GetMouseDragDelta(0).X;
@@ -1135,8 +1136,6 @@ namespace DelvUI.Config.Tree
                                 ImGui.ResetMouseDragDelta();
                             }
                         }
-                        if (i < order.Count() - 1) 
-                            ImGui.SameLine();
                     }
                 }
             }

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -1109,6 +1109,36 @@ namespace DelvUI.Config.Tree
                         changed = true;
                     }
                 }
+                else if (attribute is DragDropHorizontalAttribute dragDropHorizontalAttribute)
+                {
+                    ImGui.Text(dragDropHorizontalAttribute.friendlyName);
+                    int[] order = (int[])fieldVal;
+                    string[] names = dragDropHorizontalAttribute.names;
+                    for(int i = 0; i < order.Count(); i++){
+                        ImGui.Button(names[order[i]], new Vector2(100, 25));
+                        if (ImGui.IsItemActive()){
+                            float drag_dx = ImGui.GetMouseDragDelta(0).X;
+                            if ((drag_dx > 80.0f && i < order.Count() - 1))
+                            {
+                                var _curri = order[i];
+                                order[i] = order[i+1];
+                                order[i+1] = _curri;
+                                field.SetValue(ConfigObject, order);
+                                ImGui.ResetMouseDragDelta();
+                            }
+                            else if ((drag_dx < -80.0f && i > 0))
+                            {
+                                var _curri = order[i];
+                                order[i] = order[i-1];
+                                order[i-1] = _curri;
+                                field.SetValue(ConfigObject, order);
+                                ImGui.ResetMouseDragDelta();
+                            }
+                        }
+                        if (i < order.Count() - 1) 
+                            ImGui.SameLine();
+                    }
+                }
             }
         }
     }

--- a/DelvUI/Interface/Jobs/SamuraiHud.cs
+++ b/DelvUI/Interface/Jobs/SamuraiHud.cs
@@ -111,12 +111,13 @@ namespace DelvUI.Interface.Jobs
         {
             var target = PluginInterface.ClientState.LocalPlayer;
             var buffsSize = new Vector2(Config.BuffsBarSize.X / 2f - Config.BuffsPadding / 2f, Config.BuffsBarSize.Y);
+            var order = Config.buffOrder;
 
             // shifu
             var shifu = target.StatusEffects.FirstOrDefault(o => o.EffectId == 1299);
             var shifuDuration = shifu.Duration;
             var shifuPos = new Vector2(
-                origin.X + Config.Position.X + Config.BuffsBarPosition.X - Config.BuffsBarSize.X / 2f,
+                origin.X + Config.Position.X + Config.BuffsBarPosition.X + (2 * order[0] - 1) * Config.BuffsBarSize.X / 2f - order[0] * buffsSize.X,
                 origin.Y + Config.Position.Y + Config.BuffsBarPosition.Y - Config.BuffsBarSize.Y / 2f
             );
             var shifuBuilder = BarBuilder.Create(shifuPos, buffsSize)
@@ -128,7 +129,7 @@ namespace DelvUI.Interface.Jobs
             var jinpu = target.StatusEffects.FirstOrDefault(o => o.EffectId == 1298);
             var jinpuDuration = jinpu.Duration;
             var jinpuPos = new Vector2(
-                origin.X + Config.Position.X + Config.BuffsBarPosition.X + Config.BuffsBarSize.X / 2f - buffsSize.X,
+                origin.X + Config.Position.X + Config.BuffsBarPosition.X + (2 * order[1] - 1) * Config.BuffsBarSize.X / 2f - order[1] * buffsSize.X,
                 origin.Y + Config.Position.Y + Config.BuffsBarPosition.Y - Config.BuffsBarSize.Y / 2f
             );
             var jinpuBuilder = BarBuilder.Create(jinpuPos, buffsSize)
@@ -160,13 +161,14 @@ namespace DelvUI.Interface.Jobs
             var drawList = ImGui.GetWindowDrawList();
 
             // setsu, getsu, ka
+            var order = Config.senOrder;
             var hasSen = new int[] { gauge.HasSetsu() ? 1 : 0, gauge.HasGetsu() ? 1 : 0, gauge.HasKa() ? 1 : 0 };
             var colors = new PluginConfigColor[] { Config.SetsuColor, Config.GetsuColor, Config.KaColor };
 
             for (int i = 0; i < 3; i++)
             {
                 var builder = BarBuilder.Create(cursorPos, senBarSize).
-                    AddInnerBar(hasSen[i], 1, colors[i].Map);
+                    AddInnerBar(hasSen[order[i]], 1, colors[order[i]].Map);
 
                 builder.Build().Draw(drawList);
                 cursorPos.X += senBarWidth + Config.SenBarPadding;
@@ -294,6 +296,14 @@ namespace DelvUI.Interface.Jobs
         [Checkbox("Show Higanbana Text")]
         [CollapseWith(10, 4)]
         public bool ShowHiganbanaText = true;
+        #endregion
+
+        #region BarOrders
+        [DragDropHorizontal("Shifu/Jinpu Order", new string[] {"Shifu", "Jinpu"})]
+        public int[] buffOrder = new int[] {0, 1};
+
+        [DragDropHorizontal("Sen Order", new string[] {"Setsu", "Getsu", "Ka"})]
+        public int[] senOrder = new int[] {0, 1, 2};
         #endregion
 
         #region colors

--- a/DelvUI/Interface/Jobs/SamuraiHud.cs
+++ b/DelvUI/Interface/Jobs/SamuraiHud.cs
@@ -239,7 +239,7 @@ namespace DelvUI.Interface.Jobs
         [CollapseWith(10, 1)]
         public Vector2 SenBarPosition = new Vector2(0, HUDConstants.JobHudsBaseY - 17);
 
-        [DragDropHorizontal("Sen Order", new string[] {"Setsu", "Getsu", "Ka"})]
+        [DragDropHorizontal("Sen Order", "Setsu", "Getsu", "Ka")]
         [CollapseWith(15, 1)]
         public int[] senOrder = new int[] {0, 1, 2};
         #endregion
@@ -283,7 +283,7 @@ namespace DelvUI.Interface.Jobs
         [CollapseWith(15, 3)]
         public bool ShowBuffsText = true;
 
-        [DragDropHorizontal("Shifu/Jinpu Order", new string[] {"Shifu", "Jinpu"})]
+        [DragDropHorizontal("Shifu/Jinpu Order", "Shifu", "Jinpu")]
         [CollapseWith(20, 3)]
         public int[] buffOrder = new int[] {0, 1};
         

--- a/DelvUI/Interface/Jobs/SamuraiHud.cs
+++ b/DelvUI/Interface/Jobs/SamuraiHud.cs
@@ -238,6 +238,10 @@ namespace DelvUI.Interface.Jobs
         [DragFloat2("Sen Bar Position", min = -2000f, max = 2000f)]
         [CollapseWith(10, 1)]
         public Vector2 SenBarPosition = new Vector2(0, HUDConstants.JobHudsBaseY - 17);
+
+        [DragDropHorizontal("Sen Order", new string[] {"Setsu", "Getsu", "Ka"})]
+        [CollapseWith(15, 1)]
+        public int[] senOrder = new int[] {0, 1, 2};
         #endregion
 
         #region Meditation
@@ -278,6 +282,11 @@ namespace DelvUI.Interface.Jobs
         [Checkbox("Show Buffs Bar Text")]
         [CollapseWith(15, 3)]
         public bool ShowBuffsText = true;
+
+        [DragDropHorizontal("Shifu/Jinpu Order", new string[] {"Shifu", "Jinpu"})]
+        [CollapseWith(20, 3)]
+        public int[] buffOrder = new int[] {0, 1};
+        
         #endregion
 
         #region Higanbana
@@ -299,11 +308,9 @@ namespace DelvUI.Interface.Jobs
         #endregion
 
         #region BarOrders
-        [DragDropHorizontal("Shifu/Jinpu Order", new string[] {"Shifu", "Jinpu"})]
-        public int[] buffOrder = new int[] {0, 1};
+        
 
-        [DragDropHorizontal("Sen Order", new string[] {"Setsu", "Getsu", "Ka"})]
-        public int[] senOrder = new int[] {0, 1, 2};
+        
         #endregion
 
         #region colors


### PR DESCRIPTION
Adds a DragDropHorizontal attribute, which controls a list of integers meant to represent the ordering of a set of elements on the UI. The field that the attribute is set on will appear in the config window as a set of (uncolored) labeled buttons that can be clicked and dragged to swap the values in the field. I've included two examples - SAM Shifu/Jinpu ordering and SAM sen ordering.

Note: I tried to implement this with ImGui DragDropSource/DragDropTargets, but found that if we call SetDragDropPayload with any payload size higher than 0, the game immediately crashes as soon as you click one of the buttons. Thus, I opted for this more primitive but stable implementation that just uses MouseDelta values when clicking one of the buttons.