### PR TITLE
Implementing label configs for duration and stacks on status effects

### DIFF
--- a/DelvUI/Interface/GeneralElements/LabelHud.cs
+++ b/DelvUI/Interface/GeneralElements/LabelHud.cs
@@ -23,15 +23,15 @@ namespace DelvUI.Interface.GeneralElements
 
             var size = ImGui.CalcTextSize(Config.GetText());
             var offset = OffsetForSize(size);
+            var drawList = ImGui.GetWindowDrawList();
 
             if (Config.ShowOutline)
             {
-                DrawHelper.DrawOutlinedText(Config.GetText(), origin + Config.Position + offset, Config.Color.Vector, Config.OutlineColor.Vector);
+                DrawHelper.DrawOutlinedText(Config.GetText(), origin + Config.Position + offset, Config.Color.Base, Config.OutlineColor.Base, drawList);
             }
             else
             {
-                ImGui.SetCursorPos(origin + Config.Position + offset);
-                ImGui.TextColored(Config.Color.Vector, Config.GetText());
+                drawList.AddText(origin + Config.Position + offset, Config.Color.Base, Config.GetText());
             }
         }
 
@@ -45,15 +45,15 @@ namespace DelvUI.Interface.GeneralElements
             var text = TextTags.GenerateFormattedTextFromTags(actor, Config.GetText());
             var size = ImGui.CalcTextSize(text);
             var offset = OffsetForSize(size);
+            var drawList = ImGui.GetWindowDrawList();
 
             if (Config.ShowOutline)
             {
-                DrawHelper.DrawOutlinedText(text, origin + Config.Position + offset, Config.Color.Vector, Config.OutlineColor.Vector);
+                DrawHelper.DrawOutlinedText(text, origin + Config.Position + offset, Config.Color.Base, Config.OutlineColor.Base, drawList);
             }
             else
             {
-                ImGui.SetCursorPos(origin + Config.Position + offset);
-                ImGui.TextColored(Config.Color.Vector, text);
+                drawList.AddText(origin + Config.Position + offset, Config.Color.Base, Config.GetText());
             }
         }
 

--- a/DelvUI/Interface/StatusEffects/StatusEffectIconDrawHelper.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectIconDrawHelper.cs
@@ -1,5 +1,6 @@
 ﻿using DelvUI.Config;
 using DelvUI.Helpers;
+using DelvUI.Interface.GeneralElements;
 using ImGuiNET;
 using Lumina.Excel.GeneratedSheets;
 using System;
@@ -9,7 +10,13 @@ namespace DelvUI.Interface.StatusEffects
 {
     internal static class StatusEffectIconDrawHelper
     {
-        public static void DrawStatusEffectIcon(ImDrawListPtr drawList, Vector2 position, StatusEffectData statusEffectData, StatusEffectIconConfig config)
+        public static void DrawStatusEffectIcon(
+            ImDrawListPtr drawList,
+            Vector2 position,
+            StatusEffectData statusEffectData,
+            StatusEffectIconConfig config,
+            LabelHud durationLabel,
+            LabelHud stacksLabel)
         {
             // icon
             DrawHelper.DrawIcon<Status>(statusEffectData.Data, position, config.Size, false, drawList);
@@ -22,34 +29,21 @@ namespace DelvUI.Interface.StatusEffects
             }
 
             // duration
-            if (config.ShowDurationText && !statusEffectData.Data.IsPermanent && !statusEffectData.Data.IsFcBuff)
+            if (config.DurationLabelConfig.Enabled && !statusEffectData.Data.IsPermanent && !statusEffectData.Data.IsFcBuff)
             {
                 var duration = Math.Round(Math.Abs(statusEffectData.StatusEffect.Duration));
-                var text = Utils.DurationToString(duration);
-                var textSize = ImGui.CalcTextSize(text);
+                config.DurationLabelConfig.SetText(Utils.DurationToString(duration));
 
-                DrawHelper.DrawOutlinedText(
-                    text,
-                    position + new Vector2(config.Size.X / 2f - textSize.X / 2f, config.Size.Y / 2f - textSize.Y / 2f),
-                    drawList,
-                    2
-                );
+                durationLabel.Draw(position + config.Size / 2f);
             }
 
             // stacks
-            if (config.ShowStacksText && statusEffectData.Data.MaxStacks > 0 && statusEffectData.StatusEffect.StackCount > 0 && !statusEffectData.Data.IsFcBuff)
+            if (config.StacksLabelConfig.Enabled && statusEffectData.Data.MaxStacks > 0 && statusEffectData.StatusEffect.StackCount > 0 && !statusEffectData.Data.IsFcBuff)
             {
                 var text = $"{statusEffectData.StatusEffect.StackCount}";
-                var textSize = ImGui.CalcTextSize(text);
+                config.StacksLabelConfig.SetText(text);
 
-                DrawHelper.DrawOutlinedText(
-                    text,
-                    position + new Vector2(config.Size.X * 0.9f - textSize.X / 2f, config.Size.X * 0.2f - textSize.Y / 2f),
-                    0xFF000000,
-                    0xFFFFFFFF,
-                    drawList,
-                    2
-                );
+                stacksLabel.Draw(position + config.Size / 2f);
             }
         }
 

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -1,5 +1,6 @@
 ﻿using DelvUI.Config;
 using DelvUI.Config.Attributes;
+using DelvUI.Interface.GeneralElements;
 using ImGuiNET;
 using Newtonsoft.Json;
 using System;
@@ -207,13 +208,11 @@ namespace DelvUI.Interface.StatusEffects
         [Order(0)]
         public Vector2 Size = new(40, 40);
 
-        [Checkbox("Show Duration")]
-        [Order(5)]
-        public bool ShowDurationText = true;
+        [NestedConfig("Duration", 5)]
+        public LabelConfig DurationLabelConfig;
 
-        [Checkbox("Show Stacks")]
-        [Order(10)]
-        public bool ShowStacksText = true;
+        [NestedConfig("Stacks", 10)]
+        public LabelConfig StacksLabelConfig;
 
         [NestedConfig("Border", 15)]
         public StatusEffectIconBorderConfig BorderConfig = new StatusEffectIconBorderConfig();
@@ -224,9 +223,10 @@ namespace DelvUI.Interface.StatusEffects
         [NestedConfig("My Effects Border", 25)]
         public StatusEffectIconBorderConfig OwnedBorderConfig = new StatusEffectIconBorderConfig(new(new(50f / 255f, 255f / 255f, 100f / 255f, 100f / 100f)), 2);
 
-        public StatusEffectIconConfig()
+        public StatusEffectIconConfig(LabelConfig durationLabelConfig = null, LabelConfig stacksLabelConfig = null)
         {
-
+            DurationLabelConfig = durationLabelConfig ?? StatusEffectsListsDefaults.DefaultDurationLabelConfig();
+            StacksLabelConfig = stacksLabelConfig ?? StatusEffectsListsDefaults.DefaultStacksLabelConfig();
         }
     }
 
@@ -250,6 +250,23 @@ namespace DelvUI.Interface.StatusEffects
         {
             Color = color;
             Thickness = thickness;
+        }
+    }
+
+    internal class StatusEffectsListsDefaults
+    {
+        internal static LabelConfig DefaultDurationLabelConfig()
+        {
+            return new LabelConfig(Vector2.Zero, "", LabelTextAnchor.Center);
+        }
+
+        internal static LabelConfig DefaultStacksLabelConfig()
+        {
+            var config = new LabelConfig(new Vector2(16, -11), "", LabelTextAnchor.Center);
+            config.Color = new(Vector4.UnitW);
+            config.OutlineColor = new(Vector4.One);
+
+            return config;
         }
     }
 }

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -266,7 +266,7 @@ namespace DelvUI.Interface.StatusEffects
 
             // imgui clips the left and right borders inside windows for some reason
             // we make the window bigger so the actual drawable size is the expected one
-            var margin = new Vector2(4, 0);
+            var margin = new Vector2(14, 10);
             var windowPos = minPos - margin;
             var windowSize = maxPos - minPos;
             ImGui.SetNextWindowPos(windowPos, ImGuiCond.Always);

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -2,6 +2,7 @@
 using Dalamud.Game.ClientState.Structs;
 using Dalamud.Plugin;
 using DelvUI.Helpers;
+using DelvUI.Interface.GeneralElements;
 using ImGuiNET;
 using Lumina.Excel.GeneratedSheets;
 using System;
@@ -20,10 +21,15 @@ namespace DelvUI.Interface.StatusEffects
         private GrowthDirections _lastGrowthDirections;
         private bool _showingTooltip = false;
 
+        private LabelHud _durationLabel;
+        private LabelHud _stacksLabel;
+
         public Actor Actor { get; set; } = null;
 
-        public StatusEffectsListHud(string ID, StatusEffectsListConfig config, string displayName) : base(ID, config, displayName)
+        public StatusEffectsListHud(string id, StatusEffectsListConfig config, string displayName) : base(id, config, displayName)
         {
+            _durationLabel = new LabelHud(id + "_duration", config.IconConfig.DurationLabelConfig);
+            _stacksLabel = new LabelHud(id + "_stacks", config.IconConfig.StacksLabelConfig);
         }
 
         protected override (List<Vector2>, List<Vector2>) ChildrenPositionsAndSizes()
@@ -238,7 +244,7 @@ namespace DelvUI.Interface.StatusEffects
                 );
 
                 // draw
-                StatusEffectIconDrawHelper.DrawStatusEffectIcon(drawList, iconPos, statusEffectData, Config.IconConfig);
+                StatusEffectIconDrawHelper.DrawStatusEffectIcon(drawList, iconPos, statusEffectData, Config.IconConfig, _durationLabel, _stacksLabel);
 
                 // tooltip
                 if (Config.ShowTooltips && ImGui.IsMouseHoveringRect(iconPos, iconPos + Config.IconConfig.Size))


### PR DESCRIPTION
Example of what's possible with this: 
![image](https://user-images.githubusercontent.com/6404136/133722807-491dbd70-7a27-4031-8325-f3f78063e06f.png)
