### PR TITLE
Hides delvui when interacting with npcs or quest related stuff

### DIFF
--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -349,7 +349,8 @@ namespace DelvUI.Interface
         {
             // when in quest dialogs and events, hide everything except castbars
             // this includes talking to npcs or interacting with quest related stuff
-            if (Plugin.Condition[ConditionFlag.OccupiedInQuestEvent])
+            if (Plugin.Condition[ConditionFlag.OccupiedInQuestEvent] ||
+                Plugin.Condition[ConditionFlag.OccupiedInEvent])
             {
                 // we have to wait a bit to avoid weird flickering when clicking shiny stuff
                 // we hide delvui after half a second passed in this state

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -1,8 +1,6 @@
-using Dalamud.Game.ClientState;
+using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Interface;
-using Dalamud.Plugin;
 using DelvUI.Config;
-using DelvUI.Config.Attributes;
 using DelvUI.Helpers;
 using DelvUI.Interface.GeneralElements;
 using DelvUI.Interface.Jobs;
@@ -13,8 +11,6 @@ using ImGuiNET;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using Dalamud.Game.ClientState.Conditions;
-using Dalamud.Game.ClientState.Objects.Types;
 
 namespace DelvUI.Interface
 {
@@ -31,6 +27,7 @@ namespace DelvUI.Interface
         private List<IHudElementWithActor> _hudElementsUsingTargetOfTarget = null!;
         private List<IHudElementWithActor> _hudElementsUsingFocusTarget = null!;
 
+        private PlayerCastbarHud _playerCastbarHud = null!;
         private CustomEffectsListHud _customEffectsHud = null!;
         private PrimaryResourceHud _primaryResourceHud = null!;
         private JobHud? _jobHud = null;
@@ -171,9 +168,9 @@ namespace DelvUI.Interface
         private void CreateCastbars()
         {
             var playerCastbarConfig = ConfigurationManager.Instance.GetConfigObject<PlayerCastbarConfig>();
-            var playerCastbar = new PlayerCastbarHud("DelvUI_playerCastbar", playerCastbarConfig, "Player Castbar");
-            _hudElements.Add(playerCastbar);
-            _hudElementsUsingPlayer.Add(playerCastbar);
+            _playerCastbarHud = new PlayerCastbarHud("DelvUI_playerCastbar", playerCastbarConfig, "Player Castbar");
+            _hudElements.Add(_playerCastbarHud);
+            _hudElementsUsingPlayer.Add(_playerCastbarHud);
 
             var targetCastbarConfig = ConfigurationManager.Instance.GetConfigObject<TargetCastbarConfig>();
             var targetCastbar = new TargetCastbarHud("DelvUI_targetCastbar", targetCastbarConfig, "Target Castbar");
@@ -281,6 +278,16 @@ namespace DelvUI.Interface
 
             UpdateJob();
             AssignActors();
+
+            // when in quest dialogs and events, hide everything except castbars
+            // this includes talking to npcs or interacting with quest related stuff
+            if (Plugin.Condition[ConditionFlag.OccupiedInQuestEvent])
+            {
+                _playerCastbarHud?.Draw(_origin);
+
+                ImGui.End();
+                return;
+            }
 
             // grid
             if (_gridConfig is not null && _gridConfig.Enabled)

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -4,6 +4,7 @@ using Dalamud.Game.ClientState;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.JobGauge;
 using Dalamud.Game.ClientState.Objects;
+using Dalamud.Game.ClientState.Party;
 using Dalamud.Game.Command;
 using Dalamud.Game.Gui;
 using Dalamud.Interface;
@@ -14,14 +15,12 @@ using DelvUI.Helpers;
 using DelvUI.Interface;
 using DelvUI.Interface.GeneralElements;
 using DelvUI.Interface.Party;
-using FFXIVClientStructs;
 using ImGuiNET;
 using ImGuiScene;
 using System;
 using System.IO;
 using System.Reflection;
 using SigScanner = Dalamud.Game.SigScanner;
-using Dalamud.Game.ClientState.Party;
 
 namespace DelvUI
 {
@@ -202,12 +201,14 @@ namespace DelvUI
 
         private void Draw()
         {
-            bool hudState = Condition[ConditionFlag.WatchingCutscene]
-                         || Condition[ConditionFlag.WatchingCutscene78]
-                         || Condition[ConditionFlag.OccupiedInCutSceneEvent]
-                         || Condition[ConditionFlag.CreatingCharacter]
-                         || Condition[ConditionFlag.BetweenAreas]
-                         || Condition[ConditionFlag.BetweenAreas51];
+            bool hudState =
+                Condition[ConditionFlag.WatchingCutscene] ||
+                Condition[ConditionFlag.WatchingCutscene78] ||
+                Condition[ConditionFlag.OccupiedInCutSceneEvent] ||
+                Condition[ConditionFlag.CreatingCharacter] ||
+                Condition[ConditionFlag.BetweenAreas] ||
+                Condition[ConditionFlag.BetweenAreas51] ||
+                Condition[ConditionFlag.OccupiedSummoningBell];
 
             UiBuilder.OverrideGameCursor = false;
 


### PR DESCRIPTION
Basically the same behavior as default hotbars.
Main reason for this is so the dialog window doesn't get covered, and it's how the game's UI behave so it looks more natural this way.
Castbar needs to remain though because when you interact with shiny things for quests, you still need to see the cast.