### PR TITLE
Only Show When Hidden for Casters (minus BLM)

### DIFF
--- a/DelvUI/Interface/Jobs/DancerHud.cs
+++ b/DelvUI/Interface/Jobs/DancerHud.cs
@@ -104,10 +104,7 @@ namespace DelvUI.Interface.Jobs
         {
             DNCGauge gauge = Plugin.JobGauges.Get<DNCGauge>();
 
-            if (gauge.Esprit == 0 && Config.OnlyShowEspritWhenActive)
-            {
-                return;
-            }
+            if (gauge.Esprit == 0 && Config.OnlyShowEspritWhenActive) { return; }
 
             var xPos = origin.X + Config.Position.X + Config.EspritGaugePosition.X - Config.EspritGaugeSize.X / 2f;
             var yPos = origin.Y + Config.Position.Y + Config.EspritGaugePosition.Y - Config.EspritGaugeSize.Y / 2f;
@@ -125,7 +122,7 @@ namespace DelvUI.Interface.Jobs
             {
                 builder.AddInnerBar(gauge.Esprit, 100, Config.EspritGaugeColor);
             }
-            
+
             if (Config.EspritTextEnabled && gauge.Esprit != 0)
             {
                 builder.SetTextMode(BarTextMode.EachChunk).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
@@ -167,10 +164,7 @@ namespace DelvUI.Interface.Jobs
         {
             var gauge = Plugin.JobGauges.Get<DNCGauge>();
 
-            if (!gauge.IsDancing)
-            {
-                return;
-            }
+            if (!gauge.IsDancing) { return; }
 
             byte chunkCount = 0;
             List<PluginConfigColor> chunkColors = new List<PluginConfigColor>();
@@ -295,10 +289,7 @@ namespace DelvUI.Interface.Jobs
         {
             IEnumerable<Status> standardFinishBuff = player.StatusList.Where(o => o.StatusId is 1821 or 2024 or 2105 or 2113);
 
-            if (!standardFinishBuff.Any() && Config.OnlyShowStandardBarWhenActive)
-            {
-                return;
-            }
+            if (!standardFinishBuff.Any() && Config.OnlyShowStandardBarWhenActive) { return; }
 
             var xPos = origin.X + Config.Position.X + Config.StandardBarPosition.X - Config.StandardBarSize.X / 2f;
             var yPos = origin.Y + Config.Position.Y + Config.StandardBarPosition.Y - Config.StandardBarSize.Y / 2f;
@@ -326,27 +317,10 @@ namespace DelvUI.Interface.Jobs
             IEnumerable<Status> windmillBuff = player.StatusList.Where(o => o.StatusId is 1816);
             IEnumerable<Status> showerBuff = player.StatusList.Where(o => o.StatusId is 1817);
 
-            float cascadeTimer = 0f;
-            float fountainTimer = 0f;
-            float windmillTimer = 0f;
-            float showerTimer = 0f;
-
-            if (cascadeBuff.Any())
-            {
-                cascadeTimer = Math.Abs(cascadeBuff.First().RemainingTime);
-            }
-            if (fountainBuff.Any())
-            {
-                fountainTimer = Math.Abs(fountainBuff.First().RemainingTime);
-            }
-            if (windmillBuff.Any())
-            {
-                windmillTimer = Math.Abs(windmillBuff.First().RemainingTime);
-            }
-            if (showerBuff.Any())
-            {
-                showerTimer = Math.Abs(showerBuff.First().RemainingTime);
-            }
+            float cascadeTimer = cascadeBuff.Any() ? Math.Abs(cascadeBuff.First().RemainingTime) : 0f;
+            float fountainTimer = fountainBuff.Any() ? Math.Abs(fountainBuff.First().RemainingTime) : 0f;
+            float windmillTimer = windmillBuff.Any() ? Math.Abs(windmillBuff.First().RemainingTime) : 0f;
+            float showerTimer = showerBuff.Any() ? Math.Abs(showerBuff.First().RemainingTime) : 0f;            
 
             if (cascadeTimer == 0 && fountainTimer == 0 && windmillTimer == 0 && showerTimer == 0 && Config.OnlyShowProcsWhenActive)
             {
@@ -468,11 +442,11 @@ namespace DelvUI.Interface.Jobs
         [Order(105)]
         public bool BuffBarEnabled = true;
 
-        [DragFloat2("Buffs Position" + "##Buff", min = -4000f, max = 4000f)]
+        [DragFloat2("Position" + "##Buff", min = -4000f, max = 4000f)]
         [Order(110, collapseWith = nameof(BuffBarEnabled))]
         public Vector2 BuffBarPosition = new(0, -32);
 
-        [DragFloat2("Buffs Size" + "##Buff", min = 1f, max = 2000f)]
+        [DragFloat2("Size" + "##Buff", min = 1f, max = 2000f)]
         [Order(115, collapseWith = nameof(BuffBarEnabled))]
         public Vector2 BuffBarSize = new(254, 20);
 
@@ -534,7 +508,7 @@ namespace DelvUI.Interface.Jobs
         #region steps
         [Checkbox("Steps", separator = true)]
         [Order(185)]
-        public bool StepBarEnabled = true;        
+        public bool StepBarEnabled = true;
 
         [Checkbox("Step Glow" + "##Step")]
         [Order(195, collapseWith = nameof(StepBarEnabled))]
@@ -604,7 +578,7 @@ namespace DelvUI.Interface.Jobs
 
         [DragFloat("Spacing" + "##Procs", min = -4000f, max = 4000f)]
         [Order(275, collapseWith = nameof(ProcBarEnabled))]
-        public float ProcBarChunkPadding = 2;        
+        public float ProcBarChunkPadding = 2;
 
         [ColorEdit4("Flourishing Cascade" + "##Procs")]
         [Order(280, collapseWith = nameof(ProcBarEnabled))]

--- a/DelvUI/Interface/Jobs/DragoonHud.cs
+++ b/DelvUI/Interface/Jobs/DragoonHud.cs
@@ -194,7 +194,7 @@ namespace DelvUI.Interface.Jobs
 
             if (disembowelBuff.Any())
             {
-                duration = Math.Abs(disembowelBuff.First().RemainingTime);                
+                duration = Math.Abs(disembowelBuff.First().RemainingTime);
             }
 
             if (duration == 0f && Config.OnlyShowDisembowelWhenActive)
@@ -303,7 +303,7 @@ namespace DelvUI.Interface.Jobs
         #endregion
 
         #region Blood Bar
-        [Checkbox("Show Blood Bar", separator = true)]
+        [Checkbox("Blood of the Dragon", separator = true)]
         [Order(120)]
         public bool ShowBloodBar = true;
 
@@ -311,23 +311,23 @@ namespace DelvUI.Interface.Jobs
         [Order(125, collapseWith = nameof(ShowBloodBar))]
         public bool OnlyShowBloodBarWhenActive = false;
 
-        [DragFloat2("Blood Bar Size" + "##Blood", max = 2000f)]
+        [Checkbox("Timer" + "##Blood")]
         [Order(130, collapseWith = nameof(ShowBloodBar))]
-        public Vector2 BloodBarSize = new(254, 20);
+        public bool ShowBloodBarText = true;
 
-        [DragFloat2("Blood Bar Position" + "##Blood", min = -4000f, max = 4000f)]
+        [DragFloat2("Position" + "##Blood", min = -4000f, max = 4000f)]
         [Order(135, collapseWith = nameof(ShowBloodBar))]
         public Vector2 BloodBarPosition = new(0, -10);
 
-        [Checkbox("Show Blood Bar Text" + "##Blood")]
+        [DragFloat2("Size" + "##Blood", max = 2000f)]
         [Order(140, collapseWith = nameof(ShowBloodBar))]
-        public bool ShowBloodBarText = true;
+        public Vector2 BloodBarSize = new(254, 20);
 
-        [ColorEdit4("Blood Of The Dragon Bar Color" + "##Blood")]
+        [ColorEdit4("Blood of the Dragon" + "##Blood")]
         [Order(145, collapseWith = nameof(ShowBloodBar))]
         public PluginConfigColor BloodOfTheDragonColor = new(new Vector4(78f / 255f, 198f / 255f, 238f / 255f, 100f / 100f));
 
-        [ColorEdit4("Life Of The Dragon Bar Color" + "##Blood")]
+        [ColorEdit4("Life of the Dragon" + "##Blood")]
         [Order(150, collapseWith = nameof(ShowBloodBar))]
         public PluginConfigColor LifeOfTheDragonColor = new(new Vector4(139f / 255f, 24f / 255f, 24f / 255f, 100f / 100f));
         #endregion

--- a/DelvUI/Interface/Jobs/PaladinHud.cs
+++ b/DelvUI/Interface/Jobs/PaladinHud.cs
@@ -209,11 +209,8 @@ namespace DelvUI.Interface.Jobs
 
             if (actor is BattleChara target)
             {
-                var goringBlade = target.StatusList.Where(o => o.StatusId is 725 && o.SourceID == player.ObjectId);
-                if (goringBlade.Any())
-                {
-                    duration = Math.Abs(goringBlade.First().RemainingTime);
-                }
+                IEnumerable<Status> goringBlade = target.StatusList.Where(o => o.StatusId is 725 && o.SourceID == player.ObjectId);
+                duration = goringBlade.Any() ? Math.Abs(goringBlade.First().RemainingTime) : 0f;
             }
 
             if (Config.OnlyShowGoringBladeWhenActive && duration is 0) { return; }

--- a/DelvUI/Interface/Jobs/RedMageHud.cs
+++ b/DelvUI/Interface/Jobs/RedMageHud.cs
@@ -169,7 +169,7 @@ namespace DelvUI.Interface.Jobs
         private void DrawBlackManaBar(Vector2 origin)
         {
             var gauge = (int)Plugin.JobGauges.Get<RDMGauge>().BlackMana;
-            if(Config.OnlyShowBlackManaWhenActive && gauge is 0) { return; }
+            if (Config.OnlyShowBlackManaWhenActive && gauge is 0) { return; }
             var thresholdRatio = Config.BlackManaBarInverted ? 0.2f : 0.8f;
 
             var position = new Vector2(
@@ -183,9 +183,7 @@ namespace DelvUI.Interface.Jobs
         private void DrawAccelerationBar(Vector2 origin, PlayerCharacter player)
         {
             var accelBuff = player.StatusList.Where(o => o.StatusId == 1238);
-            var stackCount = 0;
-
-            if (accelBuff.Any()) { stackCount = accelBuff.First().StackCount; }
+            int stackCount = accelBuff.Any() ? accelBuff.First().StackCount : 0;
             if (Config.OnlyShowAccelerationWhenActive && stackCount is 0) { return; }
 
             var position = new Vector2(
@@ -207,8 +205,7 @@ namespace DelvUI.Interface.Jobs
         private void DrawDualCastBar(Vector2 origin, PlayerCharacter player)
         {
             var dualCastBuff = player.StatusList.Where(o => o.StatusId is 1249);
-            var dualCastDuration = 0f;
-            if (dualCastBuff.Any()) { dualCastDuration = Math.Abs(dualCastBuff.First().RemainingTime); }
+            var dualCastDuration = dualCastBuff.Any() ? Math.Abs(dualCastBuff.First().RemainingTime) : 0;
             if (Config.OnlyShowDualcastWhenActive && dualCastDuration is 0) { return; }
 
             var position = new Vector2(
@@ -228,13 +225,9 @@ namespace DelvUI.Interface.Jobs
 
         private void DrawVerstoneProc(Vector2 origin, PlayerCharacter player)
         {
-            var duration = 0;
             var verstone = player.StatusList.Where(o => o.StatusId is 1235);
+            int duration = verstone.Any() ? (int)Math.Abs(verstone.First().RemainingTime) : 0;
 
-            if (verstone.Any())
-            {
-                duration = (int)Math.Abs(verstone.First().RemainingTime);
-            }
             if (Config.OnlyShowVerstoneWhenActive && duration is 0) { return; }
 
             var position = new Vector2(
@@ -247,13 +240,9 @@ namespace DelvUI.Interface.Jobs
 
         private void DrawVerfireProc(Vector2 origin, PlayerCharacter player)
         {
-            var duration = 0;
             var verfire = player.StatusList.Where(o => o.StatusId is 1234);
+            int duration = verfire.Any() ? (int)Math.Abs(verfire.First().RemainingTime) : 0;
 
-            if (verfire.Any())
-            {
-                duration = (int)Math.Abs(verfire.First().RemainingTime);
-            }
             if (Config.OnlyShowVerfireWhenActive && duration is 0) { return; }
 
             var position = new Vector2(
@@ -359,7 +348,7 @@ namespace DelvUI.Interface.Jobs
         [Order(55, collapseWith = nameof(ShowWhiteManaBar))]
         public bool ShowWhiteManaValue = true;
 
-        [Checkbox("Invert" + "##WhiteMana")]
+        [Checkbox("Inverted" + "##WhiteMana")]
         [Order(60, collapseWith = nameof(ShowWhiteManaBar))]
         public bool WhiteManaBarInverted = true;
 
@@ -389,7 +378,7 @@ namespace DelvUI.Interface.Jobs
         [Order(85, collapseWith = nameof(ShowBlackManaBar))]
         public bool ShowBlackManaValue = true;
 
-        [Checkbox("Invert" + "##BlackMana")]
+        [Checkbox("Inverted" + "##BlackMana")]
         [Order(90, collapseWith = nameof(ShowBlackManaBar))]
         public bool BlackManaBarInverted = false;
 
@@ -475,7 +464,7 @@ namespace DelvUI.Interface.Jobs
         [Order(165, collapseWith = nameof(ShowVerstoneProcs))]
         public bool ShowVerstoneText = true;
 
-        [Checkbox("Invert" + "##Verstone")]
+        [Checkbox("Inverted" + "##Verstone")]
         [Order(170, collapseWith = nameof(ShowVerstoneProcs))]
         public bool InvertVerstoneBar = true;
 
@@ -505,7 +494,7 @@ namespace DelvUI.Interface.Jobs
         [Order(195, collapseWith = nameof(ShowVerfireProcs))]
         public bool ShowVerfireText = true;
 
-        [Checkbox("Invert" + "##Verfire")]
+        [Checkbox("Inverted" + "##Verfire")]
         [Order(200, collapseWith = nameof(ShowVerfireProcs))]
         public bool InvertVerfireBar = false;
 

--- a/DelvUI/Interface/Jobs/SamuraiHud.cs
+++ b/DelvUI/Interface/Jobs/SamuraiHud.cs
@@ -93,16 +93,13 @@ namespace DelvUI.Interface.Jobs
                 origin.Y + Config.Position.Y + Config.KenkiBarPosition.Y - Config.KenkiBarSize.Y / 2f
             );
 
-            if (gauge.Kenki == 0 && Config.OnlyShowKenkiWhenActive)
-            {
-                return;
-            }
+            if (gauge.Kenki == 0 && Config.OnlyShowKenkiWhenActive) { return; }
 
             var kenkiBuilder = BarBuilder.Create(pos, Config.KenkiBarSize)
                 .SetBackgroundColor(EmptyColor.Base)
                 .AddInnerBar(gauge.Kenki, 100, Config.KenkiColor);
 
-            if (Config.ShowKenkiText)
+            if (Config.ShowKenkiText && gauge.Kenki != 0)
             {
                 kenkiBuilder.SetTextMode(BarTextMode.Single).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
             }
@@ -121,16 +118,9 @@ namespace DelvUI.Interface.Jobs
 
             var actorId = player.ObjectId;
             var higanbana = target.StatusList.Where(o => o.StatusId is 1228 or 1319 && o.SourceID == actorId);
-            var higanbanaDuration = 0f;
-            if (higanbana.Any())
-            {
-                higanbanaDuration = Math.Abs(higanbana.First().RemainingTime);
-            }
+            var higanbanaDuration = higanbana.Any() ? Math.Abs(higanbana.First().RemainingTime) : 0f;
 
-            if (higanbanaDuration == 0 && Config.OnlyShowHiganbanaWhenActive)
-            {
-                return;
-            }
+            if (higanbanaDuration == 0 && Config.OnlyShowHiganbanaWhenActive) { return; }
 
             var higanbanaColor = higanbanaDuration > 5 ? Config.HiganbanaColor : Config.HiganbanaExpiryColor;
             var pos = new Vector2(
@@ -164,12 +154,8 @@ namespace DelvUI.Interface.Jobs
 
             // shifu
             var shifu = player.StatusList.Where(o => o.StatusId is 1299).ToList();
-            var shifuDuration = 0f;
-            if (shifu.Any())
-            {
-                shifuDuration = Math.Abs(shifu.First().RemainingTime);
-            }
-            
+            var shifuDuration = shifu.Any() ? Math.Abs(shifu.First().RemainingTime) : 0f;
+
             var shifuPos = new Vector2(
                 origin.X + Config.Position.X + Config.BuffsBarPosition.X + (2 * order[0] - 1) * Config.BuffsBarSize.X / 2f - order[0] * buffsSize.X,
                 origin.Y + Config.Position.Y + Config.BuffsBarPosition.Y - Config.BuffsBarSize.Y / 2f
@@ -181,20 +167,16 @@ namespace DelvUI.Interface.Jobs
             {
                 shifuBuilder.AddInnerBar(shifuDuration, 40f, Config.ShifuColor)
                 .SetFlipDrainDirection(true);
-                
+
                 if (Config.ShowBuffsText)
                 {
-                    shifuBuilder.SetTextMode(BarTextMode.Single).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);                    
+                    shifuBuilder.SetTextMode(BarTextMode.Single).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
                 }
             }
 
             // jinpu
             var jinpu = player.StatusList.Where(o => o.StatusId is 1298).ToList();
-            var jinpuDuration = 0f;
-            if (jinpu.Any())
-            {
-                jinpuDuration = Math.Abs(jinpu.First().RemainingTime);
-            }
+            var jinpuDuration = jinpu.Any() ? Math.Abs(jinpu.First().RemainingTime) : 0f;
 
             var jinpuPos = new Vector2(
                 origin.X + Config.Position.X + Config.BuffsBarPosition.X + (2 * order[1] - 1) * Config.BuffsBarSize.X / 2f - order[1] * buffsSize.X,
@@ -208,9 +190,9 @@ namespace DelvUI.Interface.Jobs
             {
                 jinpuBuilder.AddInnerBar(jinpuDuration, 40f, Config.JinpuColor)
                     .SetFlipDrainDirection(false);
-                
+
                 if (Config.ShowBuffsText)
-                {                    
+                {
                     jinpuBuilder.SetTextMode(BarTextMode.Single).SetText(BarTextPosition.CenterMiddle, BarTextType.Current);
                 }
             }
@@ -229,10 +211,7 @@ namespace DelvUI.Interface.Jobs
         {
             var gauge = Plugin.JobGauges.Get<SAMGauge>();
 
-            if (Config.OnlyShowSenWhenActive && !gauge.HasKa && !gauge.HasGetsu && !gauge.HasSetsu)
-            {
-                return;
-            }
+            if (Config.OnlyShowSenWhenActive && !gauge.HasKa && !gauge.HasGetsu && !gauge.HasSetsu) { return; }
 
             var senBarWidth = (Config.SenBarSize.X - Config.SenBarPadding * 2) / 3f;
             var senBarSize = new Vector2(senBarWidth, Config.SenBarSize.Y);
@@ -262,10 +241,7 @@ namespace DelvUI.Interface.Jobs
         {
             var gauge = Plugin.JobGauges.Get<SAMGauge>();
 
-            if (Config.OnlyShowMeditationWhenActive && gauge.MeditationStacks == 0)
-            {
-                return;
-            }
+            if (Config.OnlyShowMeditationWhenActive && gauge.MeditationStacks == 0) { return; }
 
             var pos = new Vector2(
                 origin.X + Config.Position.X + Config.MeditationBarPosition.X - Config.MeditationBarSize.X / 2f,
@@ -317,7 +293,7 @@ namespace DelvUI.Interface.Jobs
 
         [ColorEdit4("Color" + "##Kenki")]
         [Order(55, collapseWith = nameof(ShowKenkiBar))]
-        public PluginConfigColor KenkiColor = new PluginConfigColor(new(255f / 255f, 82f / 255f, 82f / 255f, 53f / 100f));        
+        public PluginConfigColor KenkiColor = new PluginConfigColor(new(255f / 255f, 82f / 255f, 82f / 255f, 53f / 100f));
         #endregion
 
         #region Sen
@@ -449,7 +425,7 @@ namespace DelvUI.Interface.Jobs
 
         [ColorEdit4("Expiry Color" + "##Higanbana")]
         [Order(210, collapseWith = nameof(ShowHiganbanaBar))]
-        public PluginConfigColor HiganbanaExpiryColor = new PluginConfigColor(new(230f / 255f, 33f / 255f, 33f / 255f, 53f / 100f));        
+        public PluginConfigColor HiganbanaExpiryColor = new PluginConfigColor(new(230f / 255f, 33f / 255f, 33f / 255f, 53f / 100f));
         #endregion
 
     }


### PR DESCRIPTION
Continued from the previous merged PRs. BLM is missing because I still need to unlock it... only job missing. Will get around to leveling it 3 levels at least to 30.

- Only Show When Active-checkbox for every bar so that people can customize what they hide when not active.
- On bars that are shown, only show text if it has a value over 0.
- Change all instances of FirstOrDefault to find buff/debuff in the StatusList to Where.
- RDM Dual Cast vertical/inverted/bar cooldown options.
- Implemented Slan's "The Great Restyling" where missing.
- Some general cleanup and applied missing styling from some of the previous PRs.