### PR TITLE
work on #444 [Bug][Beta2] Hide default job gauges

### DIFF
--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -209,16 +209,9 @@ namespace DelvUI.Interface
         {
             if (!ShouldBeVisible())
             {
+                _helper = null;
                 return;
             }
-
-            bool inEvent = Plugin.Condition[ConditionFlag.OccupiedInEvent]
-                || Plugin.Condition[ConditionFlag.OccupiedInQuestEvent]
-                || Plugin.Condition[ConditionFlag.UsingHousingFunctions];
-            bool updateByEvent = _prevInEvent != inEvent;
-
-            _helper.Configure(isEvent: updateByEvent);
-            _prevInEvent = inEvent;
 
             ImGuiHelpers.ForceNextWindowMainViewport();
             ImGui.SetNextWindowPos(Vector2.Zero);
@@ -238,6 +231,15 @@ namespace DelvUI.Interface
             {
                 return;
             }
+
+            _helper ??= new HudHelper();
+
+            bool inEvent = Plugin.Condition[ConditionFlag.OccupiedInEvent]
+                || Plugin.Condition[ConditionFlag.OccupiedInQuestEvent]
+                || Plugin.Condition[ConditionFlag.UsingHousingFunctions];
+            bool updateByEvent = _prevInEvent != inEvent;
+
+            _helper.Configure(updateByEvent);
 
             UpdateJob();
             AssignActors();
@@ -285,17 +287,8 @@ namespace DelvUI.Interface
         {
             if (!ConfigurationManager.GetInstance().ShowHUD || Plugin.ClientState.LocalPlayer == null)
             {
-                _helper = null;
                 return false;
             }
-
-            if (_helper == null)
-            {
-                _helper = new HudHelper();
-                _helper.Configure(true, true);
-            }
-
-
 
             var parameterWidget = (AtkUnitBase*)Plugin.GameGui.GetUiObjectByName("_ParameterWidget", 1);
             var fadeMiddleWidget = (AtkUnitBase*)Plugin.GameGui.GetUiObjectByName("FadeMiddle", 1);
@@ -327,13 +320,10 @@ namespace DelvUI.Interface
                 config = (JobConfig)ConfigurationManager.GetInstance().GetConfigObjectForType(types.ConfigType);
                 _jobHud = (JobHud)Activator.CreateInstance(types.HudType, types.HudType.FullName, config, types.DisplayName);
                 _jobHud.SelectEvent += OnDraggableElementSelected;
-
             }
 
             if (config != null && _primaryResourceHud != null)
             {
-                _helper.Configure(true, true);
-
                 _primaryResourceHud.ResourceType = config.UseDefaultPrimaryResourceBar ? config.PrimaryResourceType : PrimaryResourceTypes.None;
             }
         }

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -244,6 +244,8 @@ namespace DelvUI
                 return;
             }
 
+            HudHelper.RestoreToGameDefaults();
+
             ConfigurationManager.GetInstance().DrawConfigWindow = false;
 
             CommandManager.RemoveHandler("/delvui");


### PR DESCRIPTION
That should "fix" most of the issue problems.

However currently i haven't found a way to preserve audio, if that even works, and make it not show up at teleporting and other actions. if you disable job gauge sounds it should disappear for good.

- add: at Plugin.Dispose we restore the game defaults - showing castbar, jobgauge, actionbars. due to this some of the HudHelper method were migrated to static.
- a bit of clean up too