### PR TITLE
Implementing tooltips (used only in status effect lists right now)

### DIFF
--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -1,5 +1,6 @@
 using Dalamud.Plugin;
 using DelvUI.Config.Tree;
+using DelvUI.Helpers;
 using DelvUI.Interface.GeneralElements;
 using DelvUI.Interface.Jobs;
 using DelvUI.Interface.StatusEffects;
@@ -94,6 +95,7 @@ namespace DelvUI.Config
                 typeof(MiscColorConfig),
 
                 typeof(PrimaryResourceConfig),
+                typeof(TooltipsConfig),
                 typeof(GCDIndicatorConfig),
                 typeof(MPTickerConfig)
             };

--- a/DelvUI/Helpers/TooltipsHelper.cs
+++ b/DelvUI/Helpers/TooltipsHelper.cs
@@ -1,0 +1,187 @@
+﻿using Dalamud.Plugin;
+using DelvUI.Config;
+using DelvUI.Config.Attributes;
+using ImGuiNET;
+using System;
+using System.Numerics;
+using System.Text.RegularExpressions;
+
+namespace DelvUI.Helpers
+{
+    public class TooltipsHelper
+    {
+        #region Singleton
+        private TooltipsHelper()
+        {
+            _config = ConfigurationManager.GetInstance().GetConfigObject<TooltipsConfig>();
+        }
+
+        public static void Initialize() { Instance = new TooltipsHelper(); }
+
+        public static TooltipsHelper Instance { get; private set; }
+
+        #endregion
+
+        private static float MaxWidth = 300;
+        private static float Margin = 5;
+
+        private TooltipsConfig _config;
+
+        private string _currentTooltipText = null;
+        private Vector2 _textSize;
+        private string _currentTooltipTitle = null;
+        private Vector2 _titleSize;
+        private string _previousRawText = null;
+
+        private Vector2 _position;
+        private Vector2 _size;
+
+        public void ShowTooltipOnCursor(string text, string title = null)
+        {
+            ShowTooltip(text, ImGui.GetMousePos(), title);
+        }
+        public void ShowTooltip(string text, Vector2 position, string title = null)
+        {
+            if (text == null)
+            {
+                return;
+            }
+
+            PluginLog.Log(SanitizeText(text));
+
+            // remove styling tags from text
+            if (_previousRawText != text)
+            {
+                _currentTooltipText = SanitizeText(text);
+                _previousRawText = text;
+            }
+
+            // calcualte title size
+            _titleSize = Vector2.Zero;
+            if (title != null)
+            {
+                _currentTooltipTitle = title;
+                _titleSize = ImGui.CalcTextSize(title, MaxWidth);
+                _titleSize.Y += Margin;
+            }
+
+            // calculate text size
+            _textSize = ImGui.CalcTextSize(_currentTooltipText, MaxWidth);
+            _size = new Vector2(Math.Max(_titleSize.X, _textSize.X) + Margin * 2, _titleSize.Y + _textSize.Y + Margin * 2);
+
+            // position tooltip using the given coordinates as bottom center
+            position.X = position.X - _size.X / 2f;
+            position.Y = position.Y - _size.Y;
+
+            // correct tooltips off screen
+            _position = CalculatePosition(position, _size);
+        }
+
+        public void RemoveTooltip()
+        {
+            _currentTooltipText = null;
+            _currentTooltipTitle = null;
+            _previousRawText = null;
+        }
+
+        public void Draw()
+        {
+            if (_currentTooltipText == null)
+            {
+                return;
+            }
+
+            // bg
+            var drawList = ImGui.GetWindowDrawList();
+            drawList.AddRectFilled(_position, _position + _size, _config.BackgroundColor.Base);
+
+            if (_currentTooltipTitle != null)
+            {
+                // title
+                var cursorPos = new Vector2(_position.X + _size.X / 2f - _titleSize.X / 2f, _position.Y + Margin);
+                ImGui.SetCursorPos(cursorPos);
+                ImGui.PushTextWrapPos(cursorPos.X + _titleSize.X);
+                ImGui.TextColored(_config.TitleColor.Vector, _currentTooltipTitle);
+                ImGui.PopTextWrapPos();
+
+                // text
+                cursorPos = new Vector2(_position.X + _size.X / 2f - _textSize.X / 2f, _position.Y + Margin + _titleSize.Y);
+                ImGui.SetCursorPos(cursorPos);
+                ImGui.PushTextWrapPos(cursorPos.X + _textSize.X);
+                ImGui.TextColored(_config.TextColor.Vector, _currentTooltipText);
+                ImGui.PopTextWrapPos();
+            }
+            else
+            {
+                // text
+                var cursorPos = _position + new Vector2(Margin, Margin);
+                var textWidth = _size.X - Margin * 2;
+
+                ImGui.SetCursorPos(cursorPos);
+                ImGui.PushTextWrapPos(cursorPos.X + textWidth);
+                ImGui.TextColored(_config.TextColor.Vector, _currentTooltipText);
+                ImGui.PopTextWrapPos();
+            }
+        }
+
+        private string SanitizeText(string text)
+        {
+            // some data comes with unicode characters i couldn't figure out how to get rid of
+            // so im doing a pretty aggressive replace to keep only "nice" characters
+            var result = Regex.Replace(text, @"[^a-zA-Z0-9 -\.\,\?]", "");
+
+            // after that there's still some leftovers characters that need to be removed
+            Regex regex = new Regex("HI(.*?)IH");
+            foreach (Match match in regex.Matches(result))
+            {
+                if (match.Groups.Count > 1)
+                {
+                    result = result.Replace(match.Value, match.Groups[1].Value);
+                }
+            }
+
+            return result;
+        }
+
+        private Vector2 CalculatePosition(Vector2 position, Vector2 size)
+        {
+            var screenSize = ImGui.GetWindowViewport().Size;
+
+            if (position.X < 0)
+            {
+                position.X = Margin;
+            }
+            else if (position.X + size.X > screenSize.X)
+            {
+                position.X = screenSize.X - size.X - Margin;
+            }
+
+            if (position.Y < 0)
+            {
+                position.Y = Margin;
+            }
+
+            return position;
+        }
+    }
+
+    [Serializable]
+    [Section("Misc")]
+    [SubSection("Tooltips", 0)]
+    public class TooltipsConfig : PluginConfigObject
+    {
+        public new static TooltipsConfig DefaultConfig() { return new TooltipsConfig(); }
+
+        [ColorEdit4("Title Color")]
+        [Order(10)]
+        public PluginConfigColor TitleColor = new PluginConfigColor(new(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
+
+        [ColorEdit4("Text Color")]
+        [Order(10)]
+        public PluginConfigColor TextColor = new PluginConfigColor(new(255f / 255f, 255f / 255f, 255f / 255f, 80f / 100f));
+
+        [ColorEdit4("Background Color")]
+        [Order(10)]
+        public PluginConfigColor BackgroundColor = new PluginConfigColor(new(0f / 255f, 0f / 255f, 0f / 255f, 60f / 100f));
+    }
+}

--- a/DelvUI/Helpers/TooltipsHelper.cs
+++ b/DelvUI/Helpers/TooltipsHelper.cs
@@ -75,7 +75,7 @@ namespace DelvUI.Helpers
             position.Y = position.Y - _size.Y;
 
             // correct tooltips off screen
-            _position = CalculatePosition(position, _size);
+            _position = ConstrainPosition(position, _size);
         }
 
         public void RemoveTooltip()
@@ -144,7 +144,7 @@ namespace DelvUI.Helpers
             return result;
         }
 
-        private Vector2 CalculatePosition(Vector2 position, Vector2 size)
+        private Vector2 ConstrainPosition(Vector2 position, Vector2 size)
         {
             var screenSize = ImGui.GetWindowViewport().Size;
 

--- a/DelvUI/Helpers/TooltipsHelper.cs
+++ b/DelvUI/Helpers/TooltipsHelper.cs
@@ -40,6 +40,7 @@ namespace DelvUI.Helpers
         {
             ShowTooltip(text, ImGui.GetMousePos(), title);
         }
+
         public void ShowTooltip(string text, Vector2 position, string title = null)
         {
             if (text == null)

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -172,15 +172,20 @@ namespace DelvUI.Interface
             UpdateJob();
             AssignActors();
 
+            // general elements
             foreach (var element in _hudElements)
             {
                 element.Draw(_origin);
             }
 
+            // job hud
             if (_jobHud != null && _jobHud.Config.Enabled)
             {
                 _jobHud.Draw(_origin);
             }
+
+            // tooltip
+            TooltipsHelper.Instance.Draw();
 
             ImGui.End();
         }

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -17,6 +17,7 @@ namespace DelvUI.Interface.StatusEffects
         private uint _rowCount;
         private uint _colCount;
         private GrowthDirections _lastGrowthDirections;
+        private bool _showingTooltip = false;
 
         public Actor Actor { get; set; } = null;
 
@@ -171,6 +172,7 @@ namespace DelvUI.Interface.StatusEffects
 
             var row = 0;
             var col = 0;
+            var showingTooltip = false;
 
             for (var i = 0; i < count; i++)
             {
@@ -184,6 +186,13 @@ namespace DelvUI.Interface.StatusEffects
 
                 // draw
                 StatusEffectIconDrawHelper.DrawStatusEffectIcon(drawList, iconPos, statusEffectData, Config.IconConfig);
+
+                // tooltip
+                if (ImGui.IsMouseHoveringRect(iconPos, iconPos + Config.IconConfig.Size))
+                {
+                    TooltipsHelper.Instance.ShowTooltipOnCursor(statusEffectData.Data.Description, statusEffectData.Data.Name);
+                    showingTooltip = true;
+                }
 
                 // rows / columns
                 if (Config.FillRowsFirst)
@@ -205,6 +214,12 @@ namespace DelvUI.Interface.StatusEffects
                     }
                 }
             }
+
+            if (_showingTooltip && !showingTooltip)
+            {
+                TooltipsHelper.Instance.RemoveTooltip();
+            }
+            _showingTooltip = showingTooltip;
         }
 
         private GrowthDirections ValidateGrowthDirections(GrowthDirections directions)

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -86,6 +86,7 @@ namespace DelvUI
 
             TexturesCache.Initialize();
             GlobalColors.Initialize();
+            TooltipsHelper.Initialize();
             Resolver.Initialize();
 
             _hudManager = new HudManager();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6404136/132962818-a4e3fd3a-748e-4712-a898-6f140760185d.png)

Had to do some hacky regex and str replace to fix the data.
Some tooltips have tags for color and "glow" that come in very unfriendly unicode characters.
I couldn't find a way to get rid of them "nicely" so the SanitizeText method is a bit ugly.