### PR TITLE
DRK Darkside tracking and bugfixes

### DIFF
--- a/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
@@ -61,7 +61,7 @@ namespace DelvUI.Interface.GeneralElements
             if (Config.ValueLabelConfig.Enabled)
             {
                 Config.ValueLabelConfig.SetText($"{current,0}");
-                _valueLabel.Draw(origin + Config.Position, Config.Size);
+                _valueLabel.Draw(origin + Config.Position, Config.Size, Actor);
             }
 
         }

--- a/DelvUI/Interface/Jobs/DarkKnightHud.cs
+++ b/DelvUI/Interface/Jobs/DarkKnightHud.cs
@@ -43,12 +43,6 @@ namespace DelvUI.Interface.Jobs
                 sizes.Add(Config.BloodGaugeSize);
             }
 
-            if (Config.ShowDarkside)
-            {
-                positions.Add(Config.Position + Config.DarksidePosition);
-                sizes.Add(Config.DarksideSize);
-            }
-
             if (Config.ShowBuffBar)
             {
                 positions.Add(Config.Position + Config.BuffBarPosition);
@@ -135,15 +129,12 @@ namespace DelvUI.Interface.Jobs
         {
             float darksideTimer = Plugin.JobGauges.Get<DRKGauge>().DarksideTimeRemaining;
             float darksideDuration = Math.Abs(darksideTimer / 1000);
+            var max = 60f;
 
             var posX = origin.X + Config.Position.X + Config.DarksidePosition.X - Config.DarksideSize.X / 2f;
             var posY = origin.Y + Config.Position.Y + Config.DarksidePosition.Y - Config.DarksideSize.Y / 2f;
-
-            //var duration = gauge.DarksideTimeRemaining;
-            //var darksideDuration = Convert.ToSingle(duration);
-            var max = 60f;
-
-            if (darksideDuration == 0)
+                        
+            if (darksideDuration == 0 && Config.OnlyShowWhenActive)
             {
                 return;
             }
@@ -334,25 +325,29 @@ namespace DelvUI.Interface.Jobs
         [CollapseControl(40, 2)]
         public bool ShowDarkside = true;
 
-        [Checkbox("Text" + "##Darkside")]
-        [CollapseWith(5, 2)]
-        public bool ShowDarksideText = true;
+        [Checkbox("Only Show When Active" + "##Darkside")]
+        [CollapseWith(0, 2)]
+        public bool OnlyShowWhenActive = true;        
 
         [DragFloat2("Position" + "##Darkside", min = -4000f, max = 4000f)]
-        [CollapseWith(10, 2)]
-        public Vector2 DarksidePosition = new Vector2(0, -49);
+        [CollapseWith(5, 2)]
+        public Vector2 DarksidePosition = new Vector2(0, -73);
 
         [DragFloat2("Size" + "##Darkside", min = 0, max = 4000f)]
-        [CollapseWith(15, 2)]
+        [CollapseWith(10, 2)]
         public Vector2 DarksideSize = new Vector2(254, 10);
 
         [ColorEdit4("Darkside" + "##Darkside")]
-        [CollapseWith(20, 2)]
+        [CollapseWith(15, 2)]
         public PluginConfigColor DarksideColor = new(new Vector4(209 / 255f, 38f / 255f, 204f / 255f, 100f / 100f));
 
         [ColorEdit4("Darkside Expiry" + "##Darkside")]
-        [CollapseWith(25, 2)]
+        [CollapseWith(20, 2)]
         public PluginConfigColor DarksideExpiryColor = new(new Vector4(160f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
+
+        [Checkbox("Show Darkside Text" + "##Darkside")]
+        [CollapseWith(25, 2)]
+        public bool ShowDarksideText = true;
         #endregion
 
         #region Buff Bar

--- a/DelvUI/Interface/Jobs/DarkKnightHud.cs
+++ b/DelvUI/Interface/Jobs/DarkKnightHud.cs
@@ -43,6 +43,12 @@ namespace DelvUI.Interface.Jobs
                 sizes.Add(Config.BloodGaugeSize);
             }
 
+            if (Config.ShowDarkside)
+            {
+                positions.Add(Config.Position + Config.DarksidePosition);
+                sizes.Add(Config.DarksideSize);
+            }
+
             if (Config.ShowBuffBar)
             {
                 positions.Add(Config.Position + Config.BuffBarPosition);
@@ -68,6 +74,11 @@ namespace DelvUI.Interface.Jobs
             if (Config.ShowBloodGauge)
             {
                 DrawBloodGauge(origin);
+            }
+
+            if (Config.ShowDarkside)
+            {
+                DrawDarkside(origin);
             }
 
             if (Config.ShowBuffBar)
@@ -120,6 +131,37 @@ namespace DelvUI.Interface.Jobs
             builder.Build().Draw(drawList);
         }
 
+        private void DrawDarkside(Vector2 origin)
+        {
+            float darksideTimer = Plugin.JobGauges.Get<DRKGauge>().DarksideTimeRemaining;
+            float darksideDuration = Math.Abs(darksideTimer / 1000);
+
+            var posX = origin.X + Config.Position.X + Config.DarksidePosition.X - Config.DarksideSize.X / 2f;
+            var posY = origin.Y + Config.Position.Y + Config.DarksidePosition.Y - Config.DarksideSize.Y / 2f;
+
+            //var duration = gauge.DarksideTimeRemaining;
+            //var darksideDuration = Convert.ToSingle(duration);
+            var max = 60f;
+
+            if (darksideDuration == 0)
+            {
+                return;
+            }
+
+            var darksideColor = darksideDuration > 5 ? Config.DarksideColor : Config.DarksideExpiryColor;
+            BarBuilder builder = BarBuilder.Create(posX, posY, Config.DarksideSize.Y, Config.DarksideSize.X)
+                .SetBackgroundColor(EmptyColor.Background)
+                .AddInnerBar(darksideDuration, max, darksideColor);
+
+            if (Config.ShowDarksideText)
+            {
+                builder.SetTextMode(BarTextMode.Single).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
+            }
+
+            ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+            builder.Build().Draw(drawList);
+        }
+        
         private void DrawBloodGauge(Vector2 origin)
         {
             var gauge = Plugin.JobGauges.Get<DRKGauge>();
@@ -287,59 +329,85 @@ namespace DelvUI.Interface.Jobs
         public PluginConfigColor BloodColorFull = new(new Vector4(216f / 255f, 0f / 255f, 73f / 255f, 100f / 100f));
         #endregion
 
+        #region Darkside
+        [Checkbox("Darkside" + "##Darkside", separator = true)]
+        [CollapseControl(40, 2)]
+        public bool ShowDarkside = true;
+
+        [Checkbox("Text" + "##Darkside")]
+        [CollapseWith(5, 2)]
+        public bool ShowDarksideText = true;
+
+        [DragFloat2("Position" + "##Darkside", min = -4000f, max = 4000f)]
+        [CollapseWith(10, 2)]
+        public Vector2 DarksidePosition = new Vector2(0, -49);
+
+        [DragFloat2("Size" + "##Darkside", min = 0, max = 4000f)]
+        [CollapseWith(15, 2)]
+        public Vector2 DarksideSize = new Vector2(254, 10);
+
+        [ColorEdit4("Darkside" + "##Darkside")]
+        [CollapseWith(20, 2)]
+        public PluginConfigColor DarksideColor = new(new Vector4(209 / 255f, 38f / 255f, 204f / 255f, 100f / 100f));
+
+        [ColorEdit4("Darkside Expiry" + "##Darkside")]
+        [CollapseWith(25, 2)]
+        public PluginConfigColor DarksideExpiryColor = new(new Vector4(160f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
+        #endregion
+
         #region Buff Bar
         [Checkbox("Blood Weapon & Delirium", separator = true)]
-        [CollapseControl(40, 2)]
+        [CollapseControl(45, 3)]
         public bool ShowBuffBar = false;
 
         [Checkbox("Timer" + "##DRKBuffBar")]
-        [CollapseWith(0, 2)]
+        [CollapseWith(0, 3)]
         public bool ShowBuffBarText = true;
 
         [DragFloat2("Position" + "##DRKBuffBar", min = -4000f, max = 4000f)]
-        [CollapseWith(5, 2)]
+        [CollapseWith(5, 3)]
         public Vector2 BuffBarPosition = new Vector2(0, -32);
 
         [DragFloat2("Size" + "##DRKBuffBar", min = 0, max = 4000f)]
-        [CollapseWith(10, 2)]
+        [CollapseWith(10, 3)]
         public Vector2 BuffBarSize = new Vector2(254, 20);
 
         [DragInt("Spacing" + "##DRKBuffBar", min = 0)]
-        [CollapseWith(15, 2)]
+        [CollapseWith(15, 3)]
         public int BuffBarPadding = 2;
 
         [ColorEdit4("Blood Weapon" + "##DRKBuffBar")]
-        [CollapseWith(20, 2)]
+        [CollapseWith(20, 3)]
         public PluginConfigColor BloodWeaponColor = new(new Vector4(160f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
 
         [ColorEdit4("Delirium" + "##DRKBuffBar")]
-        [CollapseWith(25, 2)]
+        [CollapseWith(25, 3)]
         public PluginConfigColor DeliriumColor = new(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 100f / 100f));
         #endregion
 
         #region Living Shadow
         [Checkbox("Living Shadow", separator = true)]
-        [CollapseControl(45, 3)]
+        [CollapseControl(50, 4)]
         public bool ShowLivingShadowBar = false;
 
         [Checkbox("Timer" + "##DRKLivingShadow")]
-        [CollapseWith(0, 3)]
+        [CollapseWith(0, 4)]
         public bool ShowLivingShadowBarText = true;
 
         [DragFloat2("Position" + "##DRKLivingShadow", min = -4000f, max = 4000f)]
-        [CollapseWith(5, 3)]
+        [CollapseWith(5, 4)]
         public Vector2 LivingShadowBarPosition = new Vector2(0, -10);
 
         [DragFloat2("Size" + "##DRKLivingShadow", min = 0, max = 4000f)]
-        [CollapseWith(10, 3)]
+        [CollapseWith(10, 4)]
         public Vector2 LivingShadowBarSize = new Vector2(254, 20);
 
         [DragInt("Spacing" + "##DRKLivingShadow", min = 0)]
-        [CollapseWith(15, 3)]
+        [CollapseWith(15, 4)]
         public int LivingShadowPadding = 2;
 
         [ColorEdit4("Color" + "##DRKLivingShadow")]
-        [CollapseWith(20, 3)]
+        [CollapseWith(20, 4)]
         public PluginConfigColor LivingShadowColor = new(new Vector4(225f / 255f, 105f / 255f, 205f / 255f, 100f / 100f));
         #endregion
     }

--- a/DelvUI/Interface/Jobs/PaladinHud.cs
+++ b/DelvUI/Interface/Jobs/PaladinHud.cs
@@ -291,23 +291,23 @@ namespace DelvUI.Interface.Jobs
         [CollapseControl(40, 2)]
         public bool ShowBuffBar = true;
 
-        [Checkbox("Timer")]
+        [Checkbox("Timer" + "##Buff")]
         [CollapseWith(0, 2)]
         public bool ShowBuffBarText = true;
 
-        [DragFloat2("Position", min = -4000f, max = 4000f)]
+        [DragFloat2("Position" + "##Buff", min = -4000f, max = 4000f)]
         [CollapseWith(5, 2)]
         public Vector2 BuffBarPosition = new(0, -32);
         
-        [DragFloat2("Size", min = -4000f, max = 4000f)]
+        [DragFloat2("Size" + "##Buff", min = -4000f, max = 4000f)]
         [CollapseWith(10, 2)]
         public Vector2 BuffBarSize = new(254, 20);
 
-        [ColorEdit4("Fight or Flight")]
+        [ColorEdit4("Fight or Flight" + "##Buff")]
         [CollapseWith(15, 2)]
         public PluginConfigColor FightOrFlightColor = new(new Vector4(240f / 255f, 50f / 255f, 0f / 255f, 100f / 100f));
 
-        [ColorEdit4("Requiescat")]
+        [ColorEdit4("Requiescat" + "##Buff")]
         [CollapseWith(20, 2)]
         public PluginConfigColor RequiescatColor = new(new Vector4(61f / 255f, 61f / 255f, 255f / 255f, 100f / 100f));
         #endregion


### PR DESCRIPTION
- DRK Darkside tracking since it's been requested a lot
- Moving PLD buffbar no longer moves all PLD job elements
- Primary Resource label can now be properly jobcolored