### PR TITLE
Bug Fix:  Allow alpha adjustments for color interpolation 

### DIFF
--- a/DelvUI/Helpers/Utils.cs
+++ b/DelvUI/Helpers/Utils.cs
@@ -98,9 +98,11 @@ namespace DelvUI.Helpers
             var newColorLab = new LabColor(resultL, resultA, resultB);
             var newColorLab2RGB = _labToRgb.Convert(newColorLab);
 
+            float alpha = (fullHealthColor.Vector.W - lowHealthColor.Vector.W) * ratio + lowHealthColor.Vector.W;
+
             newColorLab2RGB.Clamp();
 
-            PluginConfigColor newColor = new PluginConfigColor(new Vector4((float)newColorLab2RGB.R, (float)newColorLab2RGB.G, (float)newColorLab2RGB.B, 100f / 100f));
+            PluginConfigColor newColor = new PluginConfigColor(new Vector4((float)newColorLab2RGB.R, (float)newColorLab2RGB.G, (float)newColorLab2RGB.B, alpha));
             return newColor;
         }
 


### PR DESCRIPTION
Allows alpha adjustments for Color Interpolation if Color Frame by Health Value is selected.