### PR TITLE
Bug fix Normalize LChab rgb convert & build converter objects once

### DIFF
--- a/DelvUI/Helpers/Utils.cs
+++ b/DelvUI/Helpers/Utils.cs
@@ -132,11 +132,14 @@ namespace DelvUI.Helpers
                 }
             }
 
-            //convert our plugin colors to RGBColor
+            //convert our fullhealth and lowhealth colors to RGBColor
             var rgbFullHealthColor = new RGBColor(fullHealthColor.Vector.X, fullHealthColor.Vector.Y, fullHealthColor.Vector.Z);
             var rgbLowHealthColor = new RGBColor(lowHealthColor.Vector.X, lowHealthColor.Vector.Y, lowHealthColor.Vector.Z);
+
+            //store our interpolated alpha to be used later on
             float alpha = (fullHealthColor.Vector.W - lowHealthColor.Vector.W) * ratio + lowHealthColor.Vector.W;
 
+            //color space selection
             switch (blendMode)
             {
                 case BlendMode.LAB:


### PR DESCRIPTION
We only need to build our converters once so we store them in a field somewhere.

