### PR TITLE
Fix status check for other languages

### DIFF
--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 namespace DelvUI.Interface.StatusEffects
@@ -374,7 +375,7 @@ namespace DelvUI.Interface.StatusEffects
 
         public bool StatusAllowed(Status status)
         {
-            var inList = List.ContainsKey(KeyName(status));
+            var inList = List.Any(pair => pair.Key.EndsWith($"[{status.RowId}]"));
             if ((inList && FilterType == FilterType.Blacklist) || (!inList && FilterType == FilterType.Whitelist))
             {
                 return false;

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -3,10 +3,11 @@ Features:
 - Added "Player Status" tracking for party frames. Currently only "Viewing Cutscene" is supported.
 
 Fixes:
-- Fixed some offsensive spells not working when the cursor is on top of a player frame with mouseover in automatic mode, but the target is valid (ie GNB's Continuation or SMN's Egi Assault).
+- Fixed some offensive spells not working when the cursor is on top of a player frame with mouseover in automatic mode, but the target is valid (ie GNB's Continuation or SMN's Egi Assault).
 - Fixed some bars not displaying the remaining duration properly.
 - Fixed delay with DRG Disembowel bar.
 - Fixed DRG Disembowel bar hiding itself for a second when re-applying buff with "Hide When Inactive" option checked.
+- Fixed status whitelists/blacklists not working properly if the imported profile was used a different game language.
 
 # 0.3.2.0
 Features:


### PR DESCRIPTION
Fixed status whitelists/blacklists not working properly if the imported profile was used a different game language.

https://user-images.githubusercontent.com/4972345/138102007-9998a105-32ce-4b43-b581-48b66e071da6.mp4

