### PR TITLE
More config nesting changes

### DIFF
--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -552,15 +552,19 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class NestedConfigAttribute : OrderAttribute
+    public class NestedConfigAttribute : Attribute
     {
         public string friendlyName;
+        public int pos;
         public bool separator = true;
         public bool spacing = false;
+        public string? collapseWith = "Enabled";
 
-        public NestedConfigAttribute(string friendlyName, int pos) : base(pos)
+        public NestedConfigAttribute(string friendlyName, int pos)
         {
             this.friendlyName = friendlyName;
+            this.pos = pos;
+
         }
     }
 

--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -552,19 +552,15 @@ namespace DelvUI.Config.Attributes
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class NestedConfigAttribute : Attribute
+    public class NestedConfigAttribute : OrderAttribute
     {
         public string friendlyName;
-        public int pos;
         public bool separator = true;
         public bool spacing = false;
-        public string? collapseWith = null;
 
-        public NestedConfigAttribute(string friendlyName, int pos)
+        public NestedConfigAttribute(string friendlyName, int pos) : base(pos)
         {
             this.friendlyName = friendlyName;
-            this.pos = pos;
-
         }
     }
 

--- a/DelvUI/Config/Tree/ConfigNode.cs
+++ b/DelvUI/Config/Tree/ConfigNode.cs
@@ -708,6 +708,11 @@ namespace DelvUI.Config.Tree
         public bool HasSeparator = true;
         public bool HasSpacing = false;
 
+        public FieldInfo? ParentCollapseField = null;
+        public PluginConfigObject? ParentConfigObject = null;
+
+        private List<KeyValuePair<int, object>> DrawList = null;
+
         public PluginConfigObject ConfigObject
         {
             get => _configObject;
@@ -806,82 +811,86 @@ namespace DelvUI.Config.Tree
 
         private void DrawWithID(ref bool changed, string? ID = null)
         {
-            FieldInfo[] fields = ConfigObject.GetType().GetFields();
-            List<KeyValuePair<int, object>> drawList = new();
-            List<CategoryField> collapseWithList = new();
-
-            foreach (FieldInfo field in fields)
+            // Only do this stuff the first time the config page is loaded
+            if (DrawList == null)
             {
-                bool wasAdded = false;
+                DrawList = new List<KeyValuePair<int, object>>();
+                FieldInfo[] fields = ConfigObject.GetType().GetFields();
+                List<CategoryField> collapseWithList = new();
 
-                foreach (object attribute in field.GetCustomAttributes(true))
+                foreach (FieldInfo field in fields)
                 {
-                    if (attribute is OrderAttribute orderAttribute)
+                    bool wasAdded = false;
+
+                    foreach (object attribute in field.GetCustomAttributes(true))
                     {
-                        CategoryField categoryField = new CategoryField(field, ConfigObject, ID);
-
-                        // By default the 'Enabled' checkbox (inherited from PluginConfigObject) is considered the parent of all config items,
-                        // so if the ConfigObject is marked as undisableable, we bypass adding items as children *only* if their parent was the 'Enabled' field.
-                        if (orderAttribute.collapseWith is null || (!ConfigObject.Disableable && orderAttribute.collapseWith.Equals("Enabled")))
+                        if (attribute is NestedConfigAttribute nestedConfigAttribute && _nestedConfigPageNodes.TryGetValue(field.Name, out ConfigPageNode? node))
                         {
-                            drawList.Add(new KeyValuePair<int, object>(orderAttribute.pos, categoryField));
-                        }
-                        else
-                        {
-                            collapseWithList.Add(categoryField);
-                        }
-
-                        wasAdded = true;
-                    }
-                    else if (attribute is NestedConfigAttribute nestedConfigAttribute && _nestedConfigPageNodes.TryGetValue(field.Name, out ConfigPageNode? node))
-                    {
-                        node.HasSeparator = nestedConfigAttribute.separator;
-                        node.HasSpacing = nestedConfigAttribute.spacing;
-                        drawList.Add(new KeyValuePair<int, object>(nestedConfigAttribute.pos, node));
-                        wasAdded = true;
-                    }
-                }
-
-                if (!wasAdded)
-                {
-                    drawList.Add(new KeyValuePair<int, object>(int.MaxValue, new CategoryField(field, ConfigObject, ID)));
-                }
-            }
-
-            // Loop through nodes that should have a parent and build those relationships
-            foreach (CategoryField categoryField in collapseWithList)
-            {
-                foreach (object attribute in categoryField.MainField.GetCustomAttributes(true))
-                {
-                    if (attribute is OrderAttribute orderAttribute && orderAttribute.collapseWith is not null)
-                    {
-                        FieldInfo? parentField = fields.Where(f => f.Name.Equals(orderAttribute.collapseWith)).FirstOrDefault();
-                        if (parentField is not null)
-                        {
-                            // The CategoryField for the parent could either be in the drawList (if it is the root) or the collapseWithList (if there is multi-layered nesting)
-                            // Create a union of the CategoryFields that already exist in the drawList and the collapseWithList, then search for the parent field.
-                            // This looks incredibly gross but it's probably the cleanest way to do it without an extremely heavy refactor of the code above.
-                            CategoryField? parentCategoryField = drawList
-                                .Where(kvp => kvp.Value is CategoryField)
-                                .Select(kvp => kvp.Value as CategoryField)
-                                .Union(collapseWithList)
-                                .Where(categoryField => categoryField is not null && parentField.Equals(categoryField.MainField))
-                                .FirstOrDefault();
-
-                            if (parentCategoryField is not null)
+                            node.HasSeparator = nestedConfigAttribute.separator;
+                            node.HasSpacing = nestedConfigAttribute.spacing;
+                            if (nestedConfigAttribute.collapseWith is not null)
                             {
-                                parentCategoryField.CollapseControl = true;
-                                categoryField.Depth = categoryField.HasSeparator ? 0 : parentCategoryField.Depth + 1;
-                                parentCategoryField.AddChild(orderAttribute.pos, categoryField);
+                                node.ParentCollapseField = fields.Where(f => f.Name.Equals(nestedConfigAttribute.collapseWith)).FirstOrDefault();
+                                node.ParentConfigObject = ConfigObject;
                             }
+
+                            DrawList.Add(new KeyValuePair<int, object>(nestedConfigAttribute.pos, node));
+                            wasAdded = true;
+                        }
+                        else if (attribute is OrderAttribute orderAttribute)
+                        {
+                            CategoryField categoryField = new CategoryField(field, ConfigObject, ID);
+
+                            // By default the 'Enabled' checkbox (inherited from PluginConfigObject) is considered the parent of all config items,
+                            // so if the ConfigObject is marked as undisableable, we bypass adding items as children *only* if their parent was the 'Enabled' field.
+                            if (orderAttribute.collapseWith is null || (!ConfigObject.Disableable && orderAttribute.collapseWith.Equals("Enabled")))
+                            {
+                                DrawList.Add(new KeyValuePair<int, object>(orderAttribute.pos, categoryField));
+                            }
+                            else
+                            {
+                                collapseWithList.Add(categoryField);
+                            }
+
+                            wasAdded = true;
+                        }
+                    }
+
+                    if (!wasAdded)
+                    {
+                        DrawList.Add(new KeyValuePair<int, object>(int.MaxValue, new CategoryField(field, ConfigObject, ID)));
+                    }
+                }
+
+                // Loop through nodes that should have a parent and build those relationships
+                foreach (CategoryField categoryField in collapseWithList)
+                {
+                    OrderAttribute? orderAttribute = categoryField.MainField.GetCustomAttributes(false).Where(a => a is OrderAttribute).FirstOrDefault() as OrderAttribute;
+                    if (orderAttribute is not null && orderAttribute.collapseWith is not null)
+                    {
+                        // The CategoryField for the parent could either be in the drawList (if it is the root) or the collapseWithList (if there is multi-layered nesting)
+                        // Create a union of the CategoryFields that already exist in the drawList and the collapseWithList, then search for the parent field.
+                        // This looks incredibly gross but it's probably the cleanest way to do it without an extremely heavy refactor of the code above.
+                        CategoryField? parentCategoryField = DrawList
+                            .Where(kvp => kvp.Value is CategoryField)
+                            .Select(kvp => kvp.Value as CategoryField)
+                            .Union(collapseWithList)
+                            .Where(categoryField => categoryField is not null && orderAttribute.collapseWith.Equals(categoryField.MainField.Name))
+                            .FirstOrDefault();
+
+                        if (parentCategoryField is not null)
+                        {
+                            parentCategoryField.CollapseControl = true;
+                            categoryField.Depth = categoryField.HasSeparator ? 0 : parentCategoryField.Depth + 1;
+                            parentCategoryField.AddChild(orderAttribute.pos, categoryField);
                         }
                     }
                 }
+
+                DrawList.Sort((x, y) => x.Key - y.Key);
             }
 
-            drawList.Sort((x, y) => x.Key - y.Key);
-
-            foreach (KeyValuePair<int, object> pair in drawList)
+            foreach (KeyValuePair<int, object> pair in DrawList)
             {
                 if (pair.Value is CategoryField categoryField)
                 {
@@ -889,6 +898,16 @@ namespace DelvUI.Config.Tree
                 }
                 else if (pair.Value is ConfigPageNode node)
                 {
+                    // If the parent checkbox of this nested config is disabled, don't draw this nestedconfig
+                    if (node.ParentCollapseField is not null && node.ParentConfigObject is not null)
+                    {
+                        if (!(Attribute.IsDefined(node.ParentCollapseField, typeof(CheckboxAttribute)) && 
+                            (node.ParentCollapseField.GetValue(node.ParentConfigObject) as bool? ?? false)))
+                        {
+                            continue;
+                        }
+                    }
+
                     ImGui.BeginGroup();
                     if (node.HasSeparator)
                     {


### PR DESCRIPTION
Stuff this change does:
- Allows NestedConfig to collapse when it's parent is disabled
- Fixes bug with config becoming indented after a separator
- Saves the layout of each ConfigPageNode so the layout doesn't get re-calculated each frame.