### PR TITLE
fix: death indicator shouldn't always be enabled

### DIFF
--- a/DelvUI/Interface/Party/PartyFramesBar.cs
+++ b/DelvUI/Interface/Party/PartyFramesBar.cs
@@ -174,7 +174,7 @@ namespace DelvUI.Interface.Party
             {
                 bgColor = Member.InvulnStatus?.InvulnId == 811 ? _invulnTrackerConfig.WalkingDeadBackgroundColor : _invulnTrackerConfig.BackgroundColor;
             }
-            else if (Member.HP <= 0)
+            else if (_config.ColorsConfig.UseDeathIndicatorBackgroundColor && Member.HP <= 0)
             {
                 bgColor = _config.ColorsConfig.DeathIndicatorBackgroundColor;
             }


### PR DESCRIPTION
oops, maybe check if user actually wants the death indicator color on party frames