### PR TITLE
Fix: PrimaryResourceBar Label wasn't displayed at all

### DIFF
--- a/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
@@ -58,6 +58,13 @@ namespace DelvUI.Interface.GeneralElements
                 drawList.AddRect(position, position + size, 0xFF000000);
             }
 
+            // label
+            if (Config.ValueLabelConfig.Enabled)
+            {
+                Config.ValueLabelConfig.SetText($"{current,0}");
+                _valueLabel.Draw(origin + Config.Position, Config.Size);
+            }
+
         }
 
         private void GetResources(ref int current, ref int max, Chara actor)


### PR DESCRIPTION
This has been broken in [d13519a](https://github.com/DelvUI/DelvUI/commit/d13519adaca460cbcdac28320415f4ffa139c027), just too much code removed.