### PR TITLE
Fix: PrimaryResourceBar Threshold not displayed

### DIFF
--- a/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
@@ -52,7 +52,7 @@ namespace DelvUI.Interface.GeneralElements
             // threshold
             if (Config.ShowThresholdMarker)
             {
-                var position = new Vector2(startPos.X + Config.ThresholdMarkerValue / 10000f * Config.Size.X - 2, Config.Size.Y);
+                var position = new Vector2(startPos.X + Config.ThresholdMarkerValue / 10000f * Config.Size.X - 2, startPos.Y);
                 var size = new Vector2(2, Config.Size.Y);
                 drawList.AddRect(position, position + size, 0xFF000000);
             }


### PR DESCRIPTION
Just a small position mistake. I was wondering what was that small vertical bar on top of my screen last time I played...