### PR TITLE
Fix: PrimaryResourceBar display configuration

### DIFF
--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -220,6 +220,7 @@ namespace DelvUI.Interface
             var newJobId = Plugin.ClientState.LocalPlayer.ClassJob.Id;
             if (_jobHud != null && _jobHud.Config.JobId == newJobId)
             {
+                _primaryResourceHud.ResourceType = _jobHud.Config.UseDefaultPrimaryResourceBar ? _jobHud.Config.PrimaryResourceType : PrimaryResourceTypes.None;
                 return;
             }
 


### PR DESCRIPTION
Any modifications wherever to display or not the Primary Resource Bar in
the job configurations was not being processed until the player changed
jobs.

This is due to the fact that there's 2 conditions wherever that
PlayerResourceBar should be displayed:
- In the Misc configuration, checked everytime the PrimaryResourceHud
  Draw call si done
- In the Job configuration

The Job configuration is being used for the PrimaryReshourceHud when the
UpdateJob method is called in HudManager.cs.
Except, that configuration is then only processed when the JobHud isn't
created or when the player changes job.

This modificaiton forces to read again the Job configuration when the
player doesn't change jobs, making both configuration work as intended.