### PR TITLE
Add invariant culture so decimals don't show up as commas

### DIFF
--- a/DelvUI/Interface/Jobs/AstrologianHud.cs
+++ b/DelvUI/Interface/Jobs/AstrologianHud.cs
@@ -13,6 +13,7 @@ using ImGuiNET;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 
@@ -456,7 +457,7 @@ namespace DelvUI.Interface.Jobs
                                  BarTextPosition.CenterMiddle,
                                  BarTextType.Custom,
                                  Config.ShowLightspeedTextBar && lightspeedDuration != 0
-                                     ? Config.EnableDecimalLightspeedBar ? Math.Abs(lightspeedDuration).ToString("N1") : lightspeedDuration.ToString("N0")
+                                     ? Config.EnableDecimalLightspeedBar ? Math.Abs(lightspeedDuration).ToString("N1", CultureInfo.InvariantCulture) : lightspeedDuration.ToString("N0")
                                      : ""
                              )
                              .Build();
@@ -503,7 +504,7 @@ namespace DelvUI.Interface.Jobs
                                         BarTextPosition.CenterMiddle,
                                         BarTextType.Custom,
                                         Config.ShowStarTextBar && starDuration != 0
-                                            ? Config.EnableDecimalStarBar ? Math.Abs(starDuration).ToString("N1") : starDuration.ToString("N0")
+                                            ? Config.EnableDecimalStarBar ? Math.Abs(starDuration).ToString("N1", CultureInfo.InvariantCulture) : starDuration.ToString("N0")
                                             : ""
                                     );
 

--- a/DelvUI/Interface/Party/PartyFramesBar.cs
+++ b/DelvUI/Interface/Party/PartyFramesBar.cs
@@ -5,6 +5,7 @@ using DelvUI.Interface.GeneralElements;
 using DelvUI.Interface.StatusEffects;
 using ImGuiNET;
 using System;
+using System.Globalization;
 using System.Numerics;
 
 namespace DelvUI.Interface.Party
@@ -311,7 +312,7 @@ namespace DelvUI.Interface.Party
             if (showingRaise)
             {
                 var duration = Math.Abs(Member.RaiseTime!.Value);
-                var text = duration < 10 ? duration.ToString("N1") : Utils.DurationToString(duration);
+                var text = duration < 10 ? duration.ToString("N1", CultureInfo.InvariantCulture) : Utils.DurationToString(duration);
                 _raiseTrackerConfig.LabelConfig.SetText(text);
                 _raiseLabelHud.Draw(Position, _config.Size);
             }


### PR DESCRIPTION
This changes certain formatting strings to show decimals like 5.9 as 5.9 instead of 5,9 etc.