### PR TITLE
(APIv4) DNC Step Bar Crash

### DIFF
--- a/DelvUI/GameStructs/OpenDNCGauge.cs
+++ b/DelvUI/GameStructs/OpenDNCGauge.cs
@@ -18,8 +18,7 @@ namespace DelvUI.GameStructs
 
     public enum DNCStep : uint
     {
-        None,
-        TechnicalStep = 15998,
+        None = 15998,
         Emboite = 15999,
         Entrechat = 16000,
         Jete = 16001,

--- a/DelvUI/GameStructs/OpenDNCGauge.cs
+++ b/DelvUI/GameStructs/OpenDNCGauge.cs
@@ -16,12 +16,13 @@ namespace DelvUI.GameStructs
         public unsafe bool IsDancing() => stepOrder[0] > 0;
     }
 
-    public enum DNCStep : byte
+    public enum DNCStep : uint
     {
         None,
-        Emboite,
-        Entrechat,
-        Jete,
-        Pirouette
+        TechnicalStep = 15998,
+        Emboite = 15999,
+        Entrechat = 16000,
+        Jete = 16001,
+        Pirouette = 16002
     }
 }

--- a/DelvUI/Interface/Jobs/DancerHud.cs
+++ b/DelvUI/Interface/Jobs/DancerHud.cs
@@ -149,7 +149,7 @@ namespace DelvUI.Interface.Jobs
         private unsafe void DrawStepBar(Vector2 origin)
         {
             var gauge = Plugin.JobGauges.Get<DNCGauge>();
-            
+
             if (!gauge.IsDancing)
             {
                 return;
@@ -202,9 +202,9 @@ namespace DelvUI.Interface.Jobs
                         chunkColors.Add(Config.PirouetteColor);
 
                         break;
-                    default:
-                        chunkColors.Add(EmptyColor);
-                        break;
+                        //default:
+                        //    chunkColors.Add(EmptyColor);
+                        //    break;
                 }
             }
 

--- a/DelvUI/Interface/Jobs/DancerHud.cs
+++ b/DelvUI/Interface/Jobs/DancerHud.cs
@@ -202,6 +202,9 @@ namespace DelvUI.Interface.Jobs
                         chunkColors.Add(Config.PirouetteColor);
 
                         break;
+                    default:
+                        chunkColors.Add(EmptyColor);
+                        break;
                 }
             }
 
@@ -220,7 +223,8 @@ namespace DelvUI.Interface.Jobs
             }
             else if (Config.StepGlowEnabled)
             {
-                builder.SetGlowChunks(glowChunks.ToArray()).SetGlowColor(Config.CurrentStepGlowColor.Base);
+                builder.SetGlowChunks(glowChunks.ToArray())
+                        .SetGlowColor(Config.CurrentStepGlowColor.Base);
             }
 
             ImDrawListPtr drawList = ImGui.GetWindowDrawList();
@@ -365,14 +369,22 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.StaticProcBarsEnabled)
             {
-                if(cascadeDuration > 0)
+                if (cascadeDuration > 0)
+                {
                     cascadeBuilder.SetTextMode(BarTextMode.Single).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
-                if(fountainDuration > 0)
+                }
+                if (fountainDuration > 0)
+                {
                     fountainBuilder.SetTextMode(BarTextMode.Single).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
-                if(windmillDuration > 0)
+                }
+                if (windmillDuration > 0)
+                {
                     windmillBuilder.SetTextMode(BarTextMode.Single).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
-                if(showerDuration > 0)
+                }
+                if (showerDuration > 0)
+                {
                     showerBuilder.SetTextMode(BarTextMode.Single).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
+                }
             }
 
             ImDrawListPtr drawList = ImGui.GetWindowDrawList();


### PR DESCRIPTION
This PR should fix the following issue: [(APIv4) DNC Step Bar Crash](https://trello.com/c/q1hQzleN/189-apiv4-dnc-step-bar-crashl)

The problem was that in APIv4, JobGauge.Steps is uint array of actionId's used in the current dance, and filled with id: 15998 (Technical Step) to 4 elements.

Thus this PR assumes that DNCStep.None = 15998 (Technical Step), and is used to denote that this step is used only in technical step dance. If anyone with lvl 70 DNC can test if everything is working as intended that would be cool.