### PR TITLE
Disable HideDefaultJobGauges

### DIFF
--- a/DelvUI/Interface/GeneralElements/HideHudConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HideHudConfig.cs
@@ -24,15 +24,15 @@ namespace DelvUI.Interface.GeneralElements
         [Order(15)]
         public bool HideOnlyJobPackHudOutsideOfCombat = false;
 
-        [Checkbox("Hide Default Job Gauges", isMonitored = true, spacing = true)]
-        [CollapseControl(20, 0)]
+        //[Checkbox("Hide Default Job Gauges", isMonitored = true, spacing = true)]
+        //[CollapseControl(20, 0)]
         public bool HideDefaultJobGauges = false;
 
-        [Checkbox("Disable Job Gauge Sounds", isMonitored = true)]
-        [CollapseWith(0, 0)]
+        //[Checkbox("Disable Job Gauge Sounds", isMonitored = true)]
+        //[CollapseWith(0, 0)]
         public bool DisableJobGaugeSounds = false;
 
-        [Checkbox("Hide Default Castbar", isMonitored = true)]
+        [Checkbox("Hide Default Castbar", isMonitored = true, spacing = true)]
         [Order(25)]
         public bool HideDefaultCastbar = false;
 

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -66,12 +66,12 @@ namespace DelvUI.Interface
 
         public unsafe void Configure(bool forceUpdate = false)
         {
+            ConfigureCombatActionBars(_isInitial || forceUpdate);
+
             if (!_isInitial && !forceUpdate)
             {
                 return;
             }
-
-            ConfigureCombatActionBars(_isInitial || forceUpdate);
 
             ToggleDefaultComponent(delegate (GUIAddon addon)
             {
@@ -79,17 +79,17 @@ namespace DelvUI.Interface
                 {
                     addon.NodeListVisibilityToggle(Config.HideDefaultCastbar);
                 }
-                else if (addon.name.StartsWith("JobHud") && !addon.name.StartsWith("JobHudNotice"))
-                {
-                    bool isHidden = Config.HideDefaultJobGauges;
+                //else if (addon.name.StartsWith("JobHud") && !addon.name.StartsWith("JobHudNotice"))
+                //{
+                //    bool isHidden = Config.HideDefaultJobGauges;
 
-                    addon.NodeListVisibilityToggle(isHidden && Config.DisableJobGaugeSounds);
-                    if (!Config.DisableJobGaugeSounds)
-                    {
-                        addon.VisibilityToggle(isHidden);
+                //    addon.NodeListVisibilityToggle(isHidden && Config.DisableJobGaugeSounds);
+                //    if (!Config.DisableJobGaugeSounds)
+                //    {
+                //        addon.VisibilityToggle(isHidden);
 
-                    }
-                }
+                //    }
+                //}
             });
 
             _isInitial = false;
@@ -137,10 +137,10 @@ namespace DelvUI.Interface
             {
                 ConfigureDefaultCastBar();
             }
-            else if (e.PropertyName == "HideDefaultJobGauges" || e.PropertyName == "DisableJobGaugeSounds")
-            {
-                ConfigureDefaultJobGauge();
-            }
+            //else if (e.PropertyName == "HideDefaultJobGauges" || e.PropertyName == "DisableJobGaugeSounds")
+            //{
+            //    ConfigureDefaultJobGauge();
+            //}
             else if (e.PropertyName == "EnableCombatActionBars")
             {
                 Config.CombatActionBars.ForEach(name => ToggleActionbar(name, Config.EnableCombatActionBars));
@@ -208,6 +208,7 @@ namespace DelvUI.Interface
 
         private unsafe void ConfigureDefaultJobGauge()
         {
+            return;
             ToggleDefaultComponent(delegate (GUIAddon addon)
             {
                 if (addon.name.StartsWith("JobHud"))
@@ -280,7 +281,7 @@ namespace DelvUI.Interface
             ToggleDefaultComponent(delegate (GUIAddon addon)
             {
                 if (addon.name == "_CastBar"
-                    || addon.name.StartsWith("JobHud")
+                    //|| addon.name.StartsWith("JobHud")
                     || addon.name.StartsWith("_ActionBar"))
                 {
                     addon.VisibilityToggle(false);

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -251,6 +251,7 @@ namespace DelvUI.Interface
             bool updateByEvent = _prevInEvent != inEvent;
 
             _helper.Configure(updateByEvent);
+            _prevInEvent = inEvent;
 
             UpdateJob();
             AssignActors();


### PR DESCRIPTION
this PR is disabling HideDefaultJobGauges / DisableJobGaugeSounds for their relation to the crash on job swap. they will be disabled while we look for better way to handle the situation.

Those changes should be applied to both api branches