### PR TITLE
adds ability to hide your DelvUI in gold saucer

### DIFF
--- a/DelvUI/Interface/GeneralElements/HideHudConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HideHudConfig.cs
@@ -16,12 +16,16 @@ namespace DelvUI.Interface.GeneralElements
         [Order(5)]
         public bool HideOutsideOfCombat = false;
 
-        [Checkbox("Hide only JobPack HUD outside of combat")]
+        [Checkbox("Hide DelvUI in Gold Saucer")]
         [Order(10)]
+        public bool HideInGoldSaucer = true;
+
+        [Checkbox("Hide only JobPack HUD outside of combat")]
+        [Order(15)]
         public bool HideOnlyJobPackHudOutsideOfCombat = false;
 
         [Checkbox("Hide Default Job Gauges", isMonitored = true, spacing = true)]
-        [CollapseControl(15, 0)]
+        [CollapseControl(20, 0)]
         public bool HideDefaultJobGauges = false;
 
         [Checkbox("Disable Job Gauge Sounds", isMonitored = true)]
@@ -29,11 +33,11 @@ namespace DelvUI.Interface.GeneralElements
         public bool DisableJobGaugeSounds = false;
 
         [Checkbox("Hide Default Castbar", isMonitored = true)]
-        [Order(20)]
+        [Order(25)]
         public bool HideDefaultCastbar = false;
 
         [Checkbox("Enable Combat Hotbars", isMonitored = true, spacing = true)]
-        [CollapseControl(25, 1)]
+        [CollapseControl(30, 1)]
         public bool EnableCombatActionBars = false;
 
         [DynamicList("Hotbars Shown Only In Combat", "Hotbar 1", "Hotbar 2", "Hotbar 3", "Hotbar 4", "Hotbar 5", "Hotbar 6", "Hotbar 7", "Hotbar 8", "Hotbar 9", "Hotbar 10", isMonitored = true)]

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -106,9 +106,7 @@ namespace DelvUI.Interface
             }
 
             // hide in gold saucer
-            var results = GoldSaucerIDs.Where(id => id == Plugin.ClientState.TerritoryType);
-            bool hasZoneIdMatch = results.Count() > 0;
-            if (Config.HideInGoldSaucer && hasZoneIdMatch)
+            if (Config.HideInGoldSaucer && GoldSaucerIDs.Where(id => id == Plugin.ClientState.TerritoryType).Count() > 0)
             {
                 return true;
             }

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -55,6 +55,7 @@ namespace DelvUI.Interface
 
         private bool _previousCombatState = true;
         private bool _isInitial = true;
+        private uint[] GoldSaucerIDs = new uint[] { 144, 388, 389, 390, 391, 579, 792, 899, 941 };
 
         public HudHelper()
         {
@@ -102,6 +103,14 @@ namespace DelvUI.Interface
             if (!ConfigurationManager.GetInstance().LockHUD)
             {
                 return ConfigurationManager.GetInstance().LockHUD;
+            }
+
+            // hide in gold saucer
+            var results = GoldSaucerIDs.Where(id => id == Plugin.ClientState.TerritoryType);
+            bool hasZoneIdMatch = results.Count() > 0;
+            if (Config.HideInGoldSaucer && hasZoneIdMatch)
+            {
+                return true;
             }
 
             bool isHidden = Config.HideOutsideOfCombat && !IsInCombat();


### PR DESCRIPTION
This PR implements the ability to hide DelvUI in certain ClientState.TerritoryType's which are part of The Gold Saucer. We do no toggling of hotbars so if the user has his Petbar only as player hotbar1 and if the respective bar is hidden it wont be visible. 

Some TerritoryType id might be missing from the list