### PR TITLE
Fixed reset/import/export, added overall import/export

### DIFF
--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -122,6 +122,14 @@ namespace DelvUI.Config
 
         public static ConfigurationManager GetInstance() => _instance;
 
+        public void RequestResetEvent()
+        {
+            if(ResetEvent != null)
+            {
+                ResetEvent(this, null);
+            }
+        }
+
         public void Draw()
         {
             if (DrawConfigWindow)
@@ -146,7 +154,7 @@ namespace DelvUI.Config
         {
             using MemoryStream output = new();
 
-            using (DeflateStream gzip = new(output, CompressionLevel.Fastest))
+            using (DeflateStream gzip = new(output, CompressionLevel.Optimal))
             {
                 using StreamWriter writer = new(gzip, Encoding.UTF8);
                 writer.Write(jsonString);

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -74,7 +74,7 @@ namespace DelvUI.Config.Tree
     public class BaseNode : Node
     {
         public new List<SectionNode> children;
-        private Dictionary<Type, PluginConfigObject> configObjectsMap;
+        public Dictionary<Type, PluginConfigObject> configObjectsMap;
 
         public BaseNode()
         {
@@ -865,8 +865,12 @@ namespace DelvUI.Config.Tree
                         if (importedConfigObject != null)
                         {
                             PluginLog.Log($"Importing {importedConfigObject.GetType()}");
+                            // update the tree
                             ConfigObject = importedConfigObject;
+                            // but also update the dictionary
+                            ConfigurationManager.GetInstance().ConfigBaseNode.configObjectsMap[ConfigObject.GetType()] = ConfigObject;
                             ConfigurationManager.GetInstance().SaveConfigurations();
+                            ConfigurationManager.GetInstance().RequestResetEvent();
                         }
                         else
                         {

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -690,9 +690,11 @@ namespace DelvUI.Config.Tree
 
                     if (importedConfigObject != null)
                     {
-                        PluginLog.Log($"Importing {importedConfigObject.GetType()}");
+                        // update the object
                         ConfigObject = importedConfigObject;
-                        ConfigurationManager.GetInstance().SaveConfigurations();
+                        // update the dictionary
+                        ConfigurationManager.GetInstance().ConfigBaseNode.configObjectsMap[ConfigObject.GetType()] = ConfigObject;
+                        //ConfigurationManager.GetInstance().SaveConfigurations();
                     }
                     else
                     {
@@ -853,29 +855,10 @@ namespace DelvUI.Config.Tree
                     {
                         PluginLog.Log($"Error parsing import string!\n{ex.StackTrace}");
                     }
-
                     // abort import if the import string is for the wrong type
                     if (importedType != null && ConfigObject.GetType().FullName == importedType.FullName)
                     {
-                        // see comments on ConfigPageNode's Load
-                        MethodInfo methodInfo = typeof(ConfigurationManager).GetMethod("LoadImportString");
-                        MethodInfo function = methodInfo.MakeGenericMethod(ConfigObject.GetType());
-                        PluginConfigObject importedConfigObject = (PluginConfigObject)function.Invoke(ConfigurationManager.GetInstance(), new object[] { _importString });
-
-                        if (importedConfigObject != null)
-                        {
-                            PluginLog.Log($"Importing {importedConfigObject.GetType()}");
-                            // update the tree
-                            ConfigObject = importedConfigObject;
-                            // but also update the dictionary
-                            ConfigurationManager.GetInstance().ConfigBaseNode.configObjectsMap[ConfigObject.GetType()] = ConfigObject;
-                            ConfigurationManager.GetInstance().SaveConfigurations();
-                            ConfigurationManager.GetInstance().RequestResetEvent();
-                        }
-                        else
-                        {
-                            PluginLog.Log($"Could not load from import string (of type {importedConfigObject.GetType()})");
-                        }
+                        ConfigurationManager.LoadImportedConfiguration(_importString, this);
                     }
                     else
                     {
@@ -1118,24 +1101,26 @@ namespace DelvUI.Config.Tree
                     ImGui.Text(dragDropHorizontalAttribute.friendlyName);
                     int[] order = (int[])fieldVal;
                     string[] names = dragDropHorizontalAttribute.names;
-                    for(int i = 0; i < order.Count(); i++){
+                    for (int i = 0; i < order.Count(); i++)
+                    {
                         ImGui.SameLine();
                         ImGui.Button(names[order[i]], new Vector2(100, 25));
-                        if (ImGui.IsItemActive()){
+                        if (ImGui.IsItemActive())
+                        {
                             float drag_dx = ImGui.GetMouseDragDelta(ImGuiMouseButton.Left).X;
                             if ((drag_dx > 80.0f && i < order.Count() - 1))
                             {
                                 var _curri = order[i];
-                                order[i] = order[i+1];
-                                order[i+1] = _curri;
+                                order[i] = order[i + 1];
+                                order[i + 1] = _curri;
                                 field.SetValue(ConfigObject, order);
                                 ImGui.ResetMouseDragDelta();
                             }
                             else if ((drag_dx < -80.0f && i > 0))
                             {
                                 var _curri = order[i];
-                                order[i] = order[i-1];
-                                order[i-1] = _curri;
+                                order[i] = order[i - 1];
+                                order[i - 1] = _curri;
                                 field.SetValue(ConfigObject, order);
                                 ImGui.ResetMouseDragDelta();
                             }

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -49,7 +49,7 @@ namespace DelvUI.Interface
         {
             _jobHud = null;
             CreateHudElements();
-            PluginLog.Log("resetting hud");
+            ConfigurationManager.GetInstance().SaveConfigurations();
         }
 
         private void CreateHudElements()

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -1,4 +1,5 @@
 using Dalamud.Interface;
+using Dalamud.Plugin;
 using DelvUI.Config;
 using DelvUI.Helpers;
 using DelvUI.Interface.GeneralElements;
@@ -46,7 +47,9 @@ namespace DelvUI.Interface
 
         private void OnConfigReset(object sender, EventArgs e)
         {
+            _jobHud = null;
             CreateHudElements();
+            PluginLog.Log("resetting hud");
         }
 
         private void CreateHudElements()

--- a/DelvUI/Interface/ImportExportConfig.cs
+++ b/DelvUI/Interface/ImportExportConfig.cs
@@ -1,0 +1,86 @@
+﻿using Dalamud.Plugin;
+using DelvUI.Config;
+using DelvUI.Config.Attributes;
+using ImGuiNET;
+using Newtonsoft.Json;
+using System;
+using System.Numerics;
+
+namespace DelvUI.Interface
+{
+    [Portable(false)]
+    [Section("Import/Export")]
+    [SubSection("General", 0)]
+    public class ImportExportConfig : PluginConfigObject
+    {
+        private string _importString = "";
+        private string _exportString = "";
+
+        public new static ImportExportConfig DefaultConfig() { return new ImportExportConfig(); }
+
+        [ManualDraw]
+        public void DrawFullImportExport()
+        {
+            uint maxLength = 100000;
+            ImGui.BeginChild("importpane", new Vector2(0, ImGui.GetWindowHeight() / 6), false, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
+            {
+                ImGui.Text("Import string:");
+                ImGui.InputText("", ref _importString, maxLength);
+
+                if (ImGui.Button("Import configuration") && _importString != "")
+                {
+                    string[] importStrings = _importString.Trim().Split(new string[] { "|" }, StringSplitOptions.RemoveEmptyEntries);
+                    ConfigurationManager.LoadTotalConfiguration(importStrings);
+                    //ConfigurationManager.ImportBaseNode(_importString);
+                }
+
+                ImGui.SameLine();
+
+                if (ImGui.Button("Paste from clipboard"))
+                {
+                    try
+                    {
+                        _importString = ImGui.GetClipboardText();
+                    }
+                    catch (Exception ex)
+                    {
+                        PluginLog.Log("Could not get clipboard text:\n" + ex.StackTrace);
+                    }
+
+                }
+            }
+
+            ImGui.EndChild();
+
+            ImGui.BeginChild("exportpane", new Vector2(0, ImGui.GetWindowHeight() / 6), false, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
+
+            {
+                ImGui.Text("Export string:");
+                ImGui.InputText("", ref _exportString, maxLength, ImGuiInputTextFlags.ReadOnly);
+
+                if (ImGui.Button("Export configuration"))
+                {
+                    _exportString = ConfigurationManager.GetInstance().ConfigBaseNode.GetBase64String();
+                    //_exportString = ConfigurationManager.ExportBaseNode(ConfigurationManager.GetInstance().ConfigBaseNode);
+                }
+
+                ImGui.SameLine();
+
+                if (ImGui.Button("Copy to clipboard") && _exportString != "")
+                {
+                    try
+                    {
+                        ImGui.SetClipboardText(_exportString);
+                    }
+                    catch (Exception ex)
+                    {
+                        PluginLog.Log("Could not set clipboard text:\n" + ex.StackTrace);
+                    }
+
+                }
+            }
+
+            ImGui.EndChild();
+        }
+    }
+}


### PR DESCRIPTION
This should bring import/export functionality to parity with v0.1.0.0.
One thing to note is that the overall import/export does not completely create a new BaseNode. I was having trouble with deserialization of complex types (related to assembly mismatches, which will affect LPL users for instance). As a result the overall import strings are quite long (about 25k characters or so).