### PR TITLE
fix: fix label anchors and draw labels relative to their parent HudElement

### DIFF
--- a/DelvUI/Interface/GeneralElements/CastbarConfig.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarConfig.cs
@@ -37,8 +37,8 @@ namespace DelvUI.Interface.GeneralElements
             var size = new Vector2(254, 24);
             var pos = new Vector2(0, HUDConstants.PlayerCastbarY);
 
-            var castNameConfig = new LabelConfig(new Vector2(-size.X / 2f + size.Y + 5, 0), "", LabelTextAnchor.Left);
-            var castTimeConfig = new LabelConfig(new Vector2(size.X / 2f - 5, 0), "", LabelTextAnchor.Right);
+            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left);
+            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right);
 
             return new PlayerCastbarConfig(pos, size, castNameConfig, castTimeConfig);
         }
@@ -83,8 +83,8 @@ namespace DelvUI.Interface.GeneralElements
             var size = new Vector2(254, 24);
             var pos = new Vector2(0, HUDConstants.BaseHUDOffsetY / 2f - size.Y / 2);
 
-            var castNameConfig = new LabelConfig(new Vector2(-size.X / 2f + size.Y + 5, 0), "", LabelTextAnchor.Left);
-            var castTimeConfig = new LabelConfig(new Vector2(size.X / 2f - 5, 0), "", LabelTextAnchor.Right);
+            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left);
+            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right);
 
             return new TargetCastbarConfig(pos, size, castNameConfig, castTimeConfig);
         }
@@ -108,8 +108,8 @@ namespace DelvUI.Interface.GeneralElements
                 HUDConstants.BaseHUDOffsetY + 5
             );
 
-            var castNameConfig = new LabelConfig(new Vector2(-size.X / 2f + size.Y + 5, 0), "", LabelTextAnchor.Left);
-            var castTimeConfig = new LabelConfig(new Vector2(size.X / 2f - 5, 0), "", LabelTextAnchor.Right);
+            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left);
+            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right);
 
             return new TargetOfTargetCastbarConfig(pos, size, castNameConfig, castTimeConfig);
         }
@@ -133,8 +133,8 @@ namespace DelvUI.Interface.GeneralElements
                 HUDConstants.BaseHUDOffsetY + 5
             );
 
-            var castNameConfig = new LabelConfig(new Vector2(-size.X / 2f + size.Y + 5, 0), "", LabelTextAnchor.Left);
-            var castTimeConfig = new LabelConfig(new Vector2(size.X / 2f - 5, 0), "", LabelTextAnchor.Right);
+            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left);
+            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right);
 
             return new FocusTargetCastbarConfig(pos, size, castNameConfig, castTimeConfig);
         }

--- a/DelvUI/Interface/GeneralElements/CastbarConfig.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarConfig.cs
@@ -37,8 +37,8 @@ namespace DelvUI.Interface.GeneralElements
             var size = new Vector2(254, 24);
             var pos = new Vector2(0, HUDConstants.PlayerCastbarY);
 
-            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left);
-            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right);
+            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left, LabelTextAnchor.Left);
+            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right, LabelTextAnchor.Right);
 
             return new PlayerCastbarConfig(pos, size, castNameConfig, castTimeConfig);
         }
@@ -83,8 +83,8 @@ namespace DelvUI.Interface.GeneralElements
             var size = new Vector2(254, 24);
             var pos = new Vector2(0, HUDConstants.BaseHUDOffsetY / 2f - size.Y / 2);
 
-            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left);
-            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right);
+            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left, LabelTextAnchor.Left);
+            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right, LabelTextAnchor.Right);
 
             return new TargetCastbarConfig(pos, size, castNameConfig, castTimeConfig);
         }
@@ -108,8 +108,8 @@ namespace DelvUI.Interface.GeneralElements
                 HUDConstants.BaseHUDOffsetY + 5
             );
 
-            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left);
-            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right);
+            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left, LabelTextAnchor.Left);
+            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right, LabelTextAnchor.Right);
 
             return new TargetOfTargetCastbarConfig(pos, size, castNameConfig, castTimeConfig);
         }
@@ -133,8 +133,8 @@ namespace DelvUI.Interface.GeneralElements
                 HUDConstants.BaseHUDOffsetY + 5
             );
 
-            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left);
-            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right);
+            var castNameConfig = new LabelConfig(new Vector2(5, 0), "", LabelTextAnchor.Left, LabelTextAnchor.Left);
+            var castTimeConfig = new LabelConfig(new Vector2(-5, 0), "", LabelTextAnchor.Right, LabelTextAnchor.Right);
 
             return new FocusTargetCastbarConfig(pos, size, castNameConfig, castTimeConfig);
         }

--- a/DelvUI/Interface/GeneralElements/CastbarHud.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarHud.cs
@@ -109,12 +109,12 @@ namespace DelvUI.Interface.GeneralElements
 
             // cast name
             Config.CastNameConfig.SetText(Config.Preview ? "Name" : _lastUsedCast.ActionText);
-            _castNameLabel.Draw(origin + Config.Position);
+            _castNameLabel.DrawRelativeToParent(origin + Config.Position + new Vector2(iconSize.X, 0), Config.Size);
 
             // cast time
             var text = Config.Preview ? "Time" : Math.Round(totalCastTime - totalCastTime * castScale, 1).ToString(CultureInfo.InvariantCulture);
             Config.CastTimeConfig.SetText(text);
-            _castTimeLabel.Draw(origin + Config.Position);
+            _castTimeLabel.DrawRelativeToParent(origin + Config.Position, Config.Size);
         }
 
         public virtual void DrawExtras(Vector2 origin, float totalCastTime)

--- a/DelvUI/Interface/GeneralElements/LabelConfig.cs
+++ b/DelvUI/Interface/GeneralElements/LabelConfig.cs
@@ -14,7 +14,7 @@ namespace DelvUI.Interface.GeneralElements
         [Order(20)]
         public string Text;
 
-        public EditableLabelConfig(Vector2 position, string text, LabelTextAnchor anchor) : base(position, text, anchor)
+        public EditableLabelConfig(Vector2 position, string text, LabelTextAnchor frameAnchor, LabelTextAnchor textAnchor) : base(position, text, frameAnchor, textAnchor)
         {
             Text = text;
         }
@@ -36,27 +36,32 @@ namespace DelvUI.Interface.GeneralElements
     {
         [JsonIgnore] protected string _text;
 
-        [Combo("Anchor", "Center", "Left", "Right", "Top", "TopLeft", "TopRight", "Bottom", "BottomLeft", "BottomRight")]
+        [Combo("Frame Anchor", "Center", "Left", "Right", "Top", "TopLeft", "TopRight", "Bottom", "BottomLeft", "BottomRight")]
         [Order(25)]
-        public LabelTextAnchor Anchor = LabelTextAnchor.Center;
+        public LabelTextAnchor FrameAnchor = LabelTextAnchor.Center;
+
+        [Combo("Text Anchor", "Center", "Left", "Right", "Top", "TopLeft", "TopRight", "Bottom", "BottomLeft", "BottomRight")]
+        [Order(30)]
+        public LabelTextAnchor TextAnchor = LabelTextAnchor.TopLeft;
 
         [ColorEdit4("Color")]
-        [Order(30)]
+        [Order(35)]
         public PluginConfigColor Color = new PluginConfigColor(Vector4.One);
 
         [Checkbox("Show Outline")]
-        [CollapseControl(35, 0)]
+        [CollapseControl(40, 0)]
         public bool ShowOutline = true;
 
         [ColorEdit4("Outline Color")]
         [CollapseWith(0, 0)]
         public PluginConfigColor OutlineColor = new PluginConfigColor(Vector4.UnitW);
 
-        public LabelConfig(Vector2 position, string text, LabelTextAnchor anchor)
+        public LabelConfig(Vector2 position, string text, LabelTextAnchor frameAnchor, LabelTextAnchor textAnchor)
         {
             Position = position;
             _text = text;
-            Anchor = anchor;
+            FrameAnchor = frameAnchor;
+            TextAnchor = textAnchor;
             Position = position;
         }
 

--- a/DelvUI/Interface/GeneralElements/LabelHud.cs
+++ b/DelvUI/Interface/GeneralElements/LabelHud.cs
@@ -48,7 +48,7 @@ namespace DelvUI.Interface.GeneralElements
         private void DrawLabel(string text, Vector2 parentOrigin, Vector2 parentSize)
         {
             var textSize = ImGui.CalcTextSize(text);
-            var offset = OffsetForSize(textSize, parentSize);
+            var offset = OffsetForFrameAchor(parentSize) + OffsetForTextAnchor(textSize);
 
             if (Config.ShowOutline)
             {
@@ -61,19 +61,37 @@ namespace DelvUI.Interface.GeneralElements
             }
         }
 
-        private Vector2 OffsetForSize(Vector2 textSize, Vector2 parentSize)
+        private Vector2 OffsetForTextAnchor(Vector2 textSize)
         {
-            switch (Config.Anchor)
+            switch (Config.TextAnchor)
             {
                 case LabelTextAnchor.Center: return -textSize / 2f;
-                case LabelTextAnchor.Left: return new Vector2(-parentSize.X / 2f, -textSize.Y / 2f);
-                case LabelTextAnchor.Right: return new Vector2(parentSize.X / 2f - textSize.X, -textSize.Y / 2f);
-                case LabelTextAnchor.Top: return new Vector2(-textSize.X / 2f, -parentSize.Y / 2f);
+                case LabelTextAnchor.Left: return new Vector2(0, -textSize.Y / 2f);
+                case LabelTextAnchor.Right: return new Vector2(-textSize.X, -textSize.Y / 2f);
+                case LabelTextAnchor.Top: return new Vector2(-textSize.X / 2f, 0);
+                case LabelTextAnchor.TopLeft: return Vector2.Zero;
+                case LabelTextAnchor.TopRight: return new Vector2(-textSize.X, 0);
+                case LabelTextAnchor.Bottom: return new Vector2(-textSize.X / 2f, -textSize.Y);
+                case LabelTextAnchor.BottomLeft: return new Vector2(0, -textSize.Y);
+                case LabelTextAnchor.BottomRight: return new Vector2(-textSize.X, -textSize.Y);
+            }
+
+            return Vector2.Zero;
+        }
+
+        private Vector2 OffsetForFrameAchor(Vector2 parentSize)
+        {
+            switch (Config.FrameAnchor)
+            {
+                case LabelTextAnchor.Center: return Vector2.Zero;
+                case LabelTextAnchor.Left: return new Vector2(-parentSize.X / 2f, 0);
+                case LabelTextAnchor.Right: return new Vector2(parentSize.X / 2f, 0);
+                case LabelTextAnchor.Top: return new Vector2(0, -parentSize.Y / 2f);
                 case LabelTextAnchor.TopLeft: return -parentSize / 2f;
-                case LabelTextAnchor.TopRight: return new Vector2(parentSize.X / 2f - textSize.X, -parentSize.Y / 2f);
-                case LabelTextAnchor.Bottom: return new Vector2(-textSize.X / 2f, parentSize.Y / 2f - textSize.Y);
-                case LabelTextAnchor.BottomLeft: return new Vector2(-parentSize.X / 2f, parentSize.Y / 2f - textSize.Y);
-                case LabelTextAnchor.BottomRight: return new Vector2(parentSize.X / 2f - textSize.X, parentSize.Y / 2f - textSize.Y);
+                case LabelTextAnchor.TopRight: return new Vector2(parentSize.X / 2f, -parentSize.Y / 2f);
+                case LabelTextAnchor.Bottom: return new Vector2(0, parentSize.Y / 2f);
+                case LabelTextAnchor.BottomLeft: return new Vector2(-parentSize.X / 2f, parentSize.Y / 2f);
+                case LabelTextAnchor.BottomRight: return parentSize / 2f;
             }
 
             return Vector2.Zero;

--- a/DelvUI/Interface/GeneralElements/LabelHud.cs
+++ b/DelvUI/Interface/GeneralElements/LabelHud.cs
@@ -48,7 +48,7 @@ namespace DelvUI.Interface.GeneralElements
         private void DrawLabel(string text, Vector2 parentOrigin, Vector2 parentSize)
         {
             var textSize = ImGui.CalcTextSize(text);
-            var offset = OffsetForFrameAchor(parentSize) + OffsetForTextAnchor(textSize);
+            var offset = OffsetForFrameAnchor(parentSize) + OffsetForTextAnchor(textSize);
             var drawList = ImGui.GetWindowDrawList();
 
             if (Config.ShowOutline)
@@ -79,7 +79,7 @@ namespace DelvUI.Interface.GeneralElements
             return Vector2.Zero;
         }
 
-        private Vector2 OffsetForFrameAchor(Vector2 parentSize)
+        private Vector2 OffsetForFrameAnchor(Vector2 parentSize)
         {
             switch (Config.FrameAnchor)
             {

--- a/DelvUI/Interface/GeneralElements/LabelHud.cs
+++ b/DelvUI/Interface/GeneralElements/LabelHud.cs
@@ -21,21 +21,20 @@ namespace DelvUI.Interface.GeneralElements
                 return;
             }
 
-            var size = ImGui.CalcTextSize(Config.GetText());
-            var offset = OffsetForSize(size);
-
-            if (Config.ShowOutline)
-            {
-                DrawHelper.DrawOutlinedText(Config.GetText(), origin + Config.Position + offset, Config.Color.Vector, Config.OutlineColor.Vector);
-            }
-            else
-            {
-                ImGui.SetCursorPos(origin + Config.Position + offset);
-                ImGui.TextColored(Config.Color.Vector, Config.GetText());
-            }
+            DrawLabel(Config.GetText(), origin, Vector2.Zero);
         }
 
-        public void DrawWithActor(Vector2 origin, Actor actor)
+        public void DrawRelativeToParent(Vector2 parentOrigin, Vector2 parentSize)
+        {
+            if (!Config.Enabled || Config.GetText() == null)
+            {
+                return;
+            }
+
+            DrawLabel(Config.GetText(), parentOrigin, parentSize);
+        }
+
+        public void DrawRelativeToParent(Vector2 parentOrigin, Vector2 parentSize, Actor actor)
         {
             if (!Config.Enabled || Config.GetText() == null)
             {
@@ -43,33 +42,38 @@ namespace DelvUI.Interface.GeneralElements
             }
 
             var text = TextTags.GenerateFormattedTextFromTags(actor, Config.GetText());
-            var size = ImGui.CalcTextSize(text);
-            var offset = OffsetForSize(size);
+            DrawLabel(text, parentOrigin, parentSize);
+        }
+
+        private void DrawLabel(string text, Vector2 parentOrigin, Vector2 parentSize)
+        {
+            var textSize = ImGui.CalcTextSize(text);
+            var offset = OffsetForSize(textSize, parentSize);
 
             if (Config.ShowOutline)
             {
-                DrawHelper.DrawOutlinedText(text, origin + Config.Position + offset, Config.Color.Vector, Config.OutlineColor.Vector);
+                DrawHelper.DrawOutlinedText(text, parentOrigin + Config.Position + offset, Config.Color.Vector, Config.OutlineColor.Vector);
             }
             else
             {
-                ImGui.SetCursorPos(origin + Config.Position + offset);
+                ImGui.SetCursorPos(parentOrigin + Config.Position + offset);
                 ImGui.TextColored(Config.Color.Vector, text);
             }
         }
 
-        private Vector2 OffsetForSize(Vector2 size)
+        private Vector2 OffsetForSize(Vector2 textSize, Vector2 parentSize)
         {
             switch (Config.Anchor)
             {
-                case LabelTextAnchor.Center: return -size / 2f;
-                case LabelTextAnchor.Left: return new Vector2(0, -size.Y / 2f);
-                case LabelTextAnchor.Right: return new Vector2(-size.X, -size.Y / 2f);
-                case LabelTextAnchor.Top: return new Vector2(-size.X / 2f, 0);
-                case LabelTextAnchor.TopLeft: return Vector2.Zero;
-                case LabelTextAnchor.TopRight: return new Vector2(size.X, 0);
-                case LabelTextAnchor.Bottom: return new Vector2(-size.X / 2f, -size.Y);
-                case LabelTextAnchor.BottomLeft: return new Vector2(0, -size.Y);
-                case LabelTextAnchor.BottomRight: return -size;
+                case LabelTextAnchor.Center: return -textSize / 2f;
+                case LabelTextAnchor.Left: return new Vector2(-parentSize.X / 2f, -textSize.Y / 2f);
+                case LabelTextAnchor.Right: return new Vector2(parentSize.X / 2f - textSize.X, -textSize.Y / 2f);
+                case LabelTextAnchor.Top: return new Vector2(-textSize.X / 2f, -parentSize.Y / 2f);
+                case LabelTextAnchor.TopLeft: return -parentSize / 2f;
+                case LabelTextAnchor.TopRight: return new Vector2(parentSize.X / 2f - textSize.X, -parentSize.Y / 2f);
+                case LabelTextAnchor.Bottom: return new Vector2(-textSize.X / 2f, parentSize.Y / 2f - textSize.Y);
+                case LabelTextAnchor.BottomLeft: return new Vector2(-parentSize.X / 2f, parentSize.Y / 2f - textSize.Y);
+                case LabelTextAnchor.BottomRight: return new Vector2(parentSize.X / 2f - textSize.X, parentSize.Y / 2f - textSize.Y);
             }
 
             return Vector2.Zero;

--- a/DelvUI/Interface/GeneralElements/LabelHud.cs
+++ b/DelvUI/Interface/GeneralElements/LabelHud.cs
@@ -53,11 +53,11 @@ namespace DelvUI.Interface.GeneralElements
 
             if (Config.ShowOutline)
             {
-                DrawHelper.DrawOutlinedText(Config.GetText(), parentOrigin + Config.Position + offset, Config.Color.Base, Config.OutlineColor.Base, drawList);
+                DrawHelper.DrawOutlinedText(text, parentOrigin + Config.Position + offset, Config.Color.Base, Config.OutlineColor.Base, drawList);
             }
             else
             {
-                drawList.AddText(parentOrigin + Config.Position + offset, Config.Color.Base, Config.GetText());
+                drawList.AddText(parentOrigin + Config.Position + offset, Config.Color.Base, text);
             }
         }
 

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
@@ -45,7 +45,7 @@ namespace DelvUI.Interface.GeneralElements
             var size = new Vector2(254, 20);
             var pos = new Vector2(0, HUDConstants.BaseHUDOffsetY - 37);
 
-            var labelConfig = new LabelConfig(Vector2.Zero, "", LabelTextAnchor.Center);
+            var labelConfig = new LabelConfig(Vector2.Zero, "", LabelTextAnchor.Center, LabelTextAnchor.TopLeft);
 
             return new PrimaryResourceConfig(pos, size, labelConfig);
         }

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
@@ -45,7 +45,7 @@ namespace DelvUI.Interface.GeneralElements
             var size = new Vector2(254, 20);
             var pos = new Vector2(0, HUDConstants.BaseHUDOffsetY - 37);
 
-            var labelConfig = new LabelConfig(Vector2.Zero, "", LabelTextAnchor.Center, LabelTextAnchor.TopLeft);
+            var labelConfig = new LabelConfig(Vector2.Zero, "", LabelTextAnchor.Center, LabelTextAnchor.Center);
 
             return new PrimaryResourceConfig(pos, size, labelConfig);
         }

--- a/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
@@ -20,8 +20,8 @@ namespace DelvUI.Interface.GeneralElements
             var size = HUDConstants.DefaultBigUnitFrameSize;
             var pos = new Vector2(-HUDConstants.UnitFramesOffsetX - size.X / 2f, HUDConstants.BaseHUDOffsetY);
 
-            var leftLabelConfig = new EditableLabelConfig(new Vector2(-size.X / 2f + 5, -size.Y / 2f + 2), "[name:abbreviate]", LabelTextAnchor.BottomLeft);
-            var rightLabelConfig = new EditableLabelConfig(new Vector2(size.X / 2 + 10, -size.Y / 2f + 2), "[health:current-short] | [health:percent]%", LabelTextAnchor.BottomRight);
+            var leftLabelConfig = new EditableLabelConfig(new Vector2(5, -24), "[name:abbreviate]", LabelTextAnchor.TopLeft);
+            var rightLabelConfig = new EditableLabelConfig(new Vector2(-5, -24), "[health:current-short] | [health:percent]", LabelTextAnchor.TopRight);
 
             var config = new PlayerUnitFrameConfig(pos, size, leftLabelConfig, rightLabelConfig);
             config.TankStanceIndicatorConfig = new TankStanceIndicatorConfig();
@@ -45,8 +45,8 @@ namespace DelvUI.Interface.GeneralElements
             var size = HUDConstants.DefaultBigUnitFrameSize;
             var pos = new Vector2(HUDConstants.UnitFramesOffsetX + size.X / 2f, HUDConstants.BaseHUDOffsetY);
 
-            var leftLabelConfig = new EditableLabelConfig(new Vector2(-size.X / 2f + 5, -size.Y / 2f + 2), "[health:current-short] | [health:percent]%", LabelTextAnchor.BottomLeft);
-            var rightLabelConfig = new EditableLabelConfig(new Vector2(size.X / 2 - 5, -size.Y / 2 + 2), "[name:abbreviate]", LabelTextAnchor.BottomRight);
+            var leftLabelConfig = new EditableLabelConfig(new Vector2(5, -24), "[health:current-short] | [health:percent]", LabelTextAnchor.TopLeft);
+            var rightLabelConfig = new EditableLabelConfig(new Vector2(-5, -24), "[name:abbreviate]", LabelTextAnchor.TopRight);
 
             return new TargetUnitFrameConfig(pos, size, leftLabelConfig, rightLabelConfig);
         }
@@ -70,8 +70,8 @@ namespace DelvUI.Interface.GeneralElements
                 HUDConstants.BaseHUDOffsetY - 15
             );
 
-            var leftLabelConfig = new EditableLabelConfig(new Vector2(0, -size.Y / 2f + 2), "[name:abbreviate]", LabelTextAnchor.Bottom);
-            var rightLabelConfig = new EditableLabelConfig(new Vector2(0, size.Y / 2f), "", LabelTextAnchor.Top);
+            var leftLabelConfig = new EditableLabelConfig(new Vector2(0, -24), "[name:abbreviate]", LabelTextAnchor.Top);
+            var rightLabelConfig = new EditableLabelConfig(new Vector2(0, 0), "", LabelTextAnchor.Center);
 
             return new TargetOfTargetUnitFrameConfig(pos, size, leftLabelConfig, rightLabelConfig);
         }

--- a/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
@@ -20,8 +20,8 @@ namespace DelvUI.Interface.GeneralElements
             var size = HUDConstants.DefaultBigUnitFrameSize;
             var pos = new Vector2(-HUDConstants.UnitFramesOffsetX - size.X / 2f, HUDConstants.BaseHUDOffsetY);
 
-            var leftLabelConfig = new EditableLabelConfig(new Vector2(5, -24), "[name:abbreviate]", LabelTextAnchor.TopLeft);
-            var rightLabelConfig = new EditableLabelConfig(new Vector2(-5, -24), "[health:current-short] | [health:percent]", LabelTextAnchor.TopRight);
+            var leftLabelConfig = new EditableLabelConfig(new Vector2(5, 0), "[name:abbreviate]", LabelTextAnchor.TopLeft, LabelTextAnchor.BottomLeft);
+            var rightLabelConfig = new EditableLabelConfig(new Vector2(-5, 0), "[health:current-short] | [health:percent]", LabelTextAnchor.TopRight, LabelTextAnchor.BottomRight);
 
             var config = new PlayerUnitFrameConfig(pos, size, leftLabelConfig, rightLabelConfig);
             config.TankStanceIndicatorConfig = new TankStanceIndicatorConfig();
@@ -45,8 +45,8 @@ namespace DelvUI.Interface.GeneralElements
             var size = HUDConstants.DefaultBigUnitFrameSize;
             var pos = new Vector2(HUDConstants.UnitFramesOffsetX + size.X / 2f, HUDConstants.BaseHUDOffsetY);
 
-            var leftLabelConfig = new EditableLabelConfig(new Vector2(5, -24), "[health:current-short] | [health:percent]", LabelTextAnchor.TopLeft);
-            var rightLabelConfig = new EditableLabelConfig(new Vector2(-5, -24), "[name:abbreviate]", LabelTextAnchor.TopRight);
+            var leftLabelConfig = new EditableLabelConfig(new Vector2(5, 0), "[health:current-short] | [health:percent]", LabelTextAnchor.TopLeft, LabelTextAnchor.BottomLeft);
+            var rightLabelConfig = new EditableLabelConfig(new Vector2(-5, 0), "[name:abbreviate]", LabelTextAnchor.TopRight, LabelTextAnchor.BottomRight);
 
             return new TargetUnitFrameConfig(pos, size, leftLabelConfig, rightLabelConfig);
         }
@@ -70,8 +70,8 @@ namespace DelvUI.Interface.GeneralElements
                 HUDConstants.BaseHUDOffsetY - 15
             );
 
-            var leftLabelConfig = new EditableLabelConfig(new Vector2(0, -24), "[name:abbreviate]", LabelTextAnchor.Top);
-            var rightLabelConfig = new EditableLabelConfig(new Vector2(0, 0), "", LabelTextAnchor.Center);
+            var leftLabelConfig = new EditableLabelConfig(new Vector2(0, 0), "[name:abbreviate]", LabelTextAnchor.Top, LabelTextAnchor.Bottom);
+            var rightLabelConfig = new EditableLabelConfig(new Vector2(0, 0), "", LabelTextAnchor.Center, LabelTextAnchor.TopLeft);
 
             return new TargetOfTargetUnitFrameConfig(pos, size, leftLabelConfig, rightLabelConfig);
         }
@@ -95,8 +95,8 @@ namespace DelvUI.Interface.GeneralElements
                 HUDConstants.BaseHUDOffsetY - 15
             );
 
-            var leftLabelConfig = new EditableLabelConfig(new Vector2(0, -size.Y / 2f + 2), "[name:abbreviate]", LabelTextAnchor.Bottom);
-            var rightLabelConfig = new EditableLabelConfig(new Vector2(0, size.Y / 2f), "", LabelTextAnchor.Top);
+            var leftLabelConfig = new EditableLabelConfig(new Vector2(0, 0), "[name:abbreviate]", LabelTextAnchor.Top, LabelTextAnchor.Bottom);
+            var rightLabelConfig = new EditableLabelConfig(new Vector2(0, 0), "", LabelTextAnchor.Center, LabelTextAnchor.Center);
 
             return new FocusTargetUnitFrameConfig(pos, size, leftLabelConfig, rightLabelConfig);
         }

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -104,8 +104,8 @@ namespace DelvUI.Interface.GeneralElements
                 ImGui.End();
 
                 // labels
-                _leftLabel.DrawWithActor(origin + Config.Position, Actor);
-                _rightLabel.DrawWithActor(origin + Config.Position, Actor);
+                _leftLabel.DrawRelativeToParent(origin + Config.Position, Config.Size, Actor);
+                _rightLabel.DrawRelativeToParent(origin + Config.Position, Config.Size, Actor);
             });
         }
 


### PR DESCRIPTION
This change allows labels on unit frames and cast bars to be drawn with knowledge of the size of the parent element. This way, the text labels will stay anchored and move while the parent element is resized.