### PR TITLE
Fix: Status effect timer formatting

### DIFF
--- a/DelvUI/Helpers/Utils.cs
+++ b/DelvUI/Helpers/Utils.cs
@@ -53,7 +53,7 @@ namespace DelvUI.Helpers
 
             if (t.Minutes >= 1)
             {
-                return t.Minutes + ":" + t.Seconds;
+                return $"{t.Minutes}:{t.Seconds:00}";
             }
 
             return t.Seconds.ToString();


### PR DESCRIPTION
When the remaining time on a status effect was between 1min and 5min, if
the seconds were under 10sec, the display didn't show any leading zero

Before:
![image](https://user-images.githubusercontent.com/1774188/133392449-1d34d4d0-989e-45b6-a646-6dbfa19daa4b.png)

After:
![image](https://user-images.githubusercontent.com/1774188/133392473-4b70d24c-9907-42d3-8a21-3621d3b4e6c4.png)
