### PR TITLE
Fixing mouseover target getting stuck without automatic mode

### DIFF
--- a/DelvUI/DelvUI.csproj
+++ b/DelvUI/DelvUI.csproj
@@ -10,9 +10,9 @@
     <!-- Assembly Configuration -->
     <PropertyGroup>
         <AssemblyName>DelvUI</AssemblyName>
-        <AssemblyVersion>0.4.0.1</AssemblyVersion>
-        <FileVersion>0.4.0.1</FileVersion>
-        <InformationalVersion>0.4.0.1 (Beta 4 Patch 1)</InformationalVersion>
+        <AssemblyVersion>0.4.0.2</AssemblyVersion>
+        <FileVersion>0.4.0.2</FileVersion>
+        <InformationalVersion>0.4.0.2 (Beta 4 Patch 2)</InformationalVersion>
     </PropertyGroup>
 
     <!-- Build Configuration -->

--- a/DelvUI/Helpers/InputsHelper.cs
+++ b/DelvUI/Helpers/InputsHelper.cs
@@ -155,22 +155,29 @@ namespace DelvUI.Helpers
             _target = target;
             HandlingMouseInputs = true;
 
-            // set mouseover target in-game
-            if (_config.MouseoverEnabled && !_config.MouseoverAutomaticMode)
-            {
-                IntPtr uiModule = Plugin.GameGui.GetUIModule();
-                long unknownAddress = (long)uiModule + UnknownOffset;
-                long targetAddress = _target != null && _target.ObjectId != 0 ? (long)_target.Address : 0;
-
-                OnSetUIMouseoverActor func = Marshal.GetDelegateForFunctionPointer<OnSetUIMouseoverActor>(_setUIMouseOverActor);
-                func.Invoke(unknownAddress, targetAddress);
-            }
+            long address = _target != null && _target.ObjectId != 0 ? (long)_target.Address : 0;
+            SetGameMouseoverTarget(address);
         }
 
         public void ClearTarget()
         {
             _target = null;
             HandlingMouseInputs = false;
+
+            SetGameMouseoverTarget(0);
+        }
+
+        private void SetGameMouseoverTarget(long address)
+        {
+            // set mouseover target in-game
+            if (_config.MouseoverEnabled && !_config.MouseoverAutomaticMode)
+            {
+                IntPtr uiModule = Plugin.GameGui.GetUIModule();
+                long unknownAddress = (long)uiModule + UnknownOffset;
+
+                OnSetUIMouseoverActor func = Marshal.GetDelegateForFunctionPointer<OnSetUIMouseoverActor>(_setUIMouseOverActor);
+                func.Invoke(unknownAddress, address);
+            }
         }
 
         private void OnConfigReset(ConfigurationManager sender)

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -89,7 +89,7 @@ namespace DelvUI
                 AssemblyLocation = Assembly.GetExecutingAssembly().Location;
             }
 
-            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.4.0.1";
+            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.4.0.2";
 
             FontsManager.Initialize(AssemblyLocation);
             LoadBanner();

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,8 @@
+# 0.4.0.2
+Fixes:
+- Fixed some game windows not covering DelvUI elements.
+- Fixed mouseover getting "stuck" with automatic mode turned off.
+
 # 0.4.0.1
 Features:
 - Added a command to switch profiles: `/delvui profile ProfileName`, no quotation marks needed.


### PR DESCRIPTION
To reproduce:
1.  Disable automatic mode
2. Setup a skill with MOAction for UI mouseover
3. Target someone else
4. Mouseover yourself in party frames, and then move the cursor outside of it
5. Cast the skill

Result: Skill is cast on yourself instead of target (mouseover target was getting stuck on yourself)