### PR TITLE
Only Show When Active for Tanks

### DIFF
--- a/DelvUI/Interface/Jobs/DarkKnightHud.cs
+++ b/DelvUI/Interface/Jobs/DarkKnightHud.cs
@@ -131,11 +131,8 @@ namespace DelvUI.Interface.Jobs
 
         private void DrawDarkside(Vector2 origin)
         {
-            var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
-            if (target is not Character && Config.HideDarksideWhenNoTarget)
-            {
-                return;
-            }
+            GameObject? actor = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
+            if (Config.HideDarksideWhenNoTarget && actor is not BattleChara) { return; }
 
             float darksideTimer = Plugin.JobGauges.Get<DRKGauge>().DarksideTimeRemaining;
             float darksideDuration = Math.Abs(darksideTimer / 1000);
@@ -352,29 +349,30 @@ namespace DelvUI.Interface.Jobs
         [Order(110, collapseWith = nameof(ShowDarkside))]
         public bool OnlyShowDarksideWhenActive = false;
 
-        [DragFloat2("Position" + "##Darkside", min = -4000f, max = 4000f)]
+        [Checkbox("Hide When No Target" + "##Darkside")]
         [Order(115, collapseWith = nameof(ShowDarkside))]
+        public bool HideDarksideWhenNoTarget = true;
+
+        [Checkbox("Timer" + "##Darkside")]
+        [Order(120, collapseWith = nameof(ShowDarkside))]
+        public bool ShowDarksideText = true;
+
+        [DragFloat2("Position" + "##Darkside", min = -4000f, max = 4000f)]
+        [Order(125, collapseWith = nameof(ShowDarkside))]
         public Vector2 DarksidePosition = new Vector2(0, -73);
 
         [DragFloat2("Size" + "##Darkside", min = 0, max = 4000f)]
-        [Order(120, collapseWith = nameof(ShowDarkside))]
+        [Order(130, collapseWith = nameof(ShowDarkside))]
         public Vector2 DarksideSize = new Vector2(254, 10);
 
         [ColorEdit4("Darkside" + "##Darkside")]
-        [Order(125, collapseWith = nameof(ShowDarkside))]
+        [Order(135, collapseWith = nameof(ShowDarkside))]
         public PluginConfigColor DarksideColor = new(new Vector4(209 / 255f, 38f / 255f, 204f / 255f, 100f / 100f));
 
         [ColorEdit4("Darkside Expiry" + "##Darkside")]
-        [Order(130, collapseWith = nameof(ShowDarkside))]
+        [Order(140, collapseWith = nameof(ShowDarkside))]
         public PluginConfigColor DarksideExpiryColor = new(new Vector4(160f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
 
-        [Checkbox("Show Darkside Text" + "##Darkside")]
-        [Order(135, collapseWith = nameof(ShowDarkside))]
-        public bool ShowDarksideText = true;
-
-        [Checkbox("Hide When No Target" + "##Darkside")]
-        [Order(140, collapseWith = nameof(ShowDarkside))]
-        public bool HideDarksideWhenNoTarget = false;
         #endregion
 
         #region Buff Bar

--- a/DelvUI/Interface/Jobs/DarkKnightHud.cs
+++ b/DelvUI/Interface/Jobs/DarkKnightHud.cs
@@ -11,7 +11,6 @@ using ImGuiNET;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 
@@ -148,7 +147,7 @@ namespace DelvUI.Interface.Jobs
                 .SetBackgroundColor(EmptyColor.Background)
                 .AddInnerBar(darksideDuration, max, darksideColor);
 
-            if (Config.ShowDarksideText)
+            if (Config.ShowDarksideText && darksideDuration != 0)
             {
                 builder.SetTextMode(BarTextMode.Single).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
             }

--- a/DelvUI/Interface/Jobs/GunbreakerHud.cs
+++ b/DelvUI/Interface/Jobs/GunbreakerHud.cs
@@ -64,6 +64,8 @@ namespace DelvUI.Interface.Jobs
 
             var gauge = Plugin.JobGauges.Get<GNBGauge>();
 
+            if (Config.OnlyShowPowderGaugeWhenActive && gauge.Ammo is 0) { return; }
+
             builder.SetChunks(2)
                    .SetChunkPadding(Config.PowderGaugeSpacing)
                    .AddInnerBar(gauge.Ammo, 2, Config.PowderGaugeFillColor, null)
@@ -78,18 +80,20 @@ namespace DelvUI.Interface.Jobs
         {
             Vector2 position = origin + Config.Position + Config.NoMercyBarPosition - Config.NoMercyBarSize / 2f;
             var noMercyBuff = player.StatusList.Where(o => o.StatusId == 1831);
+            float duration = 0f;
 
             var builder = BarBuilder.Create(position, Config.NoMercyBarSize)
                 .SetBackgroundColor(EmptyColor.Base);
 
             if (noMercyBuff.Any())
             {
-                var duration = noMercyBuff.First().RemainingTime;
+                duration = noMercyBuff.First().RemainingTime;
 
                 builder.AddInnerBar(duration, 20, Config.NoMercyFillColor, null)
                        .SetTextMode(BarTextMode.EachChunk)
                        .SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
             }
+            if (Config.OnlyShowNoMercyWhenActive && duration is 0) { return; }
 
             var drawList = ImGui.GetWindowDrawList();
             builder.Build().Draw(drawList);
@@ -109,38 +113,46 @@ namespace DelvUI.Interface.Jobs
         [Order(30)]
         public bool ShowPowderGauge = true;
 
-        [DragFloat2("Position" + "##PowderGauge", min = -4000f, max = 4000f)]
+        [Checkbox("Only Show When Active" + "##PowderGauge")]
         [Order(35, collapseWith = nameof(ShowPowderGauge))]
+        public bool OnlyShowPowderGaugeWhenActive = false;
+
+        [DragFloat2("Position" + "##PowderGauge", min = -4000f, max = 4000f)]
+        [Order(40, collapseWith = nameof(ShowPowderGauge))]
         public Vector2 PowderGaugeBarPosition = new(0, -32);
 
         [DragFloat2("Size" + "##PowderGauge", min = 1f, max = 4000f)]
-        [Order(40, collapseWith = nameof(ShowPowderGauge))]
+        [Order(45, collapseWith = nameof(ShowPowderGauge))]
         public Vector2 PowderGaugeBarSize = new(254, 20);
 
         [DragFloat("Spacing" + "##PowderGauge", min = 0)]
-        [Order(45, collapseWith = nameof(ShowPowderGauge))]
+        [Order(50, collapseWith = nameof(ShowPowderGauge))]
         public float PowderGaugeSpacing = 2.0f;
 
         [ColorEdit4("Color" + "##PowderGauge")]
-        [Order(50, collapseWith = nameof(ShowPowderGauge))]
+        [Order(55, collapseWith = nameof(ShowPowderGauge))]
         public PluginConfigColor PowderGaugeFillColor = new(new Vector4(0f / 255f, 162f / 255f, 252f / 255f, 1f));
         #endregion
 
         #region No Mercy
         [Checkbox("No Mercy", separator = true)]
-        [Order(55)]
+        [Order(60)]
         public bool ShowNoMercyBar = true;
 
+        [Checkbox("Only Show When Active" + "##NoMercy")]
+        [Order(65, collapseWith = nameof(ShowNoMercyBar))]
+        public bool OnlyShowNoMercyWhenActive = false;
+
         [DragFloat2("Position" + "##NoMercy", min = -4000f, max = 4000f)]
-        [Order(60, collapseWith = nameof(ShowNoMercyBar))]
+        [Order(70, collapseWith = nameof(ShowNoMercyBar))]
         public Vector2 NoMercyBarPosition = new(0, -10);
 
         [DragFloat2("Size" + "##NoMercy", min = 1f, max = 4000f)]
-        [Order(65, collapseWith = nameof(ShowNoMercyBar))]
+        [Order(75, collapseWith = nameof(ShowNoMercyBar))]
         public Vector2 NoMercyBarSize = new(254, 20);
 
         [ColorEdit4("Color" + "##NoMercy")]
-        [Order(70, collapseWith = nameof(ShowNoMercyBar))]
+        [Order(80, collapseWith = nameof(ShowNoMercyBar))]
         public PluginConfigColor NoMercyFillColor = new(new Vector4(252f / 255f, 204f / 255f, 255f / 255f, 1f));
         #endregion
     }

--- a/DelvUI/Interface/Jobs/PaladinHud.cs
+++ b/DelvUI/Interface/Jobs/PaladinHud.cs
@@ -133,7 +133,7 @@ namespace DelvUI.Interface.Jobs
                                            .SetBackgroundColor(EmptyColor.Base)
                                            .AddInnerBar(gauge.OathGauge, 100, Config.OathGaugeColor, PartialFillColor);
 
-            if (Config.ShowOathGaugeText)
+            if (Config.ShowOathGaugeText && gauge.OathGauge != 0)
             {
                 builder.SetTextMode(BarTextMode.EachChunk).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
             }

--- a/DelvUI/Interface/Jobs/PaladinHud.cs
+++ b/DelvUI/Interface/Jobs/PaladinHud.cs
@@ -94,6 +94,8 @@ namespace DelvUI.Interface.Jobs
             float posX = origin.X + Config.Position.X + Config.ManaBarPosition.X - Config.ManaBarSize.X / 2f;
             float posY = origin.Y + Config.Position.Y + Config.ManaBarPosition.Y - Config.ManaBarSize.Y / 2f;
 
+            if (Config.HideManaWhenFull && player.CurrentMp is 10000) { return; }
+
             BarBuilder builder = BarBuilder.Create(posX, posY, Config.ManaBarSize.Y, Config.ManaBarSize.X).SetBackgroundColor(EmptyColor.Base);
 
             if (Config.ChunkManaBar)
@@ -120,6 +122,8 @@ namespace DelvUI.Interface.Jobs
         {
             PLDGauge gauge = Plugin.JobGauges.Get<PLDGauge>();
 
+            if (Config.OnlyShowOathGaugeWhenActive && gauge.OathGauge is 0) { return; }
+
             float xPos = origin.X + Config.Position.X + Config.OathGaugePosition.X - Config.OathGaugeSize.X / 2f;
             float yPos = origin.Y + Config.Position.Y + Config.OathGaugePosition.Y - Config.OathGaugeSize.Y / 2f;
 
@@ -142,6 +146,8 @@ namespace DelvUI.Interface.Jobs
         {
             IEnumerable<Status> fightOrFlightBuff = player.StatusList.Where(o => o.StatusId == 76);
             IEnumerable<Status> requiescatBuff = player.StatusList.Where(o => o.StatusId == 1368);
+
+            if (Config.OnlyShowBuffBarWhenActive && !requiescatBuff.Any() && !fightOrFlightBuff.Any()) { return; }
 
             float xPos = origin.X + Config.Position.X + Config.BuffBarPosition.X - Config.BuffBarSize.X / 2f;
             float yPos = origin.Y + Config.Position.Y + Config.BuffBarPosition.Y - Config.BuffBarSize.Y / 2f;
@@ -179,6 +185,8 @@ namespace DelvUI.Interface.Jobs
             IEnumerable<Status> atonementBuff = player.StatusList.Where(o => o.StatusId == 1902);
             int stackCount = atonementBuff.Any() ? atonementBuff.First().StackCount : 0;
 
+            if (Config.OnlyShowAtonementWhenActive && stackCount is 0) { return; }
+
             float xPos = origin.X + Config.Position.X + Config.AtonementBarPosition.X - Config.AtonementBarSize.X / 2f;
             float yPos = origin.Y + Config.Position.Y + Config.AtonementBarPosition.Y - Config.AtonementBarSize.Y / 2f;
 
@@ -195,14 +203,20 @@ namespace DelvUI.Interface.Jobs
         private void DrawDoTBar(Vector2 origin, PlayerCharacter player)
         {
             GameObject? actor = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
-            if (actor is not BattleChara target)
+            if (actor is not BattleChara && Config.HideGoringBladeWhenNoTarget) { return; }
+
+            float duration = 0f;
+
+            if (actor is BattleChara target)
             {
-                return;
+                var goringBlade = target.StatusList.Where(o => o.StatusId is 725 && o.SourceID == player.ObjectId);
+                if (goringBlade.Any())
+                {
+                    duration = Math.Abs(goringBlade.First().RemainingTime);
+                }
             }
 
-            Status? goringBlade = target.StatusList.FirstOrDefault(o => o.StatusId == 725 && o.SourceID == player.ObjectId);
-
-            float duration = Math.Abs(goringBlade?.RemainingTime ?? 0f);
+            if (Config.OnlyShowGoringBladeWhenActive && duration is 0) { return; }
 
             float xPos = origin.X + Config.Position.X + Config.GoringBladeBarPosition.X - Config.GoringBladeBarSize.X / 2f;
             float yPos = origin.Y + Config.Position.Y + Config.GoringBladeBarPosition.Y - Config.GoringBladeBarSize.Y / 2f;
@@ -234,6 +248,10 @@ namespace DelvUI.Interface.Jobs
         [Order(30)]
         public bool ShowManaBar = true;
 
+        [Checkbox("Hide When Full" + "##MP")]
+        [Order(31, collapseWith = nameof(ShowManaBar))]
+        public bool HideManaWhenFull = false;
+
         [Checkbox("Text" + "##MP")]
         [Order(35, collapseWith = nameof(ShowManaBar))]
         public bool ShowManaBarText = true;
@@ -264,6 +282,10 @@ namespace DelvUI.Interface.Jobs
         [Order(65)]
         public bool ShowOathGauge = true;
 
+        [Checkbox("Only Show When Active" + "##Oath")]
+        [Order(66, collapseWith = nameof(ShowOathGauge))]
+        public bool OnlyShowOathGaugeWhenActive = false;
+
         [Checkbox("Text" + "##Oath")]
         [Order(70, collapseWith = nameof(ShowOathGauge))]
         public bool ShowOathGaugeText = true;
@@ -289,6 +311,10 @@ namespace DelvUI.Interface.Jobs
         [Checkbox("Fight or Flight & Requiescat", separator = true)]
         [Order(95)]
         public bool ShowBuffBar = true;
+
+        [Checkbox("Only Show When Active" + "##Buff")]
+        [Order(96, collapseWith = nameof(ShowBuffBar))]
+        public bool OnlyShowBuffBarWhenActive = false;
 
         [Checkbox("Timer" + "##Buff")]
         [Order(100, collapseWith = nameof(ShowBuffBar))]
@@ -316,6 +342,10 @@ namespace DelvUI.Interface.Jobs
         [Order(125)]
         public bool ShowAtonementBar = true;
 
+        [Checkbox("Only Show When Active" + "##Atonement")]
+        [Order(126, collapseWith = nameof(ShowAtonementBar))]
+        public bool OnlyShowAtonementWhenActive = false;
+
         [DragFloat2("Position" + "##Atonement", min = -4000f, max = 4000f)]
         [Order(130, collapseWith = nameof(ShowAtonementBar))]
         public Vector2 AtonementBarPosition = new(0, -10);
@@ -337,6 +367,14 @@ namespace DelvUI.Interface.Jobs
         [Checkbox("Goring Blade" + "##GoringBlade", separator = true)]
         [Order(150)]
         public bool ShowGoringBladeBar = true;
+
+        [Checkbox("Only Show When Active" + "##GoringBlade")]
+        [Order(151, collapseWith = nameof(ShowGoringBladeBar))]
+        public bool OnlyShowGoringBladeWhenActive = false;
+
+        [Checkbox("Hide When No Target" + "##Darkside")]
+        [Order(152, collapseWith = nameof(ShowGoringBladeBar))]
+        public bool HideGoringBladeWhenNoTarget = true;
 
         [Checkbox("Timer" + "##GoringBlade")]
         [Order(155, collapseWith = nameof(ShowGoringBladeBar))]

--- a/DelvUI/Interface/Jobs/WarriorHud.cs
+++ b/DelvUI/Interface/Jobs/WarriorHud.cs
@@ -88,7 +88,7 @@ namespace DelvUI.Interface.Jobs
 
             builder.AddInnerBar(duration, maximum, color);
 
-            if (Config.ShowStormsEyeText)
+            if (Config.ShowStormsEyeText && duration != 0)
             {
                 builder.SetTextMode(BarTextMode.EachChunk).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
             }
@@ -117,7 +117,7 @@ namespace DelvUI.Interface.Jobs
                 builder.SetChunksColors(Config.NascentChaosColor);
             }
 
-            if (Config.ShowBeastGaugeText)
+            if (Config.ShowBeastGaugeText && gauge.BeastGauge != 0)
             {
                 builder.SetTextMode(BarTextMode.EachChunk).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
             }

--- a/DelvUI/Interface/Jobs/WarriorHud.cs
+++ b/DelvUI/Interface/Jobs/WarriorHud.cs
@@ -84,6 +84,8 @@ namespace DelvUI.Interface.Jobs
                 color = Config.StormsEyeColor;
             }
 
+            if (Config.OnlyShowStormsEyeWhenActive && duration is 0) { return; }
+
             builder.AddInnerBar(duration, maximum, color);
 
             if (Config.ShowStormsEyeText)
@@ -99,6 +101,8 @@ namespace DelvUI.Interface.Jobs
         {
             WARGauge gauge = Plugin.JobGauges.Get<WARGauge>();
             var nascentChaosBuff = player.StatusList.Where(o => o.StatusId == 1897);
+
+            if (Config.OnlyShowBeastGaugeWhenActive && !nascentChaosBuff.Any() && gauge.BeastGauge is 0) { return; }
 
             Vector2 position = origin + Config.Position + Config.BeastGaugePosition - Config.BeastGaugeSize / 2f;
 
@@ -136,24 +140,28 @@ namespace DelvUI.Interface.Jobs
         [Order(30)]
         public bool ShowStormsEye = true;
 
-        [Checkbox("Text" + "##StormsEye")]
+        [Checkbox("Only Show When Active" + "##StormsEye")]
         [Order(35, collapseWith = nameof(ShowStormsEye))]
+        public bool OnlyShowStormsEyeWhenActive = false;
+
+        [Checkbox("Text" + "##StormsEye")]
+        [Order(40, collapseWith = nameof(ShowStormsEye))]
         public bool ShowStormsEyeText = true;
 
         [DragFloat2("Position" + "##StormsEye", min = -4000f, max = 4000f)]
-        [Order(40, collapseWith = nameof(ShowStormsEye))]
+        [Order(45, collapseWith = nameof(ShowStormsEye))]
         public Vector2 StormsEyePosition = new(0, -32);
 
         [DragFloat2("Size" + "##StormsEye", min = 1f, max = 4000f)]
-        [Order(45, collapseWith = nameof(ShowStormsEye))]
+        [Order(50, collapseWith = nameof(ShowStormsEye))]
         public Vector2 StormsEyeSize = new(254, 20);
 
         [ColorEdit4("Storm's Eye")]
-        [Order(50, collapseWith = nameof(ShowStormsEye))]
+        [Order(55, collapseWith = nameof(ShowStormsEye))]
         public PluginConfigColor StormsEyeColor = new(new Vector4(255f / 255f, 136f / 255f, 146f / 255f, 100f / 100f));
 
         [ColorEdit4("Inner Release")]
-        [Order(55, collapseWith = nameof(ShowStormsEye))]
+        [Order(60, collapseWith = nameof(ShowStormsEye))]
         public PluginConfigColor InnerReleaseColor = new(new Vector4(255f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
 
 
@@ -161,31 +169,35 @@ namespace DelvUI.Interface.Jobs
 
         #region Beast Gauge
         [Checkbox("Beast Gauge", separator = true)]
-        [Order(60)]
+        [Order(65)]
         public bool ShowBeastGauge = true;
 
+        [Checkbox("Only Show When Active" + "##BeastGauge")]
+        [Order(70, collapseWith = nameof(ShowBeastGauge))]
+        public bool OnlyShowBeastGaugeWhenActive = false;
+
         [Checkbox("Text" + "##BeastGauge")]
-        [Order(65, collapseWith = nameof(ShowBeastGauge))]
+        [Order(75, collapseWith = nameof(ShowBeastGauge))]
         public bool ShowBeastGaugeText = false;
 
         [DragFloat2("Position" + "##BeastGauge", min = -4000f, max = 4000f)]
-        [Order(70, collapseWith = nameof(ShowBeastGauge))]
+        [Order(80, collapseWith = nameof(ShowBeastGauge))]
         public Vector2 BeastGaugePosition = new(0, -10);
 
         [DragFloat2("Size" + "##BeastGauge", min = 1f, max = 4000f)]
-        [Order(75, collapseWith = nameof(ShowBeastGauge))]
+        [Order(85, collapseWith = nameof(ShowBeastGauge))]
         public Vector2 BeastGaugeSize = new(254, 20);
 
         [DragFloat("Spacing" + "##BeastGauge")]
-        [Order(80, collapseWith = nameof(ShowBeastGauge))]
+        [Order(90, collapseWith = nameof(ShowBeastGauge))]
         public float BeastGaugePadding = 2.0f;
 
         [ColorEdit4("Beast Gauge")]
-        [Order(85, collapseWith = nameof(ShowBeastGauge))]
+        [Order(95, collapseWith = nameof(ShowBeastGauge))]
         public PluginConfigColor BeastGaugeFillColor = new(new Vector4(201f / 255f, 13f / 255f, 13f / 255f, 100f / 100f));
 
         [ColorEdit4("Nascent Chaos")]
-        [Order(90, collapseWith = nameof(ShowBeastGauge))]
+        [Order(100, collapseWith = nameof(ShowBeastGauge))]
         public PluginConfigColor NascentChaosColor = new(new Vector4(240f / 255f, 176f / 255f, 0f / 255f, 100f / 100f));
         #endregion
     }


### PR DESCRIPTION
Continued from the previous merged PRs.

-Only Show When Active-checkbox for every bar so that people can customize what they hide when not active.
-- HideWhenFull-option for PLD/DRK mana.
- On bars that are shown, only show text if it has a value over 0.
- Implemented Slan's "The Great Restyling" where missing.
- Some general cleanup.