### PR TITLE
More Primary Resource Bar options, DNC bug fixes

### DIFF
--- a/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
@@ -27,8 +27,14 @@ namespace DelvUI.Interface.GeneralElements
         [DragInt("Value", min = 1, max = 10000)]
         [Order(40, collapseWith = nameof(ShowThresholdMarker))]
         public int ThresholdMarkerValue = 7000;
-        //TODO ADD BELOW THRESHOLD COLOR
 
+        [ColorEdit4("Color" + "##Threshold")]
+        [Order(45, collapseWith = nameof(ShowThresholdMarker))]
+        public PluginConfigColor BelowThresholdColor = new(new Vector4(190 / 255f, 28f / 255f, 57f / 255f, 100f / 100f));
+
+        [Checkbox("Hide When Full", spacing = true)]
+        [Order(50)]
+        public bool HidePrimaryResourceWhenFull = false;
 
         public PrimaryResourceConfig(Vector2 position, Vector2 size, LabelConfig valueLabelConfig)
         {

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
@@ -36,15 +36,17 @@ namespace DelvUI.Interface.GeneralElements
             int max = 0;
 
             GetResources(ref current, ref max, chara);
+            if (Config.HidePrimaryResourceWhenFull && current == max) { return; }
 
             var scale = (float)current / max;
+
             var startPos = Utils.GetAnchoredPosition(origin + Config.Position, Config.Size, Config.Anchor);
 
             // bar
             var drawList = ImGui.GetWindowDrawList();
             drawList.AddRectFilled(startPos, startPos + Config.Size, 0x88000000);
-            
-            var color = Color(Actor);
+
+            var color = Config.ShowThresholdMarker && current < Config.ThresholdMarkerValue ? Config.BelowThresholdColor : Color(Actor);
             DrawHelper.DrawGradientFilledRect(startPos, new Vector2(Config.Size.X * scale, Config.Size.Y), color, drawList);
 
             drawList.AddRect(startPos, startPos + Config.Size, 0xFF000000);

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
@@ -4,6 +4,7 @@ using ImGuiNET;
 using System.Collections.Generic;
 using System.Numerics;
 using Dalamud.Game.ClientState.Objects.Types;
+using System;
 
 namespace DelvUI.Interface.GeneralElements
 {
@@ -34,8 +35,9 @@ namespace DelvUI.Interface.GeneralElements
             var chara = (Character)Actor;
             int current = 0;
             int max = 0;
+            int percent = 0;
 
-            GetResources(ref current, ref max, chara);
+            GetResources(ref current, ref max, ref percent, chara);
             if (Config.HidePrimaryResourceWhenFull && current == max) { return; }
 
             var scale = (float)current / max;
@@ -46,7 +48,8 @@ namespace DelvUI.Interface.GeneralElements
             var drawList = ImGui.GetWindowDrawList();
             drawList.AddRectFilled(startPos, startPos + Config.Size, 0x88000000);
 
-            var color = Config.ShowThresholdMarker && current < Config.ThresholdMarkerValue ? Config.BelowThresholdColor : Color(Actor);
+            var color = Config.ShowThresholdMarker && percent < Config.ThresholdMarkerValue / 100 ? Config.BelowThresholdColor : Color(Actor);
+
             DrawHelper.DrawGradientFilledRect(startPos, new Vector2(Config.Size.X * scale, Config.Size.Y), color, drawList);
 
             drawList.AddRect(startPos, startPos + Config.Size, 0xFF000000);
@@ -68,7 +71,7 @@ namespace DelvUI.Interface.GeneralElements
 
         }
 
-        private void GetResources(ref int current, ref int max, Character actor)
+        private void GetResources(ref int current, ref int max, ref int percent, Character actor)
         {
             switch (ResourceType)
             {
@@ -76,6 +79,7 @@ namespace DelvUI.Interface.GeneralElements
                     {
                         current = (int)actor.CurrentMp;
                         max = (int)actor.MaxMp;
+                        percent = (int)Math.Round((double)(100 * current / max));
                     }
 
                     break;
@@ -84,6 +88,7 @@ namespace DelvUI.Interface.GeneralElements
                     {
                         current = (int)actor.CurrentCp;
                         max = (int)actor.MaxCp;
+                        percent = (int)Math.Round((double)(100 * current / max));
                     }
 
                     break;
@@ -92,6 +97,7 @@ namespace DelvUI.Interface.GeneralElements
                     {
                         current = (int)actor.CurrentGp;
                         max = (int)actor.MaxGp;
+                        percent = (int)Math.Round((double)(100 * current / max));
                     }
 
                     break;

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
@@ -79,7 +79,7 @@ namespace DelvUI.Interface.GeneralElements
                     {
                         current = (int)actor.CurrentMp;
                         max = (int)actor.MaxMp;
-                        percent = (int)Math.Round((double)(100 * current / max));
+                        if (max != 0) { percent = (int)Math.Round((double)(100 * current / max)); }
                     }
 
                     break;
@@ -88,7 +88,7 @@ namespace DelvUI.Interface.GeneralElements
                     {
                         current = (int)actor.CurrentCp;
                         max = (int)actor.MaxCp;
-                        percent = (int)Math.Round((double)(100 * current / max));
+                        if (max != 0) { percent = (int)Math.Round((double)(100 * current / max)); }
                     }
 
                     break;
@@ -97,7 +97,7 @@ namespace DelvUI.Interface.GeneralElements
                     {
                         current = (int)actor.CurrentGp;
                         max = (int)actor.MaxGp;
-                        percent = (int)Math.Round((double)(100 * current / max));
+                        if (max != 0) { percent = (int)Math.Round((double)(100 * current / max)); }
                     }
 
                     break;

--- a/DelvUI/Interface/Jobs/DancerHud.cs
+++ b/DelvUI/Interface/Jobs/DancerHud.cs
@@ -140,7 +140,7 @@ namespace DelvUI.Interface.Jobs
             IEnumerable<Status> flourishingBuff = player.StatusList.Where(o => o.StatusId is 1820 or 2021);
             DNCGauge gauge = Plugin.JobGauges.Get<DNCGauge>();
 
-            if (!flourishingBuff.Any() && Config.OnlyShowFeatherWhenActive)
+            if (gauge.Feathers == 0 && !flourishingBuff.Any() && Config.OnlyShowFeatherWhenActive)
             {
                 return;
             }
@@ -250,8 +250,8 @@ namespace DelvUI.Interface.Jobs
 
         private void DrawBuffBar(Vector2 origin, PlayerCharacter player)
         {
-            IEnumerable<Status> devilmentBuff = player.StatusList.Where(o => o.StatusId is 1825);
-            IEnumerable<Status> technicalFinishBuff = player.StatusList.Where(o => o.StatusId is 1822 or 2050);
+            IEnumerable<Status> devilmentBuff = player.StatusList.Where(o => o.StatusId is 1825 && o.SourceID == player.ObjectId);
+            IEnumerable<Status> technicalFinishBuff = player.StatusList.Where(o => o.StatusId is 1822 or 2050 && o.SourceID == player.ObjectId);
 
             if (!technicalFinishBuff.Any() && !devilmentBuff.Any() && Config.OnlyShowBuffBarWhenActive)
             {


### PR DESCRIPTION
- Option to hide primary resource bar when resource is full (requested)
- Option to set below threshold color for primary resource
- DNC feather gauge now properly enables when set to "only show when active" and the player gets a feather
- DNC buff bar now only shows your own buffs and not group members/dancer partners