### PR TITLE
Adding a "tracked buffs" list

### DIFF
--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -107,7 +107,7 @@ namespace DelvUI.Config
                 typeof(PlayerDebuffsListConfig),
                 typeof(TargetBuffsListConfig),
                 typeof(TargetDebuffsListConfig),
-                typeof(TrackedBuffsListConfig),
+                typeof(CustomEffectsListConfig),
 
                 typeof(PaladinConfig),
                 typeof(WarriorConfig),

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -107,6 +107,7 @@ namespace DelvUI.Config
                 typeof(PlayerDebuffsListConfig),
                 typeof(TargetBuffsListConfig),
                 typeof(TargetDebuffsListConfig),
+                typeof(TrackedBuffsListConfig),
 
                 typeof(PaladinConfig),
                 typeof(WarriorConfig),

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -28,6 +28,7 @@ namespace DelvUI.Interface
         private List<IHudElementWithActor> _hudElementsUsingTargetOfTarget;
         private List<IHudElementWithActor> _hudElementsUsingFocusTarget;
 
+        private CustomEffectsListHud _customEffectsHud;
         private PrimaryResourceHud _primaryResourceHud;
         private JobHud _jobHud = null;
         private Dictionary<uint, JobHudTypes> _jobsMap;
@@ -183,10 +184,10 @@ namespace DelvUI.Interface
             _hudElements.Add(targetDebuffs);
             _hudElementsUsingTarget.Add(targetDebuffs);
 
-            var trackedBuffsConfig = ConfigurationManager.GetInstance().GetConfigObject<TrackedBuffsListConfig>();
-            var trackedBuffs = new StatusEffectsListHud("trackedBuffs", trackedBuffsConfig, "Tracked Buffs");
-            _hudElements.Add(trackedBuffs);
-            _hudElementsUsingPlayer.Add(trackedBuffs);
+            var custonEffectsConfig = ConfigurationManager.GetInstance().GetConfigObject<CustomEffectsListConfig>();
+            _customEffectsHud = new CustomEffectsListHud("customEffects", custonEffectsConfig, "Custom Effects");
+            _hudElements.Add(_customEffectsHud);
+            _hudElementsUsingPlayer.Add(_customEffectsHud);
         }
 
         private void CreateMiscElements()
@@ -354,6 +355,11 @@ namespace DelvUI.Interface
             foreach (var element in _hudElementsUsingTarget)
             {
                 element.Actor = target;
+
+                if (_customEffectsHud != null)
+                {
+                    _customEffectsHud.TargetActor = target;
+                }
             }
 
             // target of target

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -182,6 +182,11 @@ namespace DelvUI.Interface
             var targetDebuffs = new StatusEffectsListHud("targetDebuffs", targetDebuffsConfig, "Target Debuffs");
             _hudElements.Add(targetDebuffs);
             _hudElementsUsingTarget.Add(targetDebuffs);
+
+            var trackedBuffsConfig = ConfigurationManager.GetInstance().GetConfigObject<TrackedBuffsListConfig>();
+            var trackedBuffs = new StatusEffectsListHud("trackedBuffs", trackedBuffsConfig, "Tracked Buffs");
+            _hudElements.Add(trackedBuffs);
+            _hudElementsUsingPlayer.Add(trackedBuffs);
         }
 
         private void CreateMiscElements()
@@ -478,18 +483,18 @@ namespace DelvUI.Interface
         public bool ShowCenterLines = true;
         [Checkbox("Show Anchor Points")]
         [Order(20)]
-        
+
         public bool ShowAnchorPoints = true;
         [Checkbox("Grid Divisions", spacing = true)]
-        [CollapseControl(25,0)]
+        [CollapseControl(25, 0)]
         public bool ShowGrid = true;
 
         [DragInt("Divisions Distance", min = 50, max = 500)]
-        [CollapseWith(0,0)]
+        [CollapseWith(0, 0)]
         public int GridDivisionsDistance = 50;
 
         [DragInt("Subdivision Count", min = 1, max = 10)]
-        [CollapseWith(5,0)]
+        [CollapseWith(5, 0)]
         public int GridSubdivisionCount = 4;
 
 

--- a/DelvUI/Interface/StatusEffects/CustomEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/CustomEffectsListHud.cs
@@ -1,0 +1,32 @@
+﻿using Dalamud.Game.ClientState.Actors.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DelvUI.Interface.StatusEffects
+{
+    public class CustomEffectsListHud : StatusEffectsListHud
+    {
+        public CustomEffectsListHud(string id, StatusEffectsListConfig config, string displayName) : base(id, config, displayName)
+        {
+        }
+
+        public Actor TargetActor { get; set; } = null;
+
+        protected override List<StatusEffectData> StatusEffectsData()
+        {
+            var list = StatusEffectDataList(TargetActor);
+            list.AddRange(StatusEffectDataList(Actor));
+
+            // show mine first
+            if (Config.ShowMineFirst)
+            {
+                OrderByMineFirst(list);
+            }
+
+            return list;
+        }
+    }
+}

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -286,7 +286,7 @@ namespace DelvUI.Interface.StatusEffects
         {
             if (status != null && !List.ContainsKey(status.Name))
             {
-                List.Add(status.Name, status.RowId);
+                List.Add(status.Name + "[" + status.RowId.ToString() + "]", status.RowId);
                 _input = "";
 
                 return true;
@@ -395,6 +395,7 @@ namespace DelvUI.Interface.StatusEffects
                     {
                         var id = List.Values[i];
                         var name = List.Keys[i];
+                        var row = sheet.GetRow(id);
 
                         ImGui.PushID(i.ToString());
                         ImGui.TableNextRow(ImGuiTableRowFlags.None, iconSize.Y);
@@ -416,7 +417,6 @@ namespace DelvUI.Interface.StatusEffects
                         // icon
                         if (ImGui.TableSetColumnIndex(1))
                         {
-                            var row = sheet.GetRow(id);
                             if (row != null)
                             {
                                 DrawHelper.DrawIcon<Status>(row, ImGui.GetCursorPos(), iconSize, false);
@@ -432,7 +432,8 @@ namespace DelvUI.Interface.StatusEffects
                         // name
                         if (ImGui.TableSetColumnIndex(3))
                         {
-                            ImGui.Text(name);
+                            var displayName = row != null ? row.Name : name;
+                            ImGui.Text(displayName);
                         }
 
                         ImGui.PopID();
@@ -452,53 +453,118 @@ namespace DelvUI.Interface.StatusEffects
             return changed;
         }
     }
-}
 
-// SAVING THESE FOR LATER
-/*
- 
-        protected uint[] _raidWideBuffs =
+    [Section("Buffs and Debuffs")]
+    [SubSection("Tracked Buffs", 0)]
+    public class TrackedBuffsListConfig : StatusEffectsListConfig
+    {
+        public new static TrackedBuffsListConfig DefaultConfig()
         {
-            // See https://external-preview.redd.it/bKacLk4PKav7vdP1ilT66gAtB1t7BTJjxsMrImRHr1k.png?auto=webp&s=cbe6880c34b45e2db20c247c8ab9eef543538e96
-            // Left Eye
-            1184, 1454,
-            // Battle Litany
-            786, 1414,
-            // Brotherhood
-            1185, 2174,
-            // Battle Voice
-            141,
-            // Devilment
-            1825,
-            // Technical Finish
-            1822, 2050,
-            // Standard Finish
-            1821, 2024, 2105, 2113,
-            // Embolden
-            1239, 1297, 2282,
-            // Devotion
-            1213,
-            // ------ AST Card Buffs -------
-            // The Balance
-            829, 1338, 1882,
-            // The Bole
-            830, 1339, 1883,
-            // The Arrow
-            831, 1884,
-            // The Spear
-            832, 1885,
-            // The Ewer
-            833, 1340, 1886,
-            // The Spire
-            834, 1341, 1887,
-            // Lord of Crowns
-            1451, 1876,
-            // Lady of Crowns
-            1452, 1877,
-            // Divination
-            1878, 2034,
-            // Chain Stratagem
-            1221, 1406
-        };
+            var iconConfig = new StatusEffectIconConfig();
+            iconConfig.DispellableBorderConfig.Enabled = false;
+            iconConfig.Size = new Vector2(30, 30);
 
-*/
+            var pos = new Vector2(-HUDConstants.UnitFramesOffsetX - HUDConstants.DefaultBigUnitFrameSize.X / 2f, HUDConstants.BaseHUDOffsetY - 50);
+            var size = new Vector2(iconConfig.Size.X * 5 + 10, iconConfig.Size.Y * 3 + 10);
+
+            var config = new TrackedBuffsListConfig(pos, size, true, false, false, GrowthDirections.Centered | GrowthDirections.Up, iconConfig);
+            config.Enabled = false;
+
+            // pre-populated white list
+            config.BlacklistConfig.UseAsWhitelist = true;
+
+            ExcelSheet<Status> sheet = Plugin.DataManager.GetExcelSheet<Status>();
+            if (sheet != null)
+            {
+                // Left Eye
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1184));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1454));
+
+                // Battle Litany
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(786));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1414));
+
+                // Brotherhood
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1185));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(2174));
+
+                // Battle Voice
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(141));
+
+                // Devilment
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1825));
+
+                // Technical Finish
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1822));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(2050));
+
+                // Standard Finish
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1821));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(2024));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(2105));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(2113));
+
+                // Embolden
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1239));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1297));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(2282));
+
+                // Devotion
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1213));
+
+                // ------ AST Card Buffs -------
+                // The Balance
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(829));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1338));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1882));
+
+                // The Bole
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(830));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1339));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1883));
+
+                // The Arrow
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(831));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1884));
+
+                // The Spear
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(832));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1885));
+
+                // The Ewer
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(833));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1340));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1886));
+
+                // The Spire
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(834));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1341));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1887));
+
+                // Lord of Crowns
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1451));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1876));
+
+                // Lady of Crowns
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1452));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1877));
+
+                // Divination
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1878));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(2034));
+
+                // Chain Stratagem
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1221));
+                config.BlacklistConfig.AddNewEntry(sheet.GetRow(1406));
+            }
+
+            return config;
+        }
+
+        public TrackedBuffsListConfig(Vector2 position, Vector2 size, bool showBuffs, bool showDebuffs, bool showPermanentEffects,
+            GrowthDirections growthDirections, StatusEffectIconConfig iconConfig)
+            : base(position, size, showBuffs, showDebuffs, showPermanentEffects, growthDirections, iconConfig)
+        {
+        }
+    }
+}

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -117,12 +117,13 @@ namespace DelvUI.Interface.StatusEffects
             "Right and Down",
             "Right and Up",
             "Left and Down",
-            "Left and Up"
+            "Left and Up",
+            "Centered and Up",
+            "Centered and Down"
         )]
-        //"Centered (horizontal)",    not working as expected
-        //"Centered (vertical)"       not working as expected
         [Order(30)]
         public int Directions;
+
         [DragInt("Limit (-1 for no limit)", min = -1, max = 1000)]
         [Order(35)]
         public int Limit = -1;
@@ -190,8 +191,8 @@ namespace DelvUI.Interface.StatusEffects
             GrowthDirections.Right | GrowthDirections.Up,
             GrowthDirections.Left | GrowthDirections.Down,
             GrowthDirections.Left | GrowthDirections.Up,
-            GrowthDirections.Out | GrowthDirections.Right,
-            GrowthDirections.Out | GrowthDirections.Down
+            GrowthDirections.Centered | GrowthDirections.Up,
+            GrowthDirections.Centered | GrowthDirections.Down
         };
     }
 

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -217,7 +217,7 @@ namespace DelvUI.Interface.StatusEffects
         public StatusEffectIconBorderConfig DispellableBorderConfig = new StatusEffectIconBorderConfig(new(new(141f / 255f, 206f / 255f, 229f / 255f, 100f / 100f)), 2);
 
         [NestedConfig("My Effects Border", 25)]
-        public StatusEffectIconBorderConfig OwnedBorderConfig = new StatusEffectIconBorderConfig(new(new(35f / 255f, 179f / 255f, 69f / 255f, 100f / 100f)), 2);
+        public StatusEffectIconBorderConfig OwnedBorderConfig = new StatusEffectIconBorderConfig(new(new(35f / 255f, 179f / 255f, 69f / 255f, 100f / 100f)), 1);
 
         public StatusEffectIconConfig(LabelConfig durationLabelConfig = null, LabelConfig stacksLabelConfig = null)
         {
@@ -273,7 +273,7 @@ namespace DelvUI.Interface.StatusEffects
 
         public bool StatusAllowed(Status status)
         {
-            var inList = List.ContainsKey(status.Name);
+            var inList = List.ContainsKey(status.Name + "[" + status.RowId.ToString() + "]");
             if ((inList && !UseAsWhitelist) || (!inList && UseAsWhitelist))
             {
                 return false;
@@ -453,12 +453,12 @@ namespace DelvUI.Interface.StatusEffects
             return changed;
         }
     }
-
+    /**/
     [Section("Buffs and Debuffs")]
-    [SubSection("Tracked Buffs", 0)]
-    public class TrackedBuffsListConfig : StatusEffectsListConfig
+    [SubSection("Custom Effects", 0)]
+    public class CustomEffectsListConfig : StatusEffectsListConfig
     {
-        public new static TrackedBuffsListConfig DefaultConfig()
+        public new static CustomEffectsListConfig DefaultConfig()
         {
             var iconConfig = new StatusEffectIconConfig();
             iconConfig.DispellableBorderConfig.Enabled = false;
@@ -467,7 +467,7 @@ namespace DelvUI.Interface.StatusEffects
             var pos = new Vector2(-HUDConstants.UnitFramesOffsetX - HUDConstants.DefaultBigUnitFrameSize.X / 2f, HUDConstants.BaseHUDOffsetY - 50);
             var size = new Vector2(iconConfig.Size.X * 5 + 10, iconConfig.Size.Y * 3 + 10);
 
-            var config = new TrackedBuffsListConfig(pos, size, true, false, false, GrowthDirections.Centered | GrowthDirections.Up, iconConfig);
+            var config = new CustomEffectsListConfig(pos, size, true, true, false, GrowthDirections.Centered | GrowthDirections.Up, iconConfig);
             config.Enabled = false;
 
             // pre-populated white list
@@ -561,7 +561,7 @@ namespace DelvUI.Interface.StatusEffects
             return config;
         }
 
-        public TrackedBuffsListConfig(Vector2 position, Vector2 size, bool showBuffs, bool showDebuffs, bool showPermanentEffects,
+        public CustomEffectsListConfig(Vector2 position, Vector2 size, bool showBuffs, bool showDebuffs, bool showPermanentEffects,
             GrowthDirections growthDirections, StatusEffectIconConfig iconConfig)
             : base(position, size, showBuffs, showDebuffs, showPermanentEffects, growthDirections, iconConfig)
         {


### PR DESCRIPTION
It has a pre-populated white list of common raid buffs

Also:
* Fixed / re-did the "centered" growth direction option for status effects lists
* Fixed blacklist not being able to have 2 statuses with the same name but different id, while still maintaining the list ordered by name
