### PR TITLE
uppercase first letter in cases where its missing

### DIFF
--- a/DelvUI/Extensions.cs
+++ b/DelvUI/Extensions.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using System.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using FFXIVClientStructs.FFXIV.Client.System.String;
+using static System.Globalization.CultureInfo;
 
 namespace DelvUI
 {
@@ -119,6 +120,17 @@ namespace DelvUI
             }
 
             return str.Length <= maxLength ? str : str[..maxLength];
+        }
+
+        public static string CheckForUpperCase(this string str)
+        {            
+            var culture = CurrentCulture.TextInfo;
+            if (!string.IsNullOrEmpty(str) && char.IsLetter(str[0]) && !char.IsUpper(str[0]))
+            {
+                str = culture.ToTitleCase(str);
+            }
+
+            return str;
         }
     }
 }

--- a/DelvUI/Interface/GeneralElements/CastbarHud.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarHud.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
+using static System.Globalization.CultureInfo;
 
 namespace DelvUI.Interface.GeneralElements
 {
@@ -93,7 +94,16 @@ namespace DelvUI.Interface.GeneralElements
             // cast name
             var iconSize = Config.ShowIcon ? Config.Size.Y : 0;
             var castNamePos = startPos + new Vector2(iconSize, 0);
-            Config.CastNameConfig.SetText(Config.Preview ? "Cast Name" : (LastUsedCast != null ? LastUsedCast.ActionText : ""));
+
+            var culture = CurrentCulture.TextInfo;
+            string? castName = LastUsedCast?.ActionText;
+
+            if (!string.IsNullOrEmpty(castName) && char.IsLetter(castName[0]) && !char.IsUpper(castName[0]))
+            {
+                castName = culture.ToTitleCase(castName);
+            }
+
+            Config.CastNameConfig.SetText(Config.Preview ? "Cast Name" : (castName != null ? castName : ""));
             _castNameLabel.Draw(startPos + new Vector2(iconSize, 0), Config.Size, Actor);
 
             // cast time

--- a/DelvUI/Interface/GeneralElements/CastbarHud.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarHud.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
-using static System.Globalization.CultureInfo;
 
 namespace DelvUI.Interface.GeneralElements
 {
@@ -94,14 +93,7 @@ namespace DelvUI.Interface.GeneralElements
             // cast name
             var iconSize = Config.ShowIcon ? Config.Size.Y : 0;
             var castNamePos = startPos + new Vector2(iconSize, 0);
-
-            var culture = CurrentCulture.TextInfo;
-            string? castName = LastUsedCast?.ActionText;
-
-            if (!string.IsNullOrEmpty(castName) && char.IsLetter(castName[0]) && !char.IsUpper(castName[0]))
-            {
-                castName = culture.ToTitleCase(castName);
-            }
+            string? castName = LastUsedCast?.ActionText.CheckForUpperCase();
 
             Config.CastNameConfig.SetText(Config.Preview ? "Cast Name" : (castName != null ? castName : ""));
             _castNameLabel.Draw(startPos + new Vector2(iconSize, 0), Config.Size, Actor);

--- a/DelvUI/Interface/GeneralElements/LabelHud.cs
+++ b/DelvUI/Interface/GeneralElements/LabelHud.cs
@@ -1,7 +1,6 @@
 ﻿using DelvUI.Helpers;
 using ImGuiNET;
 using System.Numerics;
-using static System.Globalization.CultureInfo;
 using Dalamud.Game.ClientState.Objects.Types;
 using DelvUI.Config;
 
@@ -28,17 +27,11 @@ namespace DelvUI.Interface.GeneralElements
                 return;
             }
 
-            var culture = CurrentCulture.TextInfo;
             var text = actor == null && actorName == null ?
                 Config.GetText() :
                 TextTags.GenerateFormattedTextFromTags(actor, Config.GetText(), actorName);
 
-            if (!string.IsNullOrEmpty(text) && char.IsLetter(text[0]) && !char.IsUpper(text[0]))
-            {
-                text = culture.ToTitleCase(text);
-            }
-
-            DrawLabel(text, origin, parentSize ?? Vector2.Zero, actor);
+            DrawLabel(actorName != null ? actorName : text, origin, parentSize ?? Vector2.Zero, actor);
         }
 
         private void DrawLabel(string text, Vector2 parentPos, Vector2 parentSize, GameObject? actor = null)

--- a/DelvUI/Interface/GeneralElements/LabelHud.cs
+++ b/DelvUI/Interface/GeneralElements/LabelHud.cs
@@ -1,6 +1,7 @@
 ﻿using DelvUI.Helpers;
 using ImGuiNET;
 using System.Numerics;
+using static System.Globalization.CultureInfo;
 using Dalamud.Game.ClientState.Objects.Types;
 using DelvUI.Config;
 
@@ -27,9 +28,15 @@ namespace DelvUI.Interface.GeneralElements
                 return;
             }
 
+            var culture = CurrentCulture.TextInfo;
             var text = actor == null && actorName == null ?
                 Config.GetText() :
                 TextTags.GenerateFormattedTextFromTags(actor, Config.GetText(), actorName);
+
+            if (!string.IsNullOrEmpty(text) && char.IsLetter(text[0]) && !char.IsUpper(text[0]))
+            {
+                text = culture.ToTitleCase(text);
+            }
 
             DrawLabel(text, origin, parentSize ?? Vector2.Zero, actor);
         }

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using Dalamud.Game.ClientState.Objects.Types;
-using FFXIVClientStructs.FFXIV.Component.GUI;
+using static System.Globalization.CultureInfo;
 
 namespace DelvUI.Interface.GeneralElements
 {
@@ -77,8 +77,19 @@ namespace DelvUI.Interface.GeneralElements
             });
 
             // labels
-            _leftLabel.Draw(startPos, Config.Size, Actor);
-            _rightLabel.Draw(startPos, Config.Size, Actor);
+            var culture = CurrentCulture.TextInfo;
+            string actorName = Actor.Name.ToString();
+            if (!string.IsNullOrEmpty(actorName) && char.IsLetter(actorName[0]) && !char.IsUpper(actorName[0]))
+            {
+                actorName = culture.ToTitleCase(actorName);
+                _leftLabel.Draw(startPos, Config.Size, Actor, actorName);
+                _rightLabel.Draw(startPos, Config.Size, Actor, actorName);
+            }
+            else
+            {
+                _leftLabel.Draw(startPos, Config.Size, Actor);
+                _rightLabel.Draw(startPos, Config.Size, Actor);
+            }
         }
 
         private void DrawChara(ImDrawListPtr drawList, Vector2 startPos, Character chara)

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -76,20 +76,10 @@ namespace DelvUI.Interface.GeneralElements
                 }
             });
 
-            // labels
-            var culture = CurrentCulture.TextInfo;
-            string actorName = Actor.Name.ToString();
-            if (!string.IsNullOrEmpty(actorName) && char.IsLetter(actorName[0]) && !char.IsUpper(actorName[0]))
-            {
-                actorName = culture.ToTitleCase(actorName);
-                _leftLabel.Draw(startPos, Config.Size, Actor, actorName);
-                _rightLabel.Draw(startPos, Config.Size, Actor, actorName);
-            }
-            else
-            {
-                _leftLabel.Draw(startPos, Config.Size, Actor);
-                _rightLabel.Draw(startPos, Config.Size, Actor);
-            }
+            // labels            
+            string actorName = Actor.Name.ToString().CheckForUpperCase();
+            _leftLabel.Draw(startPos, Config.Size, Actor, actorName);
+            _rightLabel.Draw(startPos, Config.Size, Actor, actorName);
         }
 
         private void DrawChara(ImDrawListPtr drawList, Vector2 startPos, Character chara)


### PR DESCRIPTION
Some things like "black chocobo", "aetheryte" etc were showing in all lowercase just a quick fix to check if the string to be drawn is not empty and if so starts with a letter and if the first letter is uppercase. If not, runs totitlecase on the string