### PR TITLE
Job Colors for Labels and Primary Resource bar

### DIFF
--- a/DelvUI/Interface/GeneralElements/CastbarHud.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarHud.cs
@@ -103,12 +103,12 @@ namespace DelvUI.Interface.GeneralElements
 
             // cast name
             Config.CastNameConfig.SetText(Config.Preview ? "Name" : _lastUsedCast.ActionText);
-            _castNameLabel.Draw(origin + Config.Position + new Vector2(iconSize.X, 0), Config.Size);
+            _castNameLabel.Draw(origin + Config.Position + new Vector2(iconSize.X, 0), Config.Size, Actor);
 
             // cast time
             var text = Config.Preview ? "Time" : Math.Round(totalCastTime - totalCastTime * castScale, 1).ToString(CultureInfo.InvariantCulture);
             Config.CastTimeConfig.SetText(text);
-            _castTimeLabel.Draw(origin + Config.Position, Config.Size);
+            _castTimeLabel.Draw(origin + Config.Position, Config.Size, Actor);
         }
 
         public virtual void DrawExtras(Vector2 origin, float totalCastTime)

--- a/DelvUI/Interface/GeneralElements/LabelConfig.cs
+++ b/DelvUI/Interface/GeneralElements/LabelConfig.cs
@@ -52,6 +52,10 @@ namespace DelvUI.Interface.GeneralElements
         [CollapseControl(40, 0)]
         public bool ShowOutline = true;
 
+        [Checkbox("Use Job Color")]
+        [Order(45)]
+        public bool UseJobColor = false;
+
         [ColorEdit4("Color ##Outline")]
         [CollapseWith(0, 0)]
         public PluginConfigColor OutlineColor = new PluginConfigColor(Vector4.UnitW);

--- a/DelvUI/Interface/GeneralElements/LabelHud.cs
+++ b/DelvUI/Interface/GeneralElements/LabelHud.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game.ClientState.Actors.Types;
+using DelvUI.Config;
 using DelvUI.Helpers;
 using ImGuiNET;
 using System.Numerics;
@@ -29,23 +30,38 @@ namespace DelvUI.Interface.GeneralElements
             var text = actor != null ? TextTags.GenerateFormattedTextFromTags(actor, Config.GetText()) : Config.GetText();
             var size = parentSize ?? Vector2.Zero;
 
-            DrawLabel(text, origin, size);
+            DrawLabel(text, origin, size, actor);
         }
 
-        private void DrawLabel(string text, Vector2 parentOrigin, Vector2 parentSize)
+        private void DrawLabel(string text, Vector2 parentOrigin, Vector2 parentSize, Actor actor = null)
         {
             var textSize = ImGui.CalcTextSize(text);
             var offset = OffsetForFrameAnchor(parentSize) + OffsetForTextAnchor(textSize);
             var drawList = ImGui.GetWindowDrawList();
+            var color = Color(actor);
 
             if (Config.ShowOutline)
             {
-                DrawHelper.DrawOutlinedText(text, parentOrigin + Config.Position + offset, Config.Color.Base, Config.OutlineColor.Base, drawList);
+                DrawHelper.DrawOutlinedText(text, parentOrigin + Config.Position + offset, color.Base, Config.OutlineColor.Base, drawList);
             }
             else
             {
-                drawList.AddText(parentOrigin + Config.Position + offset, Config.Color.Base, text);
+                drawList.AddText(parentOrigin + Config.Position + offset, color.Base, text);
             }
+        }
+
+        public virtual PluginConfigColor Color(Actor actor = null)
+        {
+            if (!Config.UseJobColor)
+            {
+                return Config.Color;
+            }
+            else if (Config.UseJobColor && actor is not Chara)
+            {
+                return GlobalColors.Instance.NPCFriendlyColor;
+            }
+
+            return Utils.ColorForActor((Chara)actor);
         }
 
         private Vector2 OffsetForTextAnchor(Vector2 textSize)

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
@@ -18,11 +18,15 @@ namespace DelvUI.Interface.GeneralElements
         [Order(20)]
         public PluginConfigColor Color = new PluginConfigColor(new(0 / 255f, 162f / 255f, 252f / 255f, 100f / 100f));
 
-        [NestedConfig("Label", 25)]
+        [Checkbox("Use Job Color")]
+        [Order(25)]
+        public bool UseJobColor = false;
+
+        [NestedConfig("Label", 30)]
         public LabelConfig ValueLabelConfig;
 
         [Checkbox("Threshold Marker")]
-        [CollapseControl(30, 0)]
+        [CollapseControl(35, 0)]
         public bool ShowThresholdMarker = false;
 
         [DragInt("Value", min = 1, max = 10000)]

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
@@ -44,7 +44,22 @@ namespace DelvUI.Interface.GeneralElements
             var drawList = ImGui.GetWindowDrawList();
             drawList.AddRectFilled(startPos, startPos + Config.Size, 0x88000000);
 
-            drawList.AddRectFilledMultiColor(
+            if (Config.UseJobColor)
+            {
+                var color = GlobalColors.Instance.SafeColorForJobId(chara.ClassJob.Id);
+
+                drawList.AddRectFilledMultiColor(
+                startPos,
+                startPos + new Vector2(Math.Max(1, Config.Size.X * scale), Config.Size.Y),
+                color.TopGradient,
+                color.TopGradient,
+                color.BottomGradient,
+                color.BottomGradient
+            );
+            }
+            else
+            {
+                drawList.AddRectFilledMultiColor(
                 startPos,
                 startPos + new Vector2(Math.Max(1, Config.Size.X * scale), Config.Size.Y),
                 Config.Color.TopGradient,
@@ -52,6 +67,7 @@ namespace DelvUI.Interface.GeneralElements
                 Config.Color.BottomGradient,
                 Config.Color.BottomGradient
             );
+            }
 
             drawList.AddRect(startPos, startPos + Config.Size, 0xFF000000);
 
@@ -62,7 +78,7 @@ namespace DelvUI.Interface.GeneralElements
                 var size = new Vector2(2, Config.Size.Y);
                 drawList.AddRect(position, position + size, 0xFF000000);
             }
-            
+
         }
 
         private void GetResources(ref int current, ref int max, Chara actor)

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game.ClientState.Actors.Types;
+using DelvUI.Config;
 using DelvUI.Helpers;
 using ImGuiNET;
 using System;
@@ -38,36 +39,14 @@ namespace DelvUI.Interface.GeneralElements
             GetResources(ref current, ref max, chara);
 
             var scale = (float)current / max;
-            var startPos = origin + Config.Position - Config.Size / 2f;
+            var startPos = origin + Config.Position - Config.Size / 2f;            
 
             // bar
             var drawList = ImGui.GetWindowDrawList();
             drawList.AddRectFilled(startPos, startPos + Config.Size, 0x88000000);
-
-            if (Config.UseJobColor)
-            {
-                var color = GlobalColors.Instance.SafeColorForJobId(chara.ClassJob.Id);
-
-                drawList.AddRectFilledMultiColor(
-                startPos,
-                startPos + new Vector2(Math.Max(1, Config.Size.X * scale), Config.Size.Y),
-                color.TopGradient,
-                color.TopGradient,
-                color.BottomGradient,
-                color.BottomGradient
-            );
-            }
-            else
-            {
-                drawList.AddRectFilledMultiColor(
-                startPos,
-                startPos + new Vector2(Math.Max(1, Config.Size.X * scale), Config.Size.Y),
-                Config.Color.TopGradient,
-                Config.Color.TopGradient,
-                Config.Color.BottomGradient,
-                Config.Color.BottomGradient
-            );
-            }
+            
+            var color = Color(Actor);
+            DrawHelper.DrawGradientFilledRect(startPos, new Vector2(Config.Size.X * scale, Config.Size.Y), color, drawList);
 
             drawList.AddRect(startPos, startPos + Config.Size, 0xFF000000);
 
@@ -109,6 +88,20 @@ namespace DelvUI.Interface.GeneralElements
 
                     break;
             }
+        }
+
+        public virtual PluginConfigColor Color(Actor actor = null)
+        {
+            if (!Config.UseJobColor)
+            {
+                return Config.Color;
+            }
+            else if (Config.UseJobColor && actor is not Chara)
+            {
+                return GlobalColors.Instance.NPCFriendlyColor;
+            }
+
+            return Utils.ColorForActor((Chara)actor);
         }
     }
 }

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -170,7 +170,7 @@ namespace DelvUI.Interface.GeneralElements
 
         private void DrawFriendlyNPC(ImDrawListPtr drawList, Vector2 startPos, Vector2 endPos)
         {
-            var color = GlobalColors.Instance.NPCFriendlyColor;
+            var color = Config.UseCustomColor ? Config.CustomColor : GlobalColors.Instance.NPCFriendlyColor;            
 
             drawList.AddRectFilled(startPos, endPos, GlobalColors.Instance.EmptyUnitFrameColor.Base);
 

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -169,19 +169,12 @@ namespace DelvUI.Interface.GeneralElements
         }
 
         private void DrawFriendlyNPC(ImDrawListPtr drawList, Vector2 startPos, Vector2 endPos)
-        {
+        {            
             var color = Config.UseCustomColor ? Config.CustomColor : GlobalColors.Instance.NPCFriendlyColor;            
 
             drawList.AddRectFilled(startPos, endPos, GlobalColors.Instance.EmptyUnitFrameColor.Base);
 
-            drawList.AddRectFilledMultiColor(
-                startPos,
-                endPos,
-                color.TopGradient,
-                color.TopGradient,
-                color.BottomGradient,
-                color.BottomGradient
-            );
+            DrawHelper.DrawGradientFilledRect(startPos, new Vector2(Config.Size.X, Config.Size.Y), color, drawList);
 
             drawList.AddRect(startPos, endPos, 0xFF000000);
         }


### PR DESCRIPTION
- Adds a Job Color option for labels and the primary resourcebar. Disabled by default.
- Uses NPCFriendly/Hostile/Neutral coloring for NPC targets.
- The FriendlyNPC unitframe now updates its color when UseCustomColor is checked.
