### PR TITLE
Adds a GCD queue indicator

### DIFF
--- a/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
@@ -22,6 +22,10 @@ namespace DelvUI.Interface.GeneralElements
         [Order(30)]
         public bool VerticalMode = false;
 
+        [DragFloat("GCD Queue Padding Size")]
+        [Order(40)]
+        public float GCDQueuePaddingSize = 1f;
+
         [ColorEdit4("Color")]
         [Order(35)]
         public PluginConfigColor Color = new PluginConfigColor(new(255f / 255f, 255f / 255f, 255f / 255f, 70f / 100f));

--- a/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
@@ -22,13 +22,17 @@ namespace DelvUI.Interface.GeneralElements
         [Order(30)]
         public bool VerticalMode = false;
 
-        [DragFloat("GCD Queue Padding Size")]
-        [Order(40)]
-        public float GCDQueuePaddingSize = 1f;
-
         [ColorEdit4("Color")]
         [Order(35)]
         public PluginConfigColor Color = new PluginConfigColor(new(255f / 255f, 255f / 255f, 255f / 255f, 70f / 100f));
+
+        [Checkbox("Show GCD Queue Indicator")]
+        [Order(40)]
+        public bool ShowGCDQueueIndicator = true;
+
+        [ColorEdit4("GCD Queue Color")]
+        [Order(45)]
+        public PluginConfigColor QueueColor = new PluginConfigColor(new(0f / 255f, 255f / 255f, 0f / 255f, 70f / 100f));
 
         public GCDIndicatorConfig(Vector2 position, Vector2 size)
         {
@@ -38,7 +42,7 @@ namespace DelvUI.Interface.GeneralElements
 
         public new static GCDIndicatorConfig DefaultConfig()
         {
-            var size = new Vector2(254, 4);
+            var size = new Vector2(254, 8);
             var pos = new Vector2(0, HUDConstants.BaseHUDOffsetY + 21);
 
             var config = new GCDIndicatorConfig(pos, size);

--- a/DelvUI/Interface/GeneralElements/GCDIndicatorHud.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorHud.cs
@@ -39,15 +39,22 @@ namespace DelvUI.Interface.GeneralElements
             var startPos = origin + Config.Position - Config.Size / 2f;
             var size = !Config.VerticalMode ? Config.Size : new Vector2(Config.Size.Y, -Config.Size.X);
 
-            var percentNonQueue = 1F - 0.5F / total;
+            var percentNonQueue = 1F - (500f / 1000f) / total;
 
             var drawList = ImGui.GetWindowDrawList();
             var builder = BarBuilder.Create(startPos, size)
-                .SetChunks(new float[]{percentNonQueue, 1F - percentNonQueue})
-                .SetChunkPadding(Config.GCDQueuePaddingSize)
+                .SetChunks(new float[2]{percentNonQueue, 1F - percentNonQueue})
                 .AddInnerBar(elapsed, total, Config.Color.Map)
                 .SetDrawBorder(Config.ShowBorder)
                 .SetVertical(Config.VerticalMode);
+
+            var queueStartOffset = Config.VerticalMode ? new Vector2(0, percentNonQueue * size.Y) : new Vector2(percentNonQueue * size.X, 0);
+            var queueEndOffset = Config.VerticalMode ? new Vector2(size.X, percentNonQueue * size.Y + 1f) : new Vector2(percentNonQueue * size.X + 1f, size.Y);
+            if (Config.ShowGCDQueueIndicator)
+            {
+                builder.SetChunksColors(new Dictionary<string, uint>[2]{Config.Color.Map, Config.QueueColor.Map});
+                drawList.AddRect(startPos + queueStartOffset, startPos + queueEndOffset, Config.QueueColor.Base);
+            }
 
             builder.Build().Draw(drawList);
         }

--- a/DelvUI/Interface/GeneralElements/GCDIndicatorHud.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorHud.cs
@@ -2,6 +2,7 @@
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using ImGuiNET;
+using System.Collections.Generic;
 using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
@@ -38,8 +39,12 @@ namespace DelvUI.Interface.GeneralElements
             var startPos = origin + Config.Position - Config.Size / 2f;
             var size = !Config.VerticalMode ? Config.Size : new Vector2(Config.Size.Y, -Config.Size.X);
 
+            var percentNonQueue = 1F - 0.5F / total;
+
             var drawList = ImGui.GetWindowDrawList();
             var builder = BarBuilder.Create(startPos, size)
+                .SetChunks(new float[]{percentNonQueue, 1F - percentNonQueue})
+                .SetChunkPadding(Config.GCDQueuePaddingSize)
                 .AddInnerBar(elapsed, total, Config.Color.Map)
                 .SetDrawBorder(Config.ShowBorder)
                 .SetVertical(Config.VerticalMode);


### PR DESCRIPTION
Adds a GCD queue indicator as requested in issue #377. The color of the window is configurable and the indicator can be turned on and off. From what I can tell, the 0.5-second window is a fixed amount of time, as indicated by page 53 in the [ffxiv beta manual](http://dl.square-enix.co.jp/ffxiv/download/manual/ffxiv_betamanual_en.pdf), subsection "Action Buffering" (though it is possible that this has changed since the beta). If we gain new information on this, I'll add a further commit making this time adjustable.

![gcdv1](https://user-images.githubusercontent.com/78664459/133022784-51640eab-d12a-4177-a46a-d8d281784109.png)
![gcdvert2](https://user-images.githubusercontent.com/78664459/133022785-8737b4d3-6538-408d-8394-f2c73e9ee361.png)
![gcdhoriz1](https://user-images.githubusercontent.com/78664459/133022786-85ebb558-93f7-4353-a33b-94f3e214975b.png)
![gcdhoriz2](https://user-images.githubusercontent.com/78664459/133022787-4fbb1c10-d30f-43f7-83bf-8d3ad929c1df.png)
