### PR TITLE
Hide Options config fixes

### DIFF
--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -407,14 +407,13 @@ namespace DelvUI.Config.Attributes
             ImGui.Text("Add");
             if (ImGui.Combo("##Add" + idText + friendlyName, ref intVal, addOptions.ToArray(), addOptions.Count, 6))
             {
+                changed = true;
+
                 var change = addOptions[intVal];
                 opts.Add(change);
                 field.SetValue(config, opts);
 
-                if (isMonitored && config is IOnChangeEventArgs eventObject)
-                {
-                    TriggerChangeEvent<string>(config, field.Name, change, ChangeType.ListAdd);
-                }
+                TriggerChangeEvent<string>(config, field.Name, change, ChangeType.ListAdd);
             }
 
             ImGui.Text(friendlyName + ":");
@@ -467,22 +466,16 @@ namespace DelvUI.Config.Attributes
 
             if (indexToRemove >= 0)
             {
+                changed = true;
+
                 var change = opts[indexToRemove];
                 opts.Remove(change);
                 field.SetValue(config, opts);
 
-                if (isMonitored && config is IOnChangeEventArgs eventObject)
-                {
-                    eventObject.OnValueChanged(
-                        new OnChangeEventArgs<string>(field.Name, change, ChangeType.ListRemove)
-                    );
-                }
-
+                TriggerChangeEvent<string>(config, field.Name, change, ChangeType.ListRemove);
             }
 
             ImGui.EndChild();
-
-
 
             return changed;
         }

--- a/DelvUI/Interface/GeneralElements/HideHudConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HideHudConfig.cs
@@ -18,7 +18,7 @@ namespace DelvUI.Interface.GeneralElements
 
         [Checkbox("Hide DelvUI in Gold Saucer")]
         [Order(10)]
-        public bool HideInGoldSaucer = true;
+        public bool HideInGoldSaucer = false;
 
         [Checkbox("Hide only JobPack HUD outside of combat")]
         [Order(15)]
@@ -28,7 +28,7 @@ namespace DelvUI.Interface.GeneralElements
         [Order(20)]
         public bool HideDefaultJobGauges = false;
 
-        [Checkbox("Hide Default Castbar", isMonitored = true, spacing = true)]
+        [Checkbox("Hide Default Castbar", isMonitored = true)]
         [Order(25)]
         public bool HideDefaultCastbar = false;
 

--- a/DelvUI/Interface/GeneralElements/HideHudConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HideHudConfig.cs
@@ -38,7 +38,7 @@ namespace DelvUI.Interface.GeneralElements
 
         [DynamicList("Hotbars Shown Only In Combat", "Hotbar 1", "Hotbar 2", "Hotbar 3", "Hotbar 4", "Hotbar 5", "Hotbar 6", "Hotbar 7", "Hotbar 8", "Hotbar 9", "Hotbar 10", isMonitored = true)]
         [CollapseWith(0, 1)]
-        public List<string> CombatActionBars = new();
+        public List<string> CombatActionBars = new List<string>();
 
         public Vector2 CastBarOriginalPosition;
         public Dictionary<string, Vector2> JobGaugeOriginalPosition = new Dictionary<string, Vector2>();


### PR DESCRIPTION
* Removes spacing between hide Castbar and Job Gauge
* Fixes the saving of CombatActionBars to the JSON 
* Default value of HideInGoldSaucer = false; (too many users were scared and we don't want to scare users :D )