### PR TITLE
Added a queue window indication on the gcd bar

### DIFF
--- a/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
@@ -22,6 +22,10 @@ namespace DelvUI.Interface.GeneralElements
         [Order(30)]
         public bool VerticalMode = false;
 
+        [DragFloat("GCD Queue Padding Size")]
+        [Order(40)]
+        public float GCDQueuePaddingSize = 1f;
+
         [ColorEdit4("Color")]
         [Order(35)]
         public PluginConfigColor Color = new PluginConfigColor(new(255f / 255f, 255f / 255f, 255f / 255f, 70f / 100f));

--- a/DelvUI/Interface/GeneralElements/GCDIndicatorHud.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorHud.cs
@@ -2,6 +2,7 @@
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using System.Collections.Generic;
 using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
@@ -38,8 +39,12 @@ namespace DelvUI.Interface.GeneralElements
             var startPos = origin + Config.Position - Config.Size / 2f;
             var size = !Config.VerticalMode ? Config.Size : new Vector2(Config.Size.Y, -Config.Size.X);
 
+            var percentNonQueue = 1F - 0.5F / total;
+
             var drawList = ImGui.GetWindowDrawList();
             var builder = BarBuilder.Create(startPos, size)
+                .SetChunks(new float[]{percentNonQueue, 1F - percentNonQueue})
+                .SetChunkPadding(Config.GCDQueuePaddingSize)
                 .AddInnerBar(elapsed, total, Config.Color.Map)
                 .SetDrawBorder(Config.ShowBorder)
                 .SetVertical(Config.VerticalMode);


### PR DESCRIPTION
This PR implements issue #377 by partitioning the gcd bar into two chunks. The first chunk corresponds to the first (GCD - 0.5) seconds and the second chunk corresponds to the latter 0.5 seconds. The indicator is implemented as padding between these two chunks, which has an adjustable size in the gcd configuration window.