### PR TITLE
Fix: Avoid showing NaN castbar on minions

### DIFF
--- a/DelvUI/Interface/GeneralElements/CastbarHud.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarHud.cs
@@ -1,4 +1,5 @@
-﻿using Dalamud.Game.ClientState.Actors.Types;
+﻿using Dalamud.Game.ClientState.Actors;
+using Dalamud.Game.ClientState.Actors.Types;
 using DelvUI.Enums;
 using DelvUI.Helpers;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
@@ -29,6 +30,11 @@ namespace DelvUI.Interface.GeneralElements
         public override unsafe void Draw(Vector2 origin)
         {
             if (!Config.Enabled || Actor == null || Actor is not Chara)
+            {
+                return;
+            }
+
+            if (Actor.ObjectKind != ObjectKind.Player && Actor.ObjectKind != ObjectKind.BattleNpc)
             {
                 return;
             }


### PR DESCRIPTION
Uses the same filter as used on the target status effect [StatusEffectListHud.cs:169](https://github.com/DelvUI/DelvUI/blob/beta2/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs#L169)
This "SHOULD" solve this minor issue