### PR TITLE
Beta2

### DIFF
--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -105,6 +105,11 @@ namespace DelvUI.Interface
                 return ConfigurationManager.GetInstance().LockHUD;
             }
 
+            if (element.GetType() == typeof(PlayerCastbarHud))
+            {
+                return false;
+            }
+
             // hide in gold saucer
             if (Config.HideInGoldSaucer && GoldSaucerIDs.Where(id => id == Plugin.ClientState.TerritoryType).Count() > 0)
             {
@@ -115,11 +120,6 @@ namespace DelvUI.Interface
             if (!isHidden && element is JobHud)
             {
                 return Config.HideOnlyJobPackHudOutsideOfCombat && !IsInCombat();
-            }
-
-            if (element.GetType() == typeof(PlayerCastbarHud))
-            {
-                return false;
             }
 
             if (element.GetConfig().GetType() == typeof(PlayerUnitFrameConfig))

--- a/DelvUI/Interface/Jobs/WarriorHud.cs
+++ b/DelvUI/Interface/Jobs/WarriorHud.cs
@@ -59,7 +59,7 @@ namespace DelvUI.Interface.Jobs
 
         private void DrawStormsEyeBar(Vector2 origin)
         {
-            IEnumerable<StatusEffect> innerReleaseBuff = Plugin.ClientState.LocalPlayer.StatusEffects.Where(o => o.EffectId == 1177);
+            IEnumerable<StatusEffect> innerReleaseBuff = Plugin.ClientState.LocalPlayer.StatusEffects.Where(o => o.EffectId is 1177 or 86);
             IEnumerable<StatusEffect> stormsEyeBuff = Plugin.ClientState.LocalPlayer.StatusEffects.Where(o => o.EffectId == 90);
 
             Vector2 position = origin + Config.Position + Config.StormsEyePosition - Config.StormsEyeSize / 2f;


### PR DESCRIPTION
- shows Castbar while Hide DelvUI in Gold Sauce = true
- WAR: adds tracking for Berserk to StormsEyeBar in addition to Inner Release, which is unlocked at lvl 70. and replaces Berserk.