### PR TITLE
Remove buffs with right click

### DIFF
--- a/DelvUI/Helpers/ChatHelper.cs
+++ b/DelvUI/Helpers/ChatHelper.cs
@@ -9,15 +9,13 @@ namespace DelvUI.Helpers
         #region Singleton
         private ChatHelper()
         {
-            var scanner = Plugin.PluginInterface.TargetModuleScanner;
-
-            IntPtr baseUi = scanner.GetStaticAddressFromSig("48 8B 0D ?? ?? ?? ?? 48 8D 54 24 ?? 48 83 C1 10 E8");
-            IntPtr uiModule = scanner.ScanText("E8 ?? ?? ?? ?? 48 83 7F ?? 00 48 8B F0");
+            IntPtr baseUi = Plugin.SigScanner.GetStaticAddressFromSig("48 8B 0D ?? ?? ?? ?? 48 8D 54 24 ?? 48 83 C1 10 E8");
+            IntPtr uiModule = Plugin.SigScanner.ScanText("E8 ?? ?? ?? ?? 48 83 7F ?? 00 48 8B F0");
 
             UiModuleDelegate uiModuleDelegate = Marshal.GetDelegateForFunctionPointer<UiModuleDelegate>(uiModule);
             _uiModulePtr = (IntPtr)uiModuleDelegate.DynamicInvoke(Marshal.ReadIntPtr(baseUi));
 
-            _chatModulePtr = scanner.ScanText("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9");
+            _chatModulePtr = Plugin.SigScanner.ScanText("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9");
         }
 
         public static void Initialize() { Instance = new ChatHelper(); }

--- a/DelvUI/Helpers/ChatHelper.cs
+++ b/DelvUI/Helpers/ChatHelper.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace DelvUI.Helpers
+{
+    public class ChatHelper
+    {
+        #region Singleton
+        private ChatHelper()
+        {
+            var scanner = Plugin.PluginInterface.TargetModuleScanner;
+
+            IntPtr baseUi = scanner.GetStaticAddressFromSig("48 8B 0D ?? ?? ?? ?? 48 8D 54 24 ?? 48 83 C1 10 E8");
+            IntPtr uiModule = scanner.ScanText("E8 ?? ?? ?? ?? 48 83 7F ?? 00 48 8B F0");
+
+            UiModuleDelegate uiModuleDelegate = Marshal.GetDelegateForFunctionPointer<UiModuleDelegate>(uiModule);
+            _uiModulePtr = (IntPtr)uiModuleDelegate.DynamicInvoke(Marshal.ReadIntPtr(baseUi));
+
+            _chatModulePtr = scanner.ScanText("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9");
+        }
+
+        public static void Initialize() { Instance = new ChatHelper(); }
+
+        public static ChatHelper Instance { get; private set; }
+        #endregion
+
+        private IntPtr _uiModulePtr;
+        private IntPtr _chatModulePtr;
+
+        public static void SendChatMessage(string message)
+        {
+            if (Instance == null)
+            {
+                return;
+            }
+
+            Instance.SendMessage(message);
+        }
+
+        private void SendMessage(string message)
+        {
+            if (message == null || message.Length == 0)
+            {
+                return;
+            }
+
+            // let dalamud process the command first
+            if (Plugin.CommandManager.ProcessCommand(message))
+            {
+                return;
+            }
+
+            if (_uiModulePtr == IntPtr.Zero || _chatModulePtr == IntPtr.Zero)
+            {
+                return;
+            }
+
+            // encode message
+            var (text, length) = EncodeMessage(message);
+            var payload = MessagePayload(text, length);
+
+            ChatDelegate chatDelegate = Marshal.GetDelegateForFunctionPointer<ChatDelegate>(_chatModulePtr);
+            chatDelegate.Invoke(_uiModulePtr, payload, IntPtr.Zero, (byte)0);
+
+            Marshal.FreeHGlobal(payload);
+            Marshal.FreeHGlobal(text);
+        }
+
+        private static (IntPtr, long) EncodeMessage(string message)
+        {
+            var bytes = Encoding.UTF8.GetBytes(message);
+            var mem = Marshal.AllocHGlobal(bytes.Length + 30);
+            Marshal.Copy(bytes, 0, mem, bytes.Length);
+            Marshal.WriteByte(mem + bytes.Length, 0);
+            return (mem, bytes.Length + 1);
+        }
+
+        private static IntPtr MessagePayload(IntPtr message, long length)
+        {
+            var mem = Marshal.AllocHGlobal(400);
+            Marshal.WriteInt64(mem, message.ToInt64());
+            Marshal.WriteInt64(mem + 0x8, 64);
+            Marshal.WriteInt64(mem + 0x10, length);
+            Marshal.WriteInt64(mem + 0x18, 0);
+            return mem;
+        }
+    }
+
+    public delegate IntPtr UiModuleDelegate(IntPtr baseUiPtr);
+    public delegate IntPtr ChatDelegate(IntPtr uiModulePtr, IntPtr message, IntPtr unknown1, byte unknown2);
+}

--- a/DelvUI/Interface/StatusEffects/StatusEffectIconDrawHelper.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectIconDrawHelper.cs
@@ -11,7 +11,7 @@ namespace DelvUI.Interface.StatusEffects
         public static void DrawStatusEffectIcon(ImDrawListPtr drawList, Vector2 position, StatusEffectData statusEffectData, StatusEffectIconConfig config)
         {
             // icon
-            DrawHelper.DrawIcon<Status>(statusEffectData.Data, config.Size, position, config.ShowBorder);
+            DrawHelper.DrawIcon<Status>(statusEffectData.Data, position, config.Size, false, drawList);
 
             // border
             if (config.ShowDispellableBorder && statusEffectData.Data.CanDispel)
@@ -29,7 +29,13 @@ namespace DelvUI.Interface.StatusEffects
                 var duration = Math.Round(Math.Abs(statusEffectData.StatusEffect.Duration));
                 var text = Utils.DurationToString(duration);
                 var textSize = ImGui.CalcTextSize(text);
-                DrawHelper.DrawOutlinedText(text, position + new Vector2(config.Size.X / 2f - textSize.X / 2f, config.Size.Y / 2f - textSize.Y / 2f));
+
+                DrawHelper.DrawOutlinedText(
+                    text,
+                    position + new Vector2(config.Size.X / 2f - textSize.X / 2f, config.Size.Y / 2f - textSize.Y / 2f),
+                    drawList,
+                    2
+                );
             }
 
             // stacks
@@ -41,8 +47,10 @@ namespace DelvUI.Interface.StatusEffects
                 DrawHelper.DrawOutlinedText(
                     text,
                     position + new Vector2(config.Size.X * 0.9f - textSize.X / 2f, config.Size.X * 0.2f - textSize.Y / 2f),
-                    Vector4.UnitW,
-                    Vector4.One
+                    0xFF000000,
+                    0xFFFFFFFF,
+                    drawList,
+                    2
                 );
             }
         }

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -185,7 +185,7 @@ namespace DelvUI.Interface.StatusEffects
 
             // window
             ImGuiWindowFlags windowFlags = ImGuiWindowFlags.NoTitleBar;
-            //windowFlags |= ImGuiWindowFlags.NoMove;
+            windowFlags |= ImGuiWindowFlags.NoMove;
             windowFlags |= ImGuiWindowFlags.NoDecoration;
             windowFlags |= ImGuiWindowFlags.NoBackground;
 

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -46,11 +46,14 @@ namespace DelvUI
         public static Dalamud.Game.SigScanner SigScanner => PluginInterface.TargetModuleScanner;
         public static Targets TargetManager => ClientState.Targets;
         public static UiBuilder UiBuilder => PluginInterface.UiBuilder;
-        
+
+
+
         public void Initialize(DalamudPluginInterface pluginInterface)
         {
             PluginInterface = pluginInterface;
-            
+
+
             Version = Assembly.GetExecutingAssembly()?.GetName().Version.ToString() ?? "";
 
             LoadBanner();
@@ -87,6 +90,7 @@ namespace DelvUI
             TexturesCache.Initialize();
             GlobalColors.Initialize();
             TooltipsHelper.Initialize();
+            ChatHelper.Initialize();
             Resolver.Initialize();
 
             _hudManager = new HudManager();

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -1,5 +1,10 @@
-﻿using Dalamud.Game.ClientState;
+﻿using Dalamud.Data;
+using Dalamud.Game.ClientState;
+using Dalamud.Game.ClientState.Actors;
 using Dalamud.Game.Command;
+using Dalamud.Game.Internal;
+using Dalamud.Game.Internal.Gui;
+using Dalamud.Interface;
 using Dalamud.Plugin;
 using DelvUI.Config;
 using DelvUI.Helpers;
@@ -10,11 +15,6 @@ using ImGuiNET;
 using System;
 using System.IO;
 using System.Reflection;
-using Dalamud.Data;
-using Dalamud.Game.ClientState.Actors;
-using Dalamud.Game.Internal;
-using Dalamud.Game.Internal.Gui;
-using Dalamud.Interface;
 
 namespace DelvUI
 {
@@ -47,12 +47,9 @@ namespace DelvUI
         public static Targets TargetManager => ClientState.Targets;
         public static UiBuilder UiBuilder => PluginInterface.UiBuilder;
 
-
-
         public void Initialize(DalamudPluginInterface pluginInterface)
         {
             PluginInterface = pluginInterface;
-
 
             Version = Assembly.GetExecutingAssembly()?.GetName().Version.ToString() ?? "";
 


### PR DESCRIPTION
A few notes:
* The feature uses the **/statusoff** command to remove buffs. This means we are sending a chat message in place of the user to achieve this.
* For this reason, I've created a **ChatHelper** class that allows us to send ANY message as if it was sent by the player. Right now this is only used for this particular feature, but it could be used for other things. However, we should be very careful on the things we do with this. I think we should limit its use as much as possible and only do it for small stuff like this.
* **StatusEffectListHud** has now its own window to be able to receive inputs (visually no changes though).
* Added some methods in **DrawHelper** to draw text and icons by using a pre-determined imgui draw list.
* Added a DrawOutlineText method that receives thickness as parameter (the duration and stacks on some status effects were hard to read, by increasing the outline size it looks better)

![image](https://user-images.githubusercontent.com/6404136/133009706-34aa1673-6317-4f27-8fc5-3a0010cad841.png)
