### PR TITLE
Add support to only show the GCD indicator on instant casts only.

### DIFF
--- a/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
@@ -1,4 +1,4 @@
-﻿using DelvUI.Config;
+using DelvUI.Config;
 using DelvUI.Config.Attributes;
 using DelvUI.Interface.Bars;
 using System.Numerics;
@@ -29,6 +29,10 @@ namespace DelvUI.Interface.GeneralElements
         [Checkbox("Show Border")]
         [Order(18)]
         public bool ShowBorder = true;
+
+        [Checkbox("Instant GCDs only", spacing = true)]
+        [Order(19)]
+        public bool InstantGCDsOnly = false;
 
         [Checkbox("Show GCD Queue Indicator", spacing = true)]
         [Order(20)]

--- a/DelvUI/Interface/GeneralElements/GCDIndicatorHud.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorHud.cs
@@ -18,6 +18,7 @@ namespace DelvUI.Interface.GeneralElements
 
         private bool _wasBarEnabled = true;
         private bool _wasCircularModeEnabled = false;
+        private float _lastTotalCastTime = 0;
 
         public GCDIndicatorHud(GCDIndicatorConfig config, string displayName) : base(config, displayName) { }
 
@@ -68,15 +69,38 @@ namespace DelvUI.Interface.GeneralElements
 
             GCDHelper.GetGCDInfo((PlayerCharacter)Actor, out var elapsed, out var total);
 
+            if (total == 0)
+            {
+                _lastTotalCastTime = 0;
+            }
+
             if (!Config.AlwaysShow && total == 0)
             {
                 return;
+            }
+
+            if (_lastTotalCastTime == 0 && ((BattleChara)Actor).IsCasting)
+            {
+                _lastTotalCastTime = ((BattleChara)Actor).TotalCastTime;
             }
 
             var scale = elapsed / total;
             if (scale <= 0)
             {
                 return;
+            }
+
+            if (Config.InstantGCDsOnly && _lastTotalCastTime != 0)
+            {
+                if (Config.AlwaysShow)
+                {
+                    elapsed = 0;
+                    total = 0;
+                }
+                else
+                {
+                    return;
+                }
             }
 
             Config.Bar.Position = Config.Position;


### PR DESCRIPTION
Add support to only show the GCD indicator on instant casts only.

https://user-images.githubusercontent.com/4972345/136995076-eb49c8fb-d48c-41c8-9af2-c0f3c3e6fa90.mp4



