### PR TITLE
Feat: Hide Hud

### DIFF
--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -3,7 +3,13 @@
 namespace DelvUI.Config.Attributes
 {
     [AttributeUsage(AttributeTargets.Field)]
-    public class CheckboxAttribute : Attribute
+    public class ConfigAttribute : Attribute
+    {
+        public bool isMonitored = false;
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class CheckboxAttribute : ConfigAttribute
     {
         public string friendlyName;
 
@@ -151,7 +157,7 @@ namespace DelvUI.Config.Attributes
 
     [AttributeUsage(AttributeTargets.Field)]
     public class DragDropHorizontalAttribute : Attribute
-    {   
+    {
         public string friendlyName;
         public string[] names;
 
@@ -187,6 +193,19 @@ namespace DelvUI.Config.Attributes
         {
             this.friendlyName = friendlyName;
             this.pos = pos;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class DynamicList : ConfigAttribute
+    {
+        public string friendlyName;
+        public string[] options;
+
+        public DynamicList(string friendlyName, params string[] options)
+        {
+            this.friendlyName = friendlyName;
+            this.options = options;
         }
     }
 }

--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -17,7 +17,7 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragFloatAttribute : Attribute
+    public class DragFloatAttribute : ConfigAttribute
     {
         public string friendlyName;
         public float min;
@@ -34,7 +34,7 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragIntAttribute : Attribute
+    public class DragIntAttribute : ConfigAttribute
     {
         public string friendlyName;
         public int min;
@@ -51,7 +51,7 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragFloat2Attribute : Attribute
+    public class DragFloat2Attribute : ConfigAttribute
     {
         public string friendlyName;
         public float min;
@@ -68,7 +68,7 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class DragInt2Attribute : Attribute
+    public class DragInt2Attribute : ConfigAttribute
     {
         public string friendlyName;
         public int min;
@@ -85,7 +85,7 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class InputTextAttribute : Attribute
+    public class InputTextAttribute : ConfigAttribute
     {
         public string friendlyName;
         public uint maxLength;
@@ -98,7 +98,7 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class ColorEdit4Attribute : Attribute
+    public class ColorEdit4Attribute : ConfigAttribute
     {
         public string friendlyName;
 
@@ -106,7 +106,7 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class ComboAttribute : Attribute
+    public class ComboAttribute : ConfigAttribute
     {
         public string friendlyName;
         public string[] options;

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -129,6 +129,7 @@ namespace DelvUI.Config
                 typeof(CastersColorConfig),
                 typeof(MiscColorConfig),
 
+                typeof(HideHudConfig),
                 typeof(PrimaryResourceConfig),
                 typeof(TooltipsConfig),
                 typeof(GCDIndicatorConfig),

--- a/DelvUI/Config/OnChangeEventArgs.cs
+++ b/DelvUI/Config/OnChangeEventArgs.cs
@@ -12,12 +12,12 @@ namespace DelvUI.Config
 
     public class OnChangeBaseArgs : EventArgs
     {
-        public string KeyName { get; }
+        public string PropertyName { get; }
         public ChangeType ChangeType { get; private set; }
 
         public OnChangeBaseArgs(string keyName, ChangeType type = ChangeType.None)
         {
-            KeyName = keyName;
+            PropertyName = keyName;
             ChangeType = type;
         }
     }

--- a/DelvUI/Config/OnChangeEventArgs.cs
+++ b/DelvUI/Config/OnChangeEventArgs.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace DelvUI.Config
+{
+
+    public enum ChangeType
+    {
+        None = 0,
+        ListAdd = 1,
+        ListRemove = 2
+    }
+
+    public class OnChangeBaseArgs : EventArgs
+    {
+        public string KeyName { get; }
+        public ChangeType ChangeType { get; private set; }
+
+        public OnChangeBaseArgs(string keyName, ChangeType type = ChangeType.None)
+        {
+            KeyName = keyName;
+            ChangeType = type;
+        }
+    }
+
+    public class OnChangeEventArgs<T> : OnChangeBaseArgs
+    {
+        public T Value { get; }
+
+        public OnChangeEventArgs(string keyName, T value, ChangeType type = ChangeType.None) : base(keyName, type)
+        {
+            Value = value;
+        }
+    }
+
+    public interface IOnChangeEventArgs
+    {
+        public abstract event EventHandler<OnChangeBaseArgs> onValueChanged;
+
+        public abstract void onValueChangedRegisterEvent(OnChangeBaseArgs e);
+    }
+
+}

--- a/DelvUI/Config/PluginConfigObject.cs
+++ b/DelvUI/Config/PluginConfigObject.cs
@@ -9,7 +9,7 @@ using System.Numerics;
 namespace DelvUI.Config
 {
     [Serializable]
-    public abstract class PluginConfigObject
+    public abstract class PluginConfigObject : IOnChangeEventArgs
     {
         [Checkbox("Enabled")]
         [Order(0)]
@@ -34,6 +34,19 @@ namespace DelvUI.Config
             Debug.Assert(false, "Static method 'DefaultConfig' not found !!!");
             return null;
         }
+
+        #region IOnChangeEventArgs
+
+        // sending event outside of the config
+        public event EventHandler<OnChangeBaseArgs> onValueChanged;
+
+        // received events from the node
+        public void onValueChangedRegisterEvent(OnChangeBaseArgs e)
+        {
+            onValueChanged?.Invoke(this, e);
+        }
+
+        #endregion
     }
 
     [Serializable]

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -1054,6 +1054,13 @@ namespace DelvUI.Config.Tree
                     {
                         field.SetValue(ConfigObject, floatVal);
                         changed = true;
+
+                        if (changed && dragFloatAttribute.isMonitored && ConfigObject is IOnChangeEventArgs eventObject)
+                        {
+                            eventObject.onValueChangedRegisterEvent(
+                                new OnChangeEventArgs<float>(field.Name, floatVal)
+                            );
+                        }
                     }
                 }
                 else if (attribute is DragIntAttribute dragIntAttribute)
@@ -1064,6 +1071,13 @@ namespace DelvUI.Config.Tree
                     {
                         field.SetValue(ConfigObject, intVal);
                         changed = true;
+
+                        if (changed && dragIntAttribute.isMonitored && ConfigObject is IOnChangeEventArgs eventObject)
+                        {
+                            eventObject.onValueChangedRegisterEvent(
+                                new OnChangeEventArgs<float>(field.Name, intVal)
+                            );
+                        }
                     }
                 }
                 else if (attribute is DragFloat2Attribute dragFloat2Attribute)
@@ -1075,6 +1089,14 @@ namespace DelvUI.Config.Tree
                         field.SetValue(ConfigObject, floatVal);
                         changed = true;
                     }
+
+                    if (changed && dragFloat2Attribute.isMonitored && ConfigObject is IOnChangeEventArgs eventObject)
+                    {
+                        eventObject.onValueChangedRegisterEvent(
+                            new OnChangeEventArgs<Vector2>(field.Name, floatVal)
+                        );
+                    }
+
                 }
                 else if (attribute is DragInt2Attribute dragInt2Attribute)
                 {
@@ -1084,6 +1106,13 @@ namespace DelvUI.Config.Tree
                     {
                         field.SetValue(ConfigObject, intVal);
                         changed = true;
+
+                        if (changed && dragInt2Attribute.isMonitored && ConfigObject is IOnChangeEventArgs eventObject)
+                        {
+                            eventObject.onValueChangedRegisterEvent(
+                                new OnChangeEventArgs<Vector2>(field.Name, intVal)
+                            );
+                        }
                     }
                 }
                 else if (attribute is InputTextAttribute inputTextAttribute)
@@ -1094,6 +1123,13 @@ namespace DelvUI.Config.Tree
                     {
                         field.SetValue(ConfigObject, stringVal);
                         changed = true;
+
+                        if (changed && inputTextAttribute.isMonitored && ConfigObject is IOnChangeEventArgs eventObject)
+                        {
+                            eventObject.onValueChangedRegisterEvent(
+                                new OnChangeEventArgs<string>(field.Name, stringVal)
+                            );
+                        }
                     }
                 }
                 else if (attribute is ColorEdit4Attribute colorEdit4Attribute)
@@ -1106,6 +1142,13 @@ namespace DelvUI.Config.Tree
                         colorVal.Vector = vector;
                         field.SetValue(ConfigObject, colorVal);
                         changed = true;
+
+                        if (changed && colorEdit4Attribute.isMonitored && ConfigObject is IOnChangeEventArgs eventObject)
+                        {
+                            eventObject.onValueChangedRegisterEvent(
+                                new OnChangeEventArgs<PluginConfigColor>(field.Name, colorVal)
+                            );
+                        }
                     }
                 }
                 else if (attribute is ComboAttribute comboAttribute)
@@ -1116,6 +1159,13 @@ namespace DelvUI.Config.Tree
                     {
                         field.SetValue(ConfigObject, intVal);
                         changed = true;
+
+                        if (changed && comboAttribute.isMonitored && ConfigObject is IOnChangeEventArgs eventObject)
+                        {
+                            eventObject.onValueChangedRegisterEvent(
+                                new OnChangeEventArgs<int>(field.Name, intVal)
+                            );
+                        }
                     }
                 }
                 else if (attribute is DragDropHorizontalAttribute dragDropHorizontalAttribute)

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -1036,6 +1036,14 @@ namespace DelvUI.Config.Tree
                     {
                         field.SetValue(ConfigObject, boolVal);
                         changed = true;
+
+                        if (changed && checkboxAttribute.isMonitored
+                            && ConfigObject is IOnChangeEventArgs eventObject)
+                        {
+                            eventObject.onValueChangedRegisterEvent(
+                                new OnChangeEventArgs<bool>(field.Name, boolVal)
+                            );
+                        }
                     }
                 }
                 else if (attribute is DragFloatAttribute dragFloatAttribute)
@@ -1140,6 +1148,78 @@ namespace DelvUI.Config.Tree
                             }
                         }
                     }
+                }
+                else if (attribute is DynamicList dynamicList)
+                {
+                    List<string> opts = (List<string>)fieldVal;
+
+                    ImGui.BeginGroup();
+
+                    if (ImGui.BeginTable("##myTable2" + dynamicList.friendlyName + idText, 2))
+                    {
+                        ImGui.TableNextColumn();
+
+                        List<string> addOptions = new(dynamicList.options);
+                        for (int i = 0; i < opts.Count(); i++)
+                        {
+                            addOptions.Remove(opts[i]);
+                        }
+
+                        int intVal = 0;
+                        ImGui.Text("Add");
+                        if (ImGui.Combo("##Add" + idText + dynamicList.friendlyName, ref intVal, addOptions.ToArray(), addOptions.Count(), 6))
+                        {
+                            var change = addOptions[intVal];
+                            opts.Add(change);
+                            field.SetValue(ConfigObject, opts);
+                            changed = true;
+
+                            if (dynamicList.isMonitored && ConfigObject is IOnChangeEventArgs eventObject)
+                            {
+                                eventObject.onValueChangedRegisterEvent(
+                                    new OnChangeEventArgs<string>(field.Name, change, ChangeType.ListAdd)
+                                );
+                            }
+                        }
+
+                        ImGui.TableNextColumn();
+
+                        var removeOpts = opts;
+
+                        int removeVal = 0;
+                        ImGui.Text("Remove");
+                        if (ImGui.Combo("##Remove" + idText + dynamicList.friendlyName, ref removeVal, removeOpts.ToArray(), removeOpts.Count(), 6))
+                        {
+                            var change = removeOpts[removeVal];
+                            opts.Remove(change);
+                            field.SetValue(ConfigObject, opts);
+                            changed = true;
+
+                            if (dynamicList.isMonitored && ConfigObject is IOnChangeEventArgs eventObject)
+                            {
+                                eventObject.onValueChangedRegisterEvent(
+                                    new OnChangeEventArgs<string>(field.Name, change, ChangeType.ListRemove)
+                                );
+                            }
+                        }
+
+                        ImGui.EndTable();
+                    }
+
+                    ImGui.Text(dynamicList.friendlyName + ":");
+
+                    if (opts.Count() > 0 && ImGui.BeginTable("##myTable" + dynamicList.friendlyName, 5))
+                    {
+                        var length = opts.Count();
+                        for (int i = 0; i < length; i++)
+                        {
+                            ImGui.TableNextColumn();
+                            ImGui.Text(opts[i]);
+                        }
+                        ImGui.EndTable();
+                    }
+
+                    ImGui.EndGroup();
                 }
             }
         }

--- a/DelvUI/Interface/GeneralElements/HideHudConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HideHudConfig.cs
@@ -3,13 +3,14 @@ using DelvUI.Config;
 using DelvUI.Config.Attributes;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
     [Serializable]
     [Section("Misc")]
     [SubSection("Hide Options", 0)]
-    public class HideHudConfig : PluginConfigObject, IOnChangeEventArgs
+    public class HideHudConfig : PluginConfigObject
     {
         [Checkbox("Hide DelvUI outside of combat")]
         [Order(5)]
@@ -32,18 +33,5 @@ namespace DelvUI.Interface.GeneralElements
         public List<string> CombatActionBars = new();
 
         public new static HideHudConfig DefaultConfig() { return new HideHudConfig(); }
-
-        #region OnChangeEventInterface
-
-        // sending event outside of the config
-        public event EventHandler<OnChangeBaseArgs> onValueChanged;
-
-        // received events from the node
-        public void onValueChangedRegisterEvent(OnChangeBaseArgs e)
-        {
-            onValueChanged?.Invoke(this, e);
-        }
-
-        #endregion
     }
 }

--- a/DelvUI/Interface/GeneralElements/HideHudConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HideHudConfig.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using DelvUI.Config;
+using DelvUI.Config.Attributes;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace DelvUI.Interface.GeneralElements
+{
+    [Serializable]
+    [Section("Misc")]
+    [SubSection("Hide Options", 0)]
+    public class HideHudConfig : PluginConfigObject, IOnChangeEventArgs
+    {
+        [Checkbox("Hide DelvUI outside of combat")]
+        [Order(5)]
+        public bool HideOutsideOfCombat = false;
+
+        [Checkbox("Hide Default Job Gauges", isMonitored = true)]
+        [Order(10)]
+        public bool HideDefaultJobGauges = false;
+
+        [Checkbox("Hide Default Castbar", isMonitored = true)]
+        [Order(15)]
+        public bool HideDefaultCastbar = false;
+
+        [Checkbox("Enable Combat Hotbars", isMonitored = true)]
+        [CollapseControl(20, 0)]
+        public bool EnableCombatActionBars = false;
+
+        [DynamicList("Hotbars Shown Only In Combat", "Hotbar 1", "Hotbar 2", "Hotbar 3", "Hotbar 4", "Hotbar 5", "Hotbar 6", "Hotbar 7", "Hotbar 8", "Hotbar 9", "Hotbar 10", isMonitored = true)]
+        [CollapseWith(0, 0)]
+        public List<string> CombatActionBars = new();
+
+        public new static HideHudConfig DefaultConfig() { return new HideHudConfig(); }
+
+        #region OnChangeEventInterface
+
+        // sending event outside of the config
+        public event EventHandler<OnChangeBaseArgs> onValueChanged;
+
+        // received events from the node
+        public void onValueChangedRegisterEvent(OnChangeBaseArgs e)
+        {
+            onValueChanged?.Invoke(this, e);
+        }
+
+        #endregion
+    }
+}

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -1,0 +1,245 @@
+﻿using Dalamud.Game.ClientState;
+using Dalamud.Game.ClientState.Actors.Types;
+using DelvUI.Config;
+using DelvUI.Interface.GeneralElements;
+using System.Diagnostics;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using System.Runtime.InteropServices;
+using System;
+using Dalamud.Plugin;
+using DelvUI.Config.Attributes;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace DelvUI.Interface
+{
+    internal class GUIAddon
+    {
+        public unsafe AtkUnitBase* addonPtr;
+        public string name;
+
+        public unsafe void DefaultVisibilityToggle(bool isHidden)
+        {
+            if (isHidden)
+            {
+                addonPtr->UldManager.NodeListCount = 0; // disable
+            }
+            else
+            {
+                addonPtr->UldManager.UpdateDrawNodeList(); // enable
+            }
+        }
+    }
+
+    public class HudHelper
+    {
+        private HideHudConfig Config => ConfigurationManager.GetInstance().GetConfigObject<HideHudConfig>();
+
+        private bool _previousCombatState = true;
+
+        public HudHelper()
+        {
+            Config.onValueChanged += ConfigValueChanged;
+        }
+
+        ~HudHelper()
+        {
+            Config.onValueChanged -= ConfigValueChanged;
+        }
+
+        #region Event Handlers
+
+        public void ConfigValueChanged(object sender, OnChangeBaseArgs e)
+        {
+            if (e.KeyName == "HideDefaultCastbar")
+            {
+                ConfigureDefaultCastBar();
+            }
+            else if (e.KeyName == "HideDefaultJobGauges")
+            {
+                ConfigureDefaultJobGauge();
+            }
+            else if (e.KeyName == "EnableCombatActionBars" && e is OnChangeEventArgs<bool> boolEvent)
+            {
+                Config.CombatActionBars.ForEach(name => ToggleActionbar(name, boolEvent.Value));
+            }
+            else if (e.KeyName == "CombatActionBars" && e is OnChangeEventArgs<string> listEvent)
+            {
+                switch (listEvent.ChangeType)
+                {
+                    case ChangeType.ListAdd:
+                        ToggleActionbar(listEvent.Value, !IsInCombat());
+                        break;
+                    case ChangeType.ListRemove:
+                        ToggleActionbar(listEvent.Value, false);
+                        break;
+                }
+            }
+
+        }
+
+        #endregion
+
+
+        #region Action Bars
+        public void ConfigureCombatActionBars()
+        {
+            if (!Config.EnableCombatActionBars)
+            {
+                return;
+            }
+
+            var currentCombatState = IsInCombat();
+            if (_previousCombatState != currentCombatState && Config.CombatActionBars.Count > 0)
+            {
+                Config.CombatActionBars.ForEach(name => ToggleActionbar(name, !currentCombatState));
+                _previousCombatState = currentCombatState;
+            }
+        }
+
+        #endregion
+
+        public bool IsElementHidden(HudElement element = null)
+        {
+            if (!ConfigurationManager.GetInstance().LockHUD)
+            {
+                return ConfigurationManager.GetInstance().LockHUD;
+            }
+
+            bool isHidden = Config.HideOutsideOfCombat && !IsInCombat();
+
+            if (element != null)
+            {
+                if (element.ID == HudManager.playerCastbarID)
+                {
+                    return false;
+                }
+
+                if (element.ID == HudManager.playerUnitFrameID)
+                {
+                    PlayerCharacter player = Plugin.ClientState.LocalPlayer;
+                    Debug.Assert(player != null, "HudHelper.LocalPlayer is NULL.");
+                    isHidden = isHidden && player.CurrentHp == player.MaxHp;
+                }
+            }
+
+            return isHidden;
+        }
+
+        // executed on login and on job swap
+        public void ApplyCurrentConfig()
+        {
+            ConfigureDefaultCastBar();
+            ConfigureDefaultJobGauge();
+            ConfigureCombatActionBars();
+        }
+
+        private unsafe void ToggleActionbar(string targetName, bool isHidden)
+        {
+            ToggleDefaultComponent(delegate (GUIAddon addon)
+            {
+                string keyCode = GetActionBarName(targetName);
+                if (addon.name == keyCode)
+                {
+                    if (isHidden)
+                    {
+                        addon.addonPtr->IsVisible = false;
+                        addon.addonPtr->UldManager.NodeListCount = 0; // disable
+                    }
+                    else
+                    {
+                        addon.addonPtr->IsVisible = true;
+                        addon.addonPtr->UldManager.UpdateDrawNodeList(); // enable
+                    }
+                }
+            });
+        }
+
+        private void ConfigureDefaultCastBar()
+        {
+            ToggleDefaultComponent(delegate (GUIAddon addon)
+            {
+                if (addon.name == "_CastBar")
+                {
+                    addon.DefaultVisibilityToggle(Config.HideDefaultCastbar);
+                }
+            });
+        }
+
+        private unsafe void ConfigureDefaultJobGauge()
+        {
+            ToggleDefaultComponent(delegate (GUIAddon addon)
+            {
+                if (addon.name.StartsWith("JobHud"))
+                {
+                    if (Config.HideDefaultJobGauges)
+                    {
+                        addon.addonPtr->IsVisible = false;
+                    }
+                    else
+                    {
+                        addon.addonPtr->IsVisible = true;
+                        addon.addonPtr->UldManager.UpdateDrawNodeList();
+                    }
+                }
+            });
+        }
+
+        #region Helpers
+
+        private unsafe void ToggleDefaultComponent(Action<GUIAddon> action)
+        {
+            var stage = AtkStage.GetSingleton();
+            Debug.Assert(stage != null, "stage == null");
+            var loadedUnitsList = &stage->RaptureAtkUnitManager->AtkUnitManager.AllLoadedUnitsList;
+            Debug.Assert(loadedUnitsList != null, "loadedUnitsList == null");
+            var addonList = &loadedUnitsList->AtkUnitEntries;
+            Debug.Assert(addonList != null, "addonList == null");
+
+            for (var i = 0; i < loadedUnitsList->Count; i++)
+            {
+                AtkUnitBase* addon = addonList[i];
+                Debug.Assert(addon != null, "addon == null");
+                var name = Marshal.PtrToStringAnsi(new IntPtr(addon->Name));
+                if (name == null)
+                {
+                    continue;
+                }
+
+                action?.Invoke(new GUIAddon() { addonPtr = addon, name = name });
+            }
+        }
+
+        private bool IsInCombat()
+        {
+            return Plugin.ClientState.Condition[ConditionFlag.InCombat];
+        }
+
+        private bool IsInDuty()
+        {
+            return Plugin.ClientState.Condition[ConditionFlag.BoundByDuty];
+        }
+
+        private Dictionary<string, string> _hotbarMap => new Dictionary<string, string>()
+            {
+                { "Hotbar 1", "_ActionBar" },
+                { "Hotbar 2", "_ActionBar01" },
+                { "Hotbar 3", "_ActionBar02" },
+                { "Hotbar 4", "_ActionBar03" },
+                { "Hotbar 5", "_ActionBar04" },
+                { "Hotbar 6", "_ActionBar05" },
+                { "Hotbar 7", "_ActionBar06" },
+                { "Hotbar 8", "_ActionBar07" },
+                { "Hotbar 9", "_ActionBar08" },
+                { "Hotbar 10", "_ActionBar09" },
+            };
+
+        private string GetActionBarName(string hotbarUserFriendlyName)
+        {
+            _hotbarMap.TryGetValue(hotbarUserFriendlyName, out var result);
+            return result ?? hotbarUserFriendlyName;
+        }
+
+        #endregion
+    }
+}

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -36,6 +36,7 @@ namespace DelvUI.Interface
         private HideHudConfig Config => ConfigurationManager.GetInstance().GetConfigObject<HideHudConfig>();
 
         private bool _previousCombatState = true;
+        public bool UserInterfaceWasHidden = false;
 
         public HudHelper()
         {
@@ -90,7 +91,7 @@ namespace DelvUI.Interface
             }
 
             var currentCombatState = IsInCombat();
-            if (_previousCombatState != currentCombatState && Config.CombatActionBars.Count > 0)
+            if (_previousCombatState != currentCombatState && Config.CombatActionBars.Count > 0 || UserInterfaceWasHidden)
             {
                 Config.CombatActionBars.ForEach(name => ToggleActionbar(name, !currentCombatState));
                 _previousCombatState = currentCombatState;
@@ -166,7 +167,7 @@ namespace DelvUI.Interface
             });
         }
 
-        private unsafe void ConfigureDefaultJobGauge()
+        public unsafe void ConfigureDefaultJobGauge()
         {
             ToggleDefaultComponent(delegate (GUIAddon addon)
             {

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -52,19 +52,19 @@ namespace DelvUI.Interface
 
         public void ConfigValueChanged(object sender, OnChangeBaseArgs e)
         {
-            if (e.KeyName == "HideDefaultCastbar")
+            if (e.PropertyName == "HideDefaultCastbar")
             {
                 ConfigureDefaultCastBar();
             }
-            else if (e.KeyName == "HideDefaultJobGauges")
+            else if (e.PropertyName == "HideDefaultJobGauges")
             {
                 ConfigureDefaultJobGauge();
             }
-            else if (e.KeyName == "EnableCombatActionBars" && e is OnChangeEventArgs<bool> boolEvent)
+            else if (e.PropertyName == "EnableCombatActionBars" && e is OnChangeEventArgs<bool> boolEvent)
             {
                 Config.CombatActionBars.ForEach(name => ToggleActionbar(name, boolEvent.Value));
             }
-            else if (e.KeyName == "CombatActionBars" && e is OnChangeEventArgs<string> listEvent)
+            else if (e.PropertyName == "CombatActionBars" && e is OnChangeEventArgs<string> listEvent)
             {
                 switch (listEvent.ChangeType)
                 {
@@ -76,6 +76,7 @@ namespace DelvUI.Interface
                         break;
                 }
             }
+
 
         }
 
@@ -111,12 +112,12 @@ namespace DelvUI.Interface
 
             if (element != null)
             {
-                if (element.ID == HudManager.playerCastbarID)
+                if (element.GetType() == typeof(PlayerCastbarHud))
                 {
                     return false;
                 }
 
-                if (element.ID == HudManager.playerUnitFrameID)
+                if (element.GetConfig().GetType() == typeof(PlayerUnitFrameConfig))
                 {
                     PlayerCharacter player = Plugin.ClientState.LocalPlayer;
                     Debug.Assert(player != null, "HudHelper.LocalPlayer is NULL.");

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -214,6 +214,12 @@ namespace DelvUI.Interface
                 return;
             }
 
+            if (helper.UserInterfaceWasHidden)
+            {
+                helper.ConfigureDefaultJobGauge();
+                helper.UserInterfaceWasHidden = false;
+            }
+
             helper.ConfigureCombatActionBars();
 
             ImGuiHelpers.ForceNextWindowMainViewport();

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -32,11 +32,7 @@ namespace DelvUI.Interface
         private Dictionary<uint, JobHudTypes> _jobsMap;
         private Dictionary<uint, Type> _unsupportedJobsMap;
 
-        public HudHelper helper { get; } = new HudHelper();
-
-        public static string playerUnitFrameID = "playerUnitFrame";
-        public static string playerCastbarID = "playerCastbar";
-
+        public HudHelper Helper { get; } = new HudHelper();
 
         public HudManager()
         {
@@ -120,7 +116,7 @@ namespace DelvUI.Interface
         private void CreateUnitFrames()
         {
             var playerUnitFrameConfig = ConfigurationManager.GetInstance().GetConfigObject<PlayerUnitFrameConfig>();
-            var playerUnitFrame = new UnitFrameHud(HudManager.playerUnitFrameID, playerUnitFrameConfig, "Player");
+            var playerUnitFrame = new UnitFrameHud("playerUnitFrame", playerUnitFrameConfig, "Player");
             _hudElements.Add(playerUnitFrame);
             _hudElementsUsingPlayer.Add(playerUnitFrame);
 
@@ -143,7 +139,7 @@ namespace DelvUI.Interface
         private void CreateCastbars()
         {
             var playerCastbarConfig = ConfigurationManager.GetInstance().GetConfigObject<PlayerCastbarConfig>();
-            var playerCastbar = new PlayerCastbarHud(playerCastbarID, playerCastbarConfig, "Player Castbar");
+            var playerCastbar = new PlayerCastbarHud("playerCastbar", playerCastbarConfig, "Player Castbar");
             _hudElements.Add(playerCastbar);
             _hudElementsUsingPlayer.Add(playerCastbar);
 
@@ -214,13 +210,13 @@ namespace DelvUI.Interface
                 return;
             }
 
-            if (helper.UserInterfaceWasHidden)
+            if (Helper.UserInterfaceWasHidden)
             {
-                helper.ConfigureDefaultJobGauge();
-                helper.UserInterfaceWasHidden = false;
+                Helper.ConfigureDefaultJobGauge();
+                Helper.UserInterfaceWasHidden = false;
             }
 
-            helper.ConfigureCombatActionBars();
+            Helper.ConfigureCombatActionBars();
 
             ImGuiHelpers.ForceNextWindowMainViewport();
             ImGui.SetNextWindowPos(Vector2.Zero);
@@ -256,7 +252,7 @@ namespace DelvUI.Interface
             // general elements
             foreach (var element in _hudElements)
             {
-                if (element != _selectedElement && !helper.IsElementHidden(element))
+                if (element != _selectedElement && !Helper.IsElementHidden(element))
                 {
                     element.Draw(_origin);
                 }
@@ -265,7 +261,7 @@ namespace DelvUI.Interface
             // job hud
             if (_jobHud != null && _jobHud.Config.Enabled && _jobHud != _selectedElement)
             {
-                if (!helper.IsElementHidden())
+                if (!Helper.IsElementHidden())
                 {
                     _jobHud.Draw(_origin);
                 }
@@ -324,7 +320,7 @@ namespace DelvUI.Interface
 
             if (config != null && _primaryResourceHud != null)
             {
-                helper.ApplyCurrentConfig();
+                Helper.ApplyCurrentConfig();
 
                 _primaryResourceHud.ResourceType = config.UseDefaultPrimaryResourceBar ? config.PrimaryResourceType : PrimaryResourceTypes.None;
             }

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -209,6 +209,11 @@ namespace DelvUI
                          || Condition[ConditionFlag.BetweenAreas]
                          || Condition[ConditionFlag.BetweenAreas51];
 
+            if (hudState)
+            {
+                _hudManager.helper.UserInterfaceWasHidden = true;
+            }
+
             UiBuilder.OverrideGameCursor = false;
 
             ConfigurationManager.GetInstance().Draw();

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -211,7 +211,7 @@ namespace DelvUI
 
             if (hudState)
             {
-                _hudManager.helper.UserInterfaceWasHidden = true;
+                _hudManager.Helper.UserInterfaceWasHidden = true;
             }
 
             UiBuilder.OverrideGameCursor = false;


### PR DESCRIPTION
This PR implements parts of ![](https://github.trello.services/images/mini-trello-icon.png) [Feature: Hide DelvUI Hud (Discussion)](https://trello.com/c/3PqWjVER/144-feature-hide-delvui-hud-discussion) and some more:

1) Hide HUD options (DelvUI > Misc > Hide Options)
- Hide DelvUI when outside of combat
- Hide Default Job Gauge
- Hide Default Castbar
- Show selected Hotbars only in combat

2) Config property observation
Introduces the ability to track Config changes without checking to them every frame.
- add `public interface IOnChangeEventArgs`
- add `public class OnChangeEventArgs<T> : OnChangeBaseArgs`
- add `public class DynamicList : ConfigAttribute`

Property observation can be seen implemented in `HudHelper` which subscribes for the events sent by `HideHudConfig`.
The chain for the received events is as follows:
ConfigNode (value changed) >> calls the `Config.onValueChangedRegisterEvent(EventArgs)` >> `Config.onValueChangedRegisterEvent(EventArgs)` sends msg to all subscribed classes via `EventHandler<OnChangeBaseArgs> onValueChanged`

