### PR TITLE
Fix for hiding the notice when u unlock job gauges

### DIFF
--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -81,7 +81,7 @@ namespace DelvUI.Interface
                 {
                     addon.NodeListVisibilityToggle(Config.HideDefaultCastbar);
                 }
-                else if (addon.name.StartsWith("JobHud"))
+                else if (addon.name.StartsWith("JobHud") && !addon.name.StartsWith("JobHudNotice"))
                 {
                     bool isHidden = Config.HideDefaultJobGauges;
 


### PR DESCRIPTION
This would prevent JobHudNotice from being hidden when a player unlock his/her job gauges.