### PR TITLE
use job color as background color & color health bar by health value

### DIFF
--- a/DelvUI/DelvUI.csproj
+++ b/DelvUI/DelvUI.csproj
@@ -85,6 +85,7 @@
     <!-- NuGet Packages -->
     <ItemGroup>
         <PackageReference Include="DalamudPackager" Version="2.1.2" />
+        <PackageReference Include="Colourful" Version="3.0.0" />
     </ItemGroup>
 
     <!-- Dalamud Packager Task-->

--- a/DelvUI/Helpers/Utils.cs
+++ b/DelvUI/Helpers/Utils.cs
@@ -7,6 +7,7 @@ using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.Types;
 using DelvUI.Config;
 using DelvUI.Enums;
+using Colourful;
 
 namespace DelvUI.Helpers
 {
@@ -59,6 +60,48 @@ namespace DelvUI.Helpers
             }
 
             return t.Seconds.ToString();
+        }
+
+        public static PluginConfigColor ColorByHealthValue(float i, float min, float max, PluginConfigColor fullHealthColor, PluginConfigColor lowHealthColor)
+        {
+            float ratio = i;
+            if (min > 0 || max < 1)
+            {
+                if (i < min)
+                {
+                    ratio = 0;
+                }
+                else if (i > max)
+                {
+                    ratio = 1;
+                }
+                else
+                {
+                    var range = max - min;
+                    ratio = (i - min) / range;
+                }
+            }
+
+            var _rgbToLab = new ConverterBuilder().FromRGB().ToLab().Build();
+            var _labToRgb = new ConverterBuilder().FromLab().ToRGB().Build();
+
+            var rgbFullHealthColor = new RGBColor(fullHealthColor.Vector.X, fullHealthColor.Vector.Y, fullHealthColor.Vector.Z);
+            var rgbLowHealthColor = new RGBColor(lowHealthColor.Vector.X, lowHealthColor.Vector.Y, lowHealthColor.Vector.Z);
+
+            var rgbFullHealthLab = _rgbToLab.Convert(rgbFullHealthColor);
+            var rgbLowHealthLab = _rgbToLab.Convert(rgbLowHealthColor);
+
+            float resultL = (float)((rgbFullHealthLab.L - rgbLowHealthLab.L) * ratio + rgbLowHealthLab.L);
+            float resultA = (float)((rgbFullHealthLab.a - rgbLowHealthLab.a) * ratio + rgbLowHealthLab.a);
+            float resultB = (float)((rgbFullHealthLab.b - rgbLowHealthLab.b) * ratio + rgbLowHealthLab.b);
+
+            var newColorLab = new LabColor(resultL, resultA, resultB);
+            var newColorLab2RGB = _labToRgb.Convert(newColorLab);
+
+            newColorLab2RGB.Clamp();
+
+            PluginConfigColor newColor = new PluginConfigColor(new Vector4((float)newColorLab2RGB.R, (float)newColorLab2RGB.G, (float)newColorLab2RGB.B, 100f / 100f));
+            return newColor;
         }
 
         public static PluginConfigColor ColorForActor(GameObject? actor)

--- a/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
@@ -108,6 +108,26 @@ namespace DelvUI.Interface.GeneralElements
         [CollapseWith(0, 0)]
         public PluginConfigColor CustomColor = new PluginConfigColor(new Vector4(0f / 255f, 145f / 255f, 6f / 255f, 100f / 100f));
 
+        [Checkbox("Color Based On Health Value ##CustomFrame")]
+        [CollapseWith(1, 0)]
+        public bool UseColorBasedOnHealthValue = false;
+
+        [ColorEdit4("Full Health Color ##CustomFrame")]
+        [CollapseWith(2, 0)]
+        public PluginConfigColor FullHealthColor = new PluginConfigColor(new Vector4(0f / 255f, 255f / 255f, 0f / 255f, 100f / 100f));
+
+        [ColorEdit4("Low Health Color ##CustomFrame")]
+        [CollapseWith(3, 0)]
+        public PluginConfigColor LowHealthColor = new PluginConfigColor(new Vector4(255f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
+
+        [DragFloat("Full Health Color Above Health %", min = 50f, max = 100f, velocity = 1f)]
+        [CollapseWith(4, 0)]
+        public float FullHealthColorThreshold = 75f;
+
+        [DragFloat("Low Health Color Below Health %", min = 0f, max = 50f, velocity = 1f)]
+        [CollapseWith(5, 0)]
+        public float LowHealthColorThreshold = 25f;
+
         [Checkbox("Custom Background Color")]
         [CollapseControl(25, 1)]
         public bool UseCustomBackgroundColor = false;
@@ -115,6 +135,10 @@ namespace DelvUI.Interface.GeneralElements
         [ColorEdit4("Color ##CustomBackground")]
         [CollapseWith(0, 1)]
         public PluginConfigColor CustomBackgroundColor = new PluginConfigColor(new Vector4(0f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
+
+        [Checkbox("Job Color As Background Color")]
+        [CollapseWith(1, 1)]
+        public bool UseJobColorAsBackgroundColor = false;
 
         [Checkbox("Tank Invulnerability", spacing = true)]
         [Order(30)]

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -223,7 +223,7 @@ namespace DelvUI.Interface.GeneralElements
                 return color;
             }
 
-            if (Config.UseCustomBackgroundColor)
+            if (Config.UseCustomBackgroundColor && chara is BattleChara)
             {
                 if (Config.UseJobColorAsBackgroundColor)
                 {

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -142,6 +142,11 @@ namespace DelvUI.Interface.GeneralElements
             var color = Config.UseCustomColor ? Config.CustomColor : Utils.ColorForActor(chara);
             var bgColor = BackgroundColor(chara);
 
+            if (Config.UseCustomColor && Config.UseColorBasedOnHealthValue)
+            {
+                color = Utils.ColorByHealthValue(scale, Config.LowHealthColorThreshold / 100f, Config.FullHealthColorThreshold / 100f, Config.FullHealthColor, Config.LowHealthColor);
+            }
+
             // background
             drawList.AddRectFilled(startPos, endPos, bgColor);
 
@@ -220,7 +225,14 @@ namespace DelvUI.Interface.GeneralElements
 
             if (Config.UseCustomBackgroundColor)
             {
-                return Config.CustomBackgroundColor.Base;
+                if (Config.UseJobColorAsBackgroundColor)
+                {
+                    return GlobalColors.Instance.SafeColorForJobId(chara.ClassJob.Id).Base;
+                }
+                else
+                {
+                    return Config.CustomBackgroundColor.Base;
+                }
             }
 
             return GlobalColors.Instance.EmptyUnitFrameColor.Base;


### PR DESCRIPTION
Added the option to color unit frames based on health value. We have the option to choose two colors to `interpolate` between depending on the health value of the unit. I also added the option to color the background by job color as well. The colors are converted from [`sRGB`](https://en.wikipedia.org/wiki/SRGB) color space to [`CEILAB`](https://en.wikipedia.org/wiki/CIELAB_color_space) using [`The Colorful Library`](https://github.com/tompazourek/Colourful) library. Then the colors are interpolated based on the health value of the unit then converted back to [`sRGB`](https://en.wikipedia.org/wiki/SRGB) color space.

I also added the option to display the Full Health or Low Health color when your health value is above or below certain thresholds. By default it will always display the Low Health Color below `25%` before interpolating into the Full Health Color. Full health color will always display above `75%` before interpolating into the Low Health Color.

[`The Colorful Library`](https://github.com/tompazourek/Colourful) can also be helpful for `interpolating` colors for different frames such as color by remaining duration of a buff or color the cast bar based on cast time.

[`The Colorful Library`](https://github.com/tompazourek/Colourful) is a `Open source` .NET library for working with `color spaces`.

The library is written in `C#` and released with an [`MIT license`](https://github.com/tompazourek/Colourful/blob/master/LICENSE)

![image](https://user-images.githubusercontent.com/7343912/134564069-0a5fc598-3f0d-4f96-84a0-610543440a42.png)

When interpolating from `red` to `green` in `RGB` space, we get this un-intuitive brown in the middle. Furthermore, `lchuv` and `lchab` looks very similar to `xyY` and `xyz`, but changing the initial colors a bit reveals their dissimilarity.

![image](https://user-images.githubusercontent.com/7343912/134568525-d3dff0b9-07a8-4089-8d35-4c446415245e.png)

`LCHuv` and `LCHab` is very similar to `HSV` and `HSL`, but they do avoid the luminance spikes at yellow and light blue
![image](https://user-images.githubusercontent.com/7343912/134568536-d237b10b-136e-4908-a585-d4758f2c6def.png)