### PR TITLE
Status effects blacklist

### DIFF
--- a/DelvUI/Config/ImportExportConfig.cs
+++ b/DelvUI/Config/ImportExportConfig.cs
@@ -20,7 +20,7 @@ namespace DelvUI.Interface
         public new static ImportExportConfig DefaultConfig() { return new ImportExportConfig(); }
 
         [ManualDraw]
-        public void DrawFullImportExport()
+        public bool DrawFullImportExport()
         {
             uint maxLength = 100000;
             ImGui.BeginChild("importpane", new Vector2(0, ImGui.GetWindowHeight() / 6), false, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
@@ -80,6 +80,8 @@ namespace DelvUI.Interface
             }
 
             ImGui.EndChild();
+
+            return false;
         }
     }
 }

--- a/DelvUI/Config/PluginConfigObject.cs
+++ b/DelvUI/Config/PluginConfigObject.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 
 namespace DelvUI.Config
 {
-    [Serializable]
     public abstract class PluginConfigObject : IOnChangeEventArgs
     {
         [Checkbox("Enabled", separator = true)]
@@ -38,7 +37,7 @@ namespace DelvUI.Config
 
         protected bool ColorEdit4(string label, ref PluginConfigColor color)
         {
-            var vector = color.Vector; 
+            var vector = color.Vector;
 
             if (ImGui.ColorEdit4(label, ref vector))
             {
@@ -70,7 +69,6 @@ namespace DelvUI.Config
         #endregion
     }
 
-    [Serializable]
     public abstract class MovablePluginConfigObject : PluginConfigObject
     {
         [DragInt2("Position", min = -4000, max = 4000)]
@@ -78,7 +76,6 @@ namespace DelvUI.Config
         public Vector2 Position = Vector2.Zero;
     }
 
-    [Serializable]
     public class PluginConfigColor
     {
         [JsonIgnore] private float[] _colorMapRatios = { -.8f, -.3f, .1f };

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -877,7 +877,8 @@ namespace DelvUI.Config.Tree
                 }
 
                 // TODO allow the manual draw methods to take parameters
-                method.Invoke(ConfigObject, null);
+                bool result = (bool)method.Invoke(ConfigObject, null);
+                changed |= result;
             }
 
             // if the config object is not marked with [Portable(false)], or is marked with [Portable(true)],

--- a/DelvUI/Helpers/TooltipsHelper.cs
+++ b/DelvUI/Helpers/TooltipsHelper.cs
@@ -189,7 +189,6 @@ namespace DelvUI.Helpers
         }
     }
 
-    [Serializable]
     [Section("Misc")]
     [SubSection("Tooltips", 0)]
     public class TooltipsConfig : PluginConfigObject

--- a/DelvUI/Interface/GeneralElements/CastbarConfig.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarConfig.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    [Serializable]
     [Section("Castbars")]
     [SubSection("Player", 0)]
     public class PlayerCastbarConfig : CastbarConfig
@@ -44,7 +43,6 @@ namespace DelvUI.Interface.GeneralElements
         }
     }
 
-    [Serializable]
     [Section("Castbars")]
     [SubSection("Target", 0)]
     public class TargetCastbarConfig : CastbarConfig
@@ -90,7 +88,6 @@ namespace DelvUI.Interface.GeneralElements
         }
     }
 
-    [Serializable]
     [Section("Castbars")]
     [SubSection("Target of Target", 0)]
     public class TargetOfTargetCastbarConfig : TargetCastbarConfig
@@ -115,7 +112,6 @@ namespace DelvUI.Interface.GeneralElements
         }
     }
 
-    [Serializable]
     [Section("Castbars")]
     [SubSection("Focus Target", 0)]
     public class FocusTargetCastbarConfig : TargetCastbarConfig
@@ -140,17 +136,16 @@ namespace DelvUI.Interface.GeneralElements
         }
     }
 
-    [Serializable]
     public abstract class CastbarConfig : MovablePluginConfigObject
     {
         [DragInt2("Size", min = 1, max = 4000)]
         [Order(15)]
         public Vector2 Size;
-        
+
         [Checkbox("Preview")]
         [Order(20)]
         public bool Preview = false;
-        
+
         [Checkbox("Icon", separator = true)]
         [Order(25)]
         public bool ShowIcon = true;
@@ -158,16 +153,16 @@ namespace DelvUI.Interface.GeneralElements
         [ColorEdit4("Color ##Castbar")]
         [Order(30)]
         public PluginConfigColor Color = new PluginConfigColor(new(0f / 255f, 162f / 255f, 252f / 255f, 100f / 100f));
-        
+
         //CHARA TYPE SPECIFIC CONFIGS SPAWN HERE
-        
+
         [NestedConfig("Cast Name", 45)]
         public LabelConfig CastNameConfig;
 
         [NestedConfig("Cast Time", 50)]
         public LabelConfig CastTimeConfig;
 
-        
+
 
         public CastbarConfig(Vector2 position, Vector2 size, LabelConfig castNameConfig, LabelConfig castTimeConfig)
         {

--- a/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    [Serializable]
     [Section("Misc")]
     [SubSection("GCD Indicator", 0)]
     public class GCDIndicatorConfig : MovablePluginConfigObject

--- a/DelvUI/Interface/GeneralElements/GlobalColors.cs
+++ b/DelvUI/Interface/GeneralElements/GlobalColors.cs
@@ -113,8 +113,6 @@ namespace DelvUI.Interface.GeneralElements
         public PluginConfigColor NPCNeutralColor => _miscColorConfig.NPCNeutralColor;
     }
 
-
-    [Serializable]
     [Disableable(false)]
     [Section("Colors")]
     [SubSection("Tanks", 0)]
@@ -147,7 +145,6 @@ namespace DelvUI.Interface.GeneralElements
         public PluginConfigColor MRDColor = new PluginConfigColor(new(207f / 255f, 38f / 255f, 33f / 255f, 100f / 100f));
     }
 
-    [Serializable]
     [Disableable(false)]
     [Section("Colors")]
     [SubSection("Healers", 0)]
@@ -172,7 +169,6 @@ namespace DelvUI.Interface.GeneralElements
         public PluginConfigColor CNJColor = new PluginConfigColor(new(255f / 255f, 240f / 255f, 220f / 255f, 100f / 100f));
     }
 
-    [Serializable]
     [Disableable(false)]
     [Section("Colors")]
     [SubSection("Melee", 0)]
@@ -209,7 +205,6 @@ namespace DelvUI.Interface.GeneralElements
         public PluginConfigColor LNCColor = new PluginConfigColor(new(65f / 255f, 100f / 255f, 205f / 255f, 100f / 100f));
     }
 
-    [Serializable]
     [Disableable(false)]
     [Section("Colors")]
     [SubSection("Ranged", 0)]
@@ -234,7 +229,6 @@ namespace DelvUI.Interface.GeneralElements
         public PluginConfigColor ARCColor = new PluginConfigColor(new(145f / 255f, 186f / 255f, 94f / 255f, 100f / 100f));
     }
 
-    [Serializable]
     [Disableable(false)]
     [Section("Colors")]
     [SubSection("Caster", 0)]
@@ -267,7 +261,6 @@ namespace DelvUI.Interface.GeneralElements
         public PluginConfigColor ACNColor = new PluginConfigColor(new(45f / 255f, 155f / 255f, 120f / 255f, 100f / 100f));
     }
 
-    [Serializable]
     [Disableable(false)]
     [Section("Colors")]
     [SubSection("Misc", 0)]

--- a/DelvUI/Interface/GeneralElements/HideHudConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HideHudConfig.cs
@@ -7,7 +7,6 @@ using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    [Serializable]
     [Disableable(false)]
     [Section("Misc")]
     [SubSection("Hide Options", 0)]

--- a/DelvUI/Interface/GeneralElements/LabelConfig.cs
+++ b/DelvUI/Interface/GeneralElements/LabelConfig.cs
@@ -6,7 +6,6 @@ using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    [Serializable]
     [Portable(false)]
     public class EditableLabelConfig : LabelConfig
     {
@@ -30,7 +29,6 @@ namespace DelvUI.Interface.GeneralElements
         }
     }
 
-    [Serializable]
     [Portable(false)]
     public class LabelConfig : MovablePluginConfigObject
     {

--- a/DelvUI/Interface/GeneralElements/MPTickerConfig.cs
+++ b/DelvUI/Interface/GeneralElements/MPTickerConfig.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    [Serializable]
     [Section("Misc")]
     [SubSection("MP Ticker", 0)]
     public class MPTickerConfig : MovablePluginConfigObject

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    [Serializable]
     [Section("Misc")]
     [SubSection("Primary Resource Bar", 0)]
     public class PrimaryResourceConfig : MovablePluginConfigObject

--- a/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
@@ -5,7 +5,6 @@ using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    [Serializable]
     [Section("Unit Frames")]
     [SubSection("Player", 0)]
     public class PlayerUnitFrameConfig : UnitFrameConfig
@@ -30,7 +29,6 @@ namespace DelvUI.Interface.GeneralElements
         }
     }
 
-    [Serializable]
     [Section("Unit Frames")]
     [SubSection("Target", 0)]
     public class TargetUnitFrameConfig : UnitFrameConfig
@@ -52,7 +50,6 @@ namespace DelvUI.Interface.GeneralElements
         }
     }
 
-    [Serializable]
     [Section("Unit Frames")]
     [SubSection("Target of Target", 0)]
     public class TargetOfTargetUnitFrameConfig : UnitFrameConfig
@@ -77,7 +74,6 @@ namespace DelvUI.Interface.GeneralElements
         }
     }
 
-    [Serializable]
     [Section("Unit Frames")]
     [SubSection("Focus Target", 0)]
     public class FocusTargetUnitFrameConfig : UnitFrameConfig
@@ -102,13 +98,12 @@ namespace DelvUI.Interface.GeneralElements
         }
     }
 
-    [Serializable]
     public class UnitFrameConfig : MovablePluginConfigObject
     {
         [DragInt2("Size", min = 1, max = 4000)]
         [Order(15)]
         public Vector2 Size;
-        
+
         [Checkbox("Custom Frame Color", separator = true)]
         [CollapseControl(20, 0)]
         public bool UseCustomColor = false;
@@ -143,7 +138,7 @@ namespace DelvUI.Interface.GeneralElements
         [NestedConfig("Right Text", 45)]
         public EditableLabelConfig RightLabelConfig;
 
-        
+
         [NestedConfig("Shields", 50)]
         public ShieldConfig ShieldConfig = new ShieldConfig();
 
@@ -159,7 +154,6 @@ namespace DelvUI.Interface.GeneralElements
         }
     }
 
-    [Serializable]
     [Portable(false)]
     public class ShieldConfig : PluginConfigObject
     {
@@ -180,7 +174,6 @@ namespace DelvUI.Interface.GeneralElements
         public PluginConfigColor Color = new PluginConfigColor(new Vector4(198f / 255f, 210f / 255f, 255f / 255f, 70f / 100f));
     }
 
-    [Serializable]
     [Portable(false)]
     public class TankStanceIndicatorConfig : PluginConfigObject
     {

--- a/DelvUI/Interface/Jobs/AstrologianHud.cs
+++ b/DelvUI/Interface/Jobs/AstrologianHud.cs
@@ -510,7 +510,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Healer", 0)]
     [SubSection("Astrologian", 1)]

--- a/DelvUI/Interface/Jobs/BardHud.cs
+++ b/DelvUI/Interface/Jobs/BardHud.cs
@@ -336,7 +336,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Ranged", 0)]
     [SubSection("Bard", 1)]

--- a/DelvUI/Interface/Jobs/BlackMageHud.cs
+++ b/DelvUI/Interface/Jobs/BlackMageHud.cs
@@ -302,7 +302,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Caster", 0)]
     [SubSection("Black Mage", 1)]

--- a/DelvUI/Interface/Jobs/DancerHud.cs
+++ b/DelvUI/Interface/Jobs/DancerHud.cs
@@ -375,7 +375,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Ranged", 0)]
     [SubSection("Dancer", 1)]

--- a/DelvUI/Interface/Jobs/DarkKnightHud.cs
+++ b/DelvUI/Interface/Jobs/DarkKnightHud.cs
@@ -215,7 +215,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Tank", 0)]
     [SubSection("Dark Knight", 1)]

--- a/DelvUI/Interface/Jobs/DragoonHud.cs
+++ b/DelvUI/Interface/Jobs/DragoonHud.cs
@@ -201,7 +201,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Melee", 0)]
     [SubSection("Dragoon", 1)]

--- a/DelvUI/Interface/Jobs/GunbreakerHud.cs
+++ b/DelvUI/Interface/Jobs/GunbreakerHud.cs
@@ -95,7 +95,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Tank", 0)]
     [SubSection("Gunbreaker", 1)]

--- a/DelvUI/Interface/Jobs/JobConfig.cs
+++ b/DelvUI/Interface/Jobs/JobConfig.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 
 namespace DelvUI.Interface.Jobs
 {
-    [Serializable]
     public abstract class JobConfig : MovablePluginConfigObject
     {
         [JsonIgnore]

--- a/DelvUI/Interface/Jobs/MachinistHud.cs
+++ b/DelvUI/Interface/Jobs/MachinistHud.cs
@@ -185,7 +185,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Ranged", 0)]
     [SubSection("Machinist", 1)]

--- a/DelvUI/Interface/Jobs/MonkHud.cs
+++ b/DelvUI/Interface/Jobs/MonkHud.cs
@@ -386,7 +386,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Melee", 0)]
     [SubSection("Monk", 1)]

--- a/DelvUI/Interface/Jobs/NinjaHud.cs
+++ b/DelvUI/Interface/Jobs/NinjaHud.cs
@@ -333,7 +333,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Melee", 0)]
     [SubSection("Ninja", 1)]

--- a/DelvUI/Interface/Jobs/PaladinHud.cs
+++ b/DelvUI/Interface/Jobs/PaladinHud.cs
@@ -222,7 +222,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Tank", 0)]
     [SubSection("Paladin", 1)]

--- a/DelvUI/Interface/Jobs/RedMageHud.cs
+++ b/DelvUI/Interface/Jobs/RedMageHud.cs
@@ -281,8 +281,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Caster", 0)]
     [SubSection("Red Mage", 1)]

--- a/DelvUI/Interface/Jobs/SamuraiHud.cs
+++ b/DelvUI/Interface/Jobs/SamuraiHud.cs
@@ -226,7 +226,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Melee", 0)]
     [SubSection("Samurai", 1)]

--- a/DelvUI/Interface/Jobs/ScholarHud.cs
+++ b/DelvUI/Interface/Jobs/ScholarHud.cs
@@ -174,7 +174,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Healer", 0)]
     [SubSection("Scholar", 1)]

--- a/DelvUI/Interface/Jobs/SummonerHud.cs
+++ b/DelvUI/Interface/Jobs/SummonerHud.cs
@@ -339,7 +339,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Caster", 0)]
     [SubSection("Summoner", 1)]

--- a/DelvUI/Interface/Jobs/WarriorHud.cs
+++ b/DelvUI/Interface/Jobs/WarriorHud.cs
@@ -121,7 +121,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Tank", 0)]
     [SubSection("Warrior", 1)]

--- a/DelvUI/Interface/Jobs/WhiteMageHud.cs
+++ b/DelvUI/Interface/Jobs/WhiteMageHud.cs
@@ -163,7 +163,6 @@ namespace DelvUI.Interface.Jobs
         }
     }
 
-    [Serializable]
     [Section("Job Specific Bars")]
     [SubSection("Healer", 0)]
     [SubSection("White Mage", 1)]

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -268,11 +268,11 @@ namespace DelvUI.Interface.StatusEffects
     public class StatusEffectsBlacklistConfig : PluginConfigObject
     {
         public bool UseAsWhitelist = false;
-        public SortedList<uint, string> List = new SortedList<uint, string>();
+        public SortedList<string, uint> List = new SortedList<string, uint>();
 
-        public bool StatusEffectIDAllowed(uint id)
+        public bool StatusAllowed(Status status)
         {
-            var inList = List.ContainsKey((uint)id);
+            var inList = List.ContainsKey(status.Name);
             if ((inList && !UseAsWhitelist) || (!inList && UseAsWhitelist))
             {
                 return false;
@@ -283,9 +283,9 @@ namespace DelvUI.Interface.StatusEffects
 
         public bool AddNewEntry(Status status)
         {
-            if (status != null && !List.ContainsKey(status.RowId))
+            if (status != null && !List.ContainsKey(status.Name))
             {
-                List.Add(status.RowId, status.Name);
+                List.Add(status.Name, status.RowId);
                 _input = "";
 
                 return true;
@@ -392,8 +392,8 @@ namespace DelvUI.Interface.StatusEffects
 
                     for (int i = 0; i < List.Count; i++)
                     {
-                        var id = List.Keys[i];
-                        var name = List.Values[i];
+                        var id = List.Values[i];
+                        var name = List.Keys[i];
 
                         ImGui.PushID(i.ToString());
                         ImGui.TableNextRow(ImGuiTableRowFlags.None, iconSize.Y);

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -123,7 +123,7 @@ namespace DelvUI.Interface.StatusEffects
                 }
 
                 // blacklist
-                if (Config.BlacklistConfig.Enabled && !Config.BlacklistConfig.StatusEffectIDAllowed((uint)status.EffectId))
+                if (Config.BlacklistConfig.Enabled && !Config.BlacklistConfig.StatusAllowed(row))
                 {
                     continue;
                 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6404136/133946528-e1633d57-faa6-4668-b8eb-7d77d4ccf862.png)
Left is the player buffs with the black list (it has permanent effects disabled as well)
On the right is the target buffs without the black list

* Each status effect config has its own black list
* The same list can be inverted and used as a white list
* Implemented a shortcut to automatically add status effects to the black list

Note: Also removed all [Serialized] tags from classes since it doesn't do anything for JSON serialization.