### PR TITLE
Utilize partial fill for chunked bars with disabled chunking

### DIFF
--- a/DelvUI/Interface/Bars/BarUtilities.cs
+++ b/DelvUI/Interface/Bars/BarUtilities.cs
@@ -238,7 +238,8 @@ namespace DelvUI.Interface.Bars
             float min = 0f,
             GameObject? actor = null,
             BarGlowConfig? glowConfig = null,
-            PluginConfigColor? fillColor = null)
+            PluginConfigColor? fillColor = null,
+            int thresholdChunk = 1)
         {
             var color = fillColor ?? config.FillColor;
 
@@ -271,7 +272,8 @@ namespace DelvUI.Interface.Bars
                 return GetChunkedBars(config, chunks, current, max, min, actor, labels, color, partialColor, glowConfig);
             }
 
-            BarHud bar = GetProgressBar(config, null, new LabelConfig[] { config.Label }, current, max, min, actor, color, glowConfig);
+            var threshold = GetThresholdConfigForChunk(config, thresholdChunk, chunks, min, max);
+            BarHud bar = GetProgressBar(config, threshold, new LabelConfig[] { config.Label }, current, max, min, actor, color, glowConfig);
             return new BarHud[] { bar };
         }
 
@@ -359,5 +361,16 @@ namespace DelvUI.Interface.Bars
 
             return new Rect(pos + fillPos, fillSize, color);
         }
+        
+        public static ThresholdConfig GetThresholdConfigForChunk(ChunkedProgressBarConfig config, int chunk, int chunks, float min, float max) =>
+            new ThresholdConfig
+            {
+                ThresholdType = ThresholdType.Below,
+                Color = config.PartialFillColor,
+                Enabled = config.UsePartialFillColor,
+                Value = (max - min) / chunks * chunk,
+                ChangeColor = true,
+                ShowMarker = false
+            };
     }
 }

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,6 +1,7 @@
 # 0.4.0.1
 Features:
 - Added a command to switch profiles: `/delvui profile ProfileName`, no quotation marks needed.
+- Partial Fill Color is now used for bars when Show In Chunks is unchecked
 
 Fixes:
 - Fixed BLU Job Specific Bar config not saving and only showing when actually on the BLU job.


### PR DESCRIPTION
`PartialFillColor` is currently not used at all when `UseChunks` is `false`. This uses it in the following way: partial fill means that the first chunk (if the bar was chunked) wasn't filled.

I included a variable for which chunk needs to be filled in order to not be considered partialy filled, because maybe for some job it might make sense to have it differently (e.g. partial fill for 2 out of 3 chunks etc.). Can remove this if it's not needed and hardcode to 1 as well.

Example (DNC esprit)
![image](https://user-images.githubusercontent.com/346477/138066457-a8640112-6f73-4c6e-9bc2-a0d12f5136d7.png)
![image](https://user-images.githubusercontent.com/346477/138066543-041c10c2-6490-4e0a-b850-a733b2ba53d5.png)
