### PR TITLE
Disabling input for status effect lists when there are no buffs

### DIFF
--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -173,6 +173,11 @@ namespace DelvUI.Interface.StatusEffects
 
             // calculate layout
             var list = StatusEffectsData(filterStatusEffects);
+            if (list.Count == 0)
+            {
+                return;
+            }
+
             var count = CalculateLayout(list);
 
             // validate growth directions
@@ -188,6 +193,10 @@ namespace DelvUI.Interface.StatusEffects
             windowFlags |= ImGuiWindowFlags.NoMove;
             windowFlags |= ImGuiWindowFlags.NoDecoration;
             windowFlags |= ImGuiWindowFlags.NoBackground;
+            if (!Config.ShowBuffs)
+            {
+                windowFlags |= ImGuiWindowFlags.NoInputs;
+            }
 
             // imgui clips the left and right borders inside windows for some reason
             // we make the window bigger so the actual drawable size is the expected one


### PR DESCRIPTION
Next step would be to make the window as small as possible when there are buffs.
That kinda overlaps with what I'm doing for draggables since for that the windows calculate the position and size based on the content, so this second part should be "automagically" fixed once draggables are in.