### PR TITLE
Re-enable labels on chunked bars

### DIFF
--- a/DelvUI/Interface/Bars/BarUtilities.cs
+++ b/DelvUI/Interface/Bars/BarUtilities.cs
@@ -202,7 +202,7 @@ namespace DelvUI.Interface.Bars
             float max,
             float min = 0f,
             GameObject? actor = null,
-            LabelConfig? label = null,
+            LabelConfig? labelTemplate = null,
             PluginConfigColor? fillColor = null,
             PluginConfigColor? partialFillColor = null,
             BarGlowConfig? glowConfig = null,
@@ -219,8 +219,15 @@ namespace DelvUI.Interface.Bars
                 float chunkPercent = Math.Clamp((current - chunkMin) / (chunkMax - chunkMin), 0f, 1f);
 
                 PluginConfigColor chunkColor = partialFillColor != null && current < chunkMax ? partialFillColor : fillColor ?? config.FillColor;
+                LabelConfig? label = null;
+                
+                if (labelTemplate != null)
+                {
+                    label = labelTemplate.Clone();
+                    label.SetText(Math.Clamp(current - chunkMin, 0, chunkRange).ToString("N0"));
+                }
 
-                barChunks[barIndex] = new Tuple<PluginConfigColor, float, LabelConfig?>(chunkColor, chunkPercent, chunkPercent < 1f ? label : null);
+                barChunks[barIndex] = new Tuple<PluginConfigColor, float, LabelConfig?>(chunkColor, chunkPercent, label);
             }
 
             if (glowConfig != null && chunksToGlow == null)
@@ -246,7 +253,7 @@ namespace DelvUI.Interface.Bars
             if (config.UseChunks)
             {
                 var partialColor = config.UsePartialFillColor ? config.PartialFillColor : null;
-                return GetChunkedBars(config, chunks, current, max, min, actor, null, color, partialColor, glowConfig);
+                return GetChunkedBars(config, chunks, current, max, min, actor, config.Label, color, partialColor, glowConfig);
             }
 
             BarHud bar = GetProgressBar(config, null, new LabelConfig[] { config.Label }, current, max, min, actor, color, glowConfig);

--- a/DelvUI/Interface/GeneralElements/LabelConfig.cs
+++ b/DelvUI/Interface/GeneralElements/LabelConfig.cs
@@ -92,5 +92,19 @@ namespace DelvUI.Interface.GeneralElements
         {
             _text = text;
         }
+
+        public virtual LabelConfig Clone() =>
+            new LabelConfig(Position, _text, FrameAnchor, TextAnchor)
+            {
+                Color = Color,
+                OutlineColor = OutlineColor,
+                ShadowColor = ShadowColor,
+                ShadowOffset = ShadowOffset,
+                ShowOutline = ShowOutline,
+                ShowShadow = ShowShadow,
+                FontID = FontID,
+                UseJobColor = UseJobColor,
+                Enabled = Enabled,
+            };
     }
 }


### PR DESCRIPTION
Impl of #678. The functionality to display labels was already there, but unused. This reactivates it.