### PR TITLE
Handle tooltip correctly by parsing it as SeString and converting it.

### DIFF
--- a/DelvUI/Helpers/TooltipsHelper.cs
+++ b/DelvUI/Helpers/TooltipsHelper.cs
@@ -3,7 +3,6 @@ using DelvUI.Config.Attributes;
 using ImGuiNET;
 using System;
 using System.Numerics;
-using System.Text.RegularExpressions;
 
 namespace DelvUI.Helpers
 {
@@ -71,7 +70,7 @@ namespace DelvUI.Helpers
             // remove styling tags from text
             if (_previousRawText != text)
             {
-                _currentTooltipText = SanitizeText(text);
+                _currentTooltipText = text;
                 _previousRawText = text;
             }
 
@@ -190,27 +189,6 @@ namespace DelvUI.Helpers
             ImGui.PopStyleVar();
 
             RemoveTooltip();
-        }
-
-        private string SanitizeText(string text)
-        {
-            // some data comes with unicode characters i couldn't figure out how to get rid of
-            // so im doing a pretty aggressive replace to keep only "nice" characters
-            var result = Regex.Replace(text, @"[^a-zA-Z0-9 -\:\.\,\?\!\(\)%]", "");
-
-            // after that there's still some leftovers characters that need to be removed
-            Regex regex = new Regex("HI(.*?)IH");
-            foreach (Match match in regex.Matches(result))
-            {
-                if (match.Groups.Count > 1)
-                {
-                    result = result.Replace(match.Value, match.Groups[1].Value);
-                }
-            }
-
-            result = result.Replace("%", "%%");
-
-            return result;
         }
 
         private Vector2 ConstrainPosition(Vector2 position, Vector2 size)

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -9,6 +9,7 @@ using Lumina.Excel.GeneratedSheets;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using Dalamud.Utility;
 using LuminaStatus = Lumina.Excel.GeneratedSheets.Status;
 using StatusStruct = FFXIVClientStructs.FFXIV.Client.Game.Status;
 
@@ -371,7 +372,7 @@ namespace DelvUI.Interface.StatusEffects
                     if (Config.ShowTooltips)
                     {
                         TooltipsHelper.Instance.ShowTooltipOnCursor(
-                            statusEffectData.Data.Description,
+                            statusEffectData.Data.Description.ToDalamudString().ToString(),
                             statusEffectData.Data.Name,
                             statusEffectData.Status.StatusID
                         );

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,6 +1,7 @@
 # 0.3.0.2
 - Fixed smooth HP in party frames not being smooth enough.
 - Switching profile will now reload fonts as they can differ between profiles.
+- Fixed tooltips missing characters / not working in other languages with a non-standard latin alphabet.
 
 # 0.3.0.1
 - Fixed smooth HP in party frames.


### PR DESCRIPTION
Fixes tooltips by properly handling the SeString and converting it.

Before (without SanitizeText method)
![Advanced_Combat_Tracker_2021-10-14_14-36-04](https://user-images.githubusercontent.com/4972345/137320023-d694827f-5ead-41e6-9371-93a022b5b4c0.png)

After: 

![Advanced_Combat_Tracker_2021-10-14_14-35-43](https://user-images.githubusercontent.com/4972345/137320037-f0fadb81-b13e-4da4-809d-56cfbd26ddd0.png)
![Advanced_Combat_Tracker_2021-10-14_14-40-01](https://user-images.githubusercontent.com/4972345/137319952-a092c1f8-1ad3-4dd4-bfb1-d83ec3d4e2a5.png)
![Advanced_Combat_Tracker_2021-10-14_14-44-11](https://user-images.githubusercontent.com/4972345/137319964-0ff2591d-867c-4a07-9b96-bc6789ff8bba.png)