### PR TITLE
Deduplicate statuses in custom effects

### DIFF
--- a/DelvUI/Interface/StatusEffects/CustomEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/CustomEffectsListHud.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Dalamud.Game.ClientState.Objects.Types;
 
 namespace DelvUI.Interface.StatusEffects

--- a/DelvUI/Interface/StatusEffects/CustomEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/CustomEffectsListHud.cs
@@ -16,6 +16,11 @@ namespace DelvUI.Interface.StatusEffects
             var list = StatusEffectDataList(TargetActor);
             list.AddRange(StatusEffectDataList(Actor));
 
+            // cull duplicate statuses from the same source
+            list = list.GroupBy(s => new { s.Status.StatusID, s.Status.SourceID })
+                .Select(status => status.First())
+                .ToList();
+
             // show mine first
             if (Config.ShowMineFirst)
             {


### PR DESCRIPTION
Since "custom effects" seems to be primarily about tracking buffs, it doesn't make sense to show two icons for each raid buff that you and your target share (see image). This PR hides duplicate statuses if they were applied by the same source player.

![image](https://user-images.githubusercontent.com/65056303/135703512-07e2bc61-7fb6-40b6-bf82-e83a50d910cc.png)
