### PR TITLE
a few more variants on the [name:first] texttag

### DIFF
--- a/DelvUI/Helpers/TextTags.cs
+++ b/DelvUI/Helpers/TextTags.cs
@@ -1,4 +1,4 @@
-﻿
+﻿using Dalamud.Game.ClientState.Actors;
 using Dalamud.Game.ClientState.Actors.Types;
 using System;
 using System.Linq;
@@ -71,6 +71,15 @@ namespace DelvUI.Helpers
                 // Name
                 "[name]" when IsPropertyExist(actor, "Name") => actor.Name.ToString(),
                 "[name:first]" when IsPropertyExist(actor, "Name") => ((string)actor.Name).FirstName(),
+                "[name:first-npcmedium]" when IsPropertyExist(actor, "Name") && IsPropertyExist(actor, "ObjectKind") => actor.ObjectKind == ObjectKind.Player
+                ? ((string)actor.Name).FirstName()
+                : ((string)actor.Name).Truncate(15),
+                "[name:first-npclong]" when IsPropertyExist(actor, "Name") && IsPropertyExist(actor, "ObjectKind") => actor.ObjectKind == ObjectKind.Player
+                ? ((string)actor.Name).FirstName()
+                : ((string)actor.Name).Truncate(20),
+                "[name:first-npcfull]" when IsPropertyExist(actor, "Name") && IsPropertyExist(actor, "ObjectKind") => actor.ObjectKind == ObjectKind.Player
+                ? ((string)actor.Name).FirstName()
+                : actor.Name.ToString(),
                 "[name:first-initial]" when IsPropertyExist(actor, "Name") => ((string)actor.Name).FirstName().Length == 0 ? "" : ((string)actor.Name).FirstName().Substring(0, 1),
                 "[name:last]" when IsPropertyExist(actor, "Name") => ((string)actor.Name).LastName(),
                 "[name:last-initial]" when IsPropertyExist(actor, "Name") => ((string)actor.Name).LastName().Length == 0 ? "" : ((string)actor.Name).LastName().Substring(0, 1),


### PR DESCRIPTION
3 more variants on the [name:first] texttag:

- [name:first-npcmedium] works the same as [name:first] for players but NPCs/objects will have their names trunctuated to 15 characters.
- [name:first-npclong] works the same as [name:first] for players but NPCs/objects will have their names trunctuated to 20 characters.
- [name:first-npcfull] works the same as [name:first] for players but NPCs/Objects will show their full name.

Just something that came from personal annoyance with seeing targets names cut off, when all I wanted was to remove lastnames from myself and other players