### PR TITLE
disable compiler warnings for nullable reference types

### DIFF
--- a/DelvUI/DelvUI.csproj
+++ b/DelvUI/DelvUI.csproj
@@ -25,8 +25,8 @@
         <DebugSymbols>true</DebugSymbols>
         <DebugType>full</DebugType>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Nullable>enable</Nullable>
         <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+        <NoWarn>8632</NoWarn>
     </PropertyGroup>
 
     <!-- Release Configuration -->


### PR DESCRIPTION
This will disable huge list of compiler warnings for usage of nullable reference types. Tischel seemed okay with it, told me to create a PR and let you decide @jdsmith2816 