### PR TITLE
Hide HUD changes, i hope they work.

### DIFF
--- a/DelvUI/Interface/GeneralElements/HideHudConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HideHudConfig.cs
@@ -21,19 +21,23 @@ namespace DelvUI.Interface.GeneralElements
         public bool HideOnlyJobPackHudOutsideOfCombat = false;
 
         [Checkbox("Hide Default Job Gauges", isMonitored = true)]
-        [Order(15)]
+        [CollapseControl(15, 0)]
         public bool HideDefaultJobGauges = false;
+
+        [Checkbox("I Dont Care About The Sound", isMonitored = true)]
+        [CollapseWith(0, 0)]
+        public bool IDontCareAboutTheSounds = false;
 
         [Checkbox("Hide Default Castbar", isMonitored = true)]
         [Order(20)]
         public bool HideDefaultCastbar = false;
 
         [Checkbox("Enable Combat Hotbars", isMonitored = true)]
-        [CollapseControl(25, 0)]
+        [CollapseControl(25, 1)]
         public bool EnableCombatActionBars = false;
 
         [DynamicList("Hotbars Shown Only In Combat", "Hotbar 1", "Hotbar 2", "Hotbar 3", "Hotbar 4", "Hotbar 5", "Hotbar 6", "Hotbar 7", "Hotbar 8", "Hotbar 9", "Hotbar 10", isMonitored = true)]
-        [CollapseWith(0, 0)]
+        [CollapseWith(0, 1)]
         public List<string> CombatActionBars = new();
 
         public new static HideHudConfig DefaultConfig() { return new HideHudConfig(); }

--- a/DelvUI/Interface/GeneralElements/HideHudConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HideHudConfig.cs
@@ -24,9 +24,9 @@ namespace DelvUI.Interface.GeneralElements
         [CollapseControl(15, 0)]
         public bool HideDefaultJobGauges = false;
 
-        [Checkbox("I Dont Care About The Sound", isMonitored = true)]
+        [Checkbox("Disable Job Gauge Sounds", isMonitored = true)]
         [CollapseWith(0, 0)]
-        public bool IDontCareAboutTheSounds = false;
+        public bool DisableJobGaugeSounds = false;
 
         [Checkbox("Hide Default Castbar", isMonitored = true)]
         [Order(20)]

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -19,7 +19,16 @@ namespace DelvUI.Interface
         public unsafe AtkUnitBase* addonPtr;
         public string name;
 
-        public unsafe void DefaultVisibilityToggle(bool isHidden)
+        public unsafe void VisibilityToggle(bool isHidden)
+        {
+            addonPtr->IsVisible = !isHidden;
+            if (!isHidden)
+            {
+                addonPtr->UldManager.UpdateDrawNodeList(); // enable
+            }
+        }
+
+        public unsafe void NodeListVisibilityToggle(bool isHidden)
         {
             if (isHidden)
             {
@@ -27,9 +36,11 @@ namespace DelvUI.Interface
             }
             else
             {
+                addonPtr->IsVisible = true;
                 addonPtr->UldManager.UpdateDrawNodeList(); // enable
             }
         }
+
     }
 
     public class HudHelper
@@ -37,7 +48,6 @@ namespace DelvUI.Interface
         private HideHudConfig Config => ConfigurationManager.GetInstance().GetConfigObject<HideHudConfig>();
 
         private bool _previousCombatState = true;
-        public bool UserInterfaceWasHidden = false;
 
         public HudHelper()
         {
@@ -49,9 +59,54 @@ namespace DelvUI.Interface
             Config.onValueChanged -= ConfigValueChanged;
         }
 
+        public unsafe void Configure(bool isInitial = false, bool isEvent = false)
+        {
+            ConfigureCombatActionBars(isInitial || isEvent);
+
+            if (isInitial)
+            {
+                ConfigureDefaultCastBar();
+                ConfigureDefaultJobGauge();
+            }
+
+            if (isEvent && !Config.IDontCareAboutTheSounds)
+            {
+                ConfigureDefaultJobGauge();
+            }
+
+        }
+
+        public bool IsElementHidden(HudElement element)
+        {
+            if (!ConfigurationManager.GetInstance().LockHUD)
+            {
+                return ConfigurationManager.GetInstance().LockHUD;
+            }
+
+            bool isHidden = Config.HideOutsideOfCombat && !IsInCombat();
+            if (!isHidden && element is JobHud)
+            {
+                return Config.HideOnlyJobPackHudOutsideOfCombat && !IsInCombat();
+            }
+
+            if (element.GetType() == typeof(PlayerCastbarHud))
+            {
+                return false;
+            }
+
+            if (element.GetConfig().GetType() == typeof(PlayerUnitFrameConfig))
+            {
+                PlayerCharacter player = Plugin.ClientState.LocalPlayer;
+                Debug.Assert(player != null, "HudHelper.LocalPlayer is NULL.");
+                isHidden = isHidden && player.CurrentHp == player.MaxHp;
+            }
+
+            return isHidden;
+        }
+
         #region Event Handlers
 
-        public void ConfigValueChanged(object sender, OnChangeBaseArgs e)
+        private void ConfigValueChanged(object sender, OnChangeBaseArgs e)
         {
             if (e.PropertyName == "HideDefaultCastbar")
             {
@@ -60,6 +115,21 @@ namespace DelvUI.Interface
             else if (e.PropertyName == "HideDefaultJobGauges")
             {
                 ConfigureDefaultJobGauge();
+            }
+            else if (e.PropertyName == "IDontCareAboutTheSounds" && e is OnChangeEventArgs<bool> soundEvent)
+            {
+                PluginLog.Log(e.PropertyName);
+                ToggleDefaultComponent(delegate (GUIAddon addon)
+                {
+                    if (addon.name.StartsWith("JobHud"))
+                    {
+                        addon.NodeListVisibilityToggle(Config.IDontCareAboutTheSounds);
+                        if (!Config.IDontCareAboutTheSounds)
+                        {
+                            addon.VisibilityToggle(Config.HideDefaultJobGauges);
+                        }
+                    }
+                });
             }
             else if (e.PropertyName == "EnableCombatActionBars" && e is OnChangeEventArgs<bool> boolEvent)
             {
@@ -81,9 +151,8 @@ namespace DelvUI.Interface
 
         #endregion
 
-
         #region Action Bars
-        public void ConfigureCombatActionBars()
+        private void ConfigureCombatActionBars(bool forceHide = false)
         {
             if (!Config.EnableCombatActionBars)
             {
@@ -91,7 +160,7 @@ namespace DelvUI.Interface
             }
 
             var currentCombatState = IsInCombat();
-            if (_previousCombatState != currentCombatState && Config.CombatActionBars.Count > 0 || UserInterfaceWasHidden)
+            if (_previousCombatState != currentCombatState && Config.CombatActionBars.Count > 0 || forceHide)
             {
                 Config.CombatActionBars.ForEach(name => ToggleActionbar(name, !currentCombatState));
                 _previousCombatState = currentCombatState;
@@ -99,46 +168,6 @@ namespace DelvUI.Interface
         }
 
         #endregion
-
-        public bool IsElementHidden(HudElement element)
-        {
-            if (!ConfigurationManager.GetInstance().LockHUD)
-            {
-                return ConfigurationManager.GetInstance().LockHUD;
-            }
-
-            bool isHidden = Config.HideOutsideOfCombat && !IsInCombat();
-
-            if ( !isHidden && element is JobHud _jobHud)
-            {
-                return Config.HideOnlyJobPackHudOutsideOfCombat && !IsInCombat();
-            }
-
-            if (element != null)
-            {
-                if (element.GetType() == typeof(PlayerCastbarHud))
-                {
-                    return false;
-                }
-
-                if (element.GetConfig().GetType() == typeof(PlayerUnitFrameConfig))
-                {
-                    PlayerCharacter player = Plugin.ClientState.LocalPlayer;
-                    Debug.Assert(player != null, "HudHelper.LocalPlayer is NULL.");
-                    isHidden = isHidden && player.CurrentHp == player.MaxHp;
-                }
-            }
-
-            return isHidden;
-        }
-
-        // executed on login and on job swap
-        public void ApplyCurrentConfig()
-        {
-            ConfigureDefaultCastBar();
-            ConfigureDefaultJobGauge();
-            ConfigureCombatActionBars();
-        }
 
         private unsafe void ToggleActionbar(string targetName, bool isHidden)
         {
@@ -167,25 +196,24 @@ namespace DelvUI.Interface
             {
                 if (addon.name == "_CastBar")
                 {
-                    addon.DefaultVisibilityToggle(Config.HideDefaultCastbar);
+                    addon.NodeListVisibilityToggle(Config.HideDefaultCastbar);
                 }
             });
         }
 
-        public unsafe void ConfigureDefaultJobGauge()
+        private unsafe void ConfigureDefaultJobGauge()
         {
             ToggleDefaultComponent(delegate (GUIAddon addon)
             {
                 if (addon.name.StartsWith("JobHud"))
                 {
-                    if (Config.HideDefaultJobGauges)
+                    bool isHidden = Config.HideDefaultJobGauges;
+
+                    addon.NodeListVisibilityToggle(isHidden && Config.IDontCareAboutTheSounds);
+                    if (!Config.IDontCareAboutTheSounds)
                     {
-                        addon.addonPtr->IsVisible = false;
-                    }
-                    else
-                    {
-                        addon.addonPtr->IsVisible = true;
-                        addon.addonPtr->UldManager.UpdateDrawNodeList();
+                        addon.VisibilityToggle(isHidden);
+
                     }
                 }
             });

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -69,7 +69,7 @@ namespace DelvUI.Interface
                 ConfigureDefaultJobGauge();
             }
 
-            if (isEvent && !Config.IDontCareAboutTheSounds)
+            if (isEvent && !Config.DisableJobGaugeSounds)
             {
                 ConfigureDefaultJobGauge();
             }
@@ -123,8 +123,8 @@ namespace DelvUI.Interface
                 {
                     if (addon.name.StartsWith("JobHud"))
                     {
-                        addon.NodeListVisibilityToggle(Config.IDontCareAboutTheSounds);
-                        if (!Config.IDontCareAboutTheSounds)
+                        addon.NodeListVisibilityToggle(Config.DisableJobGaugeSounds);
+                        if (!Config.DisableJobGaugeSounds)
                         {
                             addon.VisibilityToggle(Config.HideDefaultJobGauges);
                         }
@@ -209,8 +209,8 @@ namespace DelvUI.Interface
                 {
                     bool isHidden = Config.HideDefaultJobGauges;
 
-                    addon.NodeListVisibilityToggle(isHidden && Config.IDontCareAboutTheSounds);
-                    if (!Config.IDontCareAboutTheSounds)
+                    addon.NodeListVisibilityToggle(isHidden && Config.DisableJobGaugeSounds);
+                    if (!Config.DisableJobGaugeSounds)
                     {
                         addon.VisibilityToggle(isHidden);
 

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -212,12 +212,6 @@ namespace DelvUI
                          || Condition[ConditionFlag.BetweenAreas]
                          || Condition[ConditionFlag.BetweenAreas51];
 
-            if (hudState)
-            {
-                _hudManager.Helper.ApplyCurrentConfig();
-                _hudManager.Helper.UserInterfaceWasHidden = true;
-            }
-
             UiBuilder.OverrideGameCursor = false;
 
             ConfigurationManager.GetInstance().Draw();


### PR DESCRIPTION
- Refactor/clean up of HudHelper
- HudHelper is not private property of HudManager
- addressed some cases where in-game JobHud was shown.
- added "I Dont Care About The Sounds" option in settings under "Hide Default Job Gauges"; in that case a lot less traversal of the addonList structs is done.