### PR TITLE
Saving original positions for castbar, pulltimer and job gauges for all hud layouts

### DIFF
--- a/DelvUI/Interface/GeneralElements/HUDOptionsConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HUDOptionsConfig.cs
@@ -1,5 +1,6 @@
 ﻿using DelvUI.Config;
 using DelvUI.Config.Attributes;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 
@@ -107,10 +108,64 @@ namespace DelvUI.Interface.GeneralElements
         [Order(301, collapseWith = nameof(EnableClipRects))]
         public bool HideInsteadOfClip = false;
 
-        public Vector2 CastBarOriginalPosition;
-        public Vector2 PulltimerOriginalPosition;
-        public Dictionary<string, Vector2> JobGaugeOriginalPosition = new();
+        // saves original positions for all 4 layouts
+        public Vector2[] CastBarOriginalPositions = new Vector2[] { Vector2.Zero, Vector2.Zero, Vector2.Zero, Vector2.Zero };
+        public Vector2[] PulltimerOriginalPositions = new Vector2[] { Vector2.Zero, Vector2.Zero, Vector2.Zero, Vector2.Zero };
+        public Dictionary<string, Vector2>[] JobGaugeOriginalPositions = new Dictionary<string, Vector2>[] { new(), new(), new(), new() };
 
         public new static HUDOptionsConfig DefaultConfig() => new();
+    }
+
+    public class HUDOptionsConfigConverter : PluginConfigObjectConverter
+    {
+        public HUDOptionsConfigConverter()
+        {
+            Func<Vector2, Vector2[]> func = (value) =>
+            {
+                Vector2[] array = new Vector2[4];
+                for (int i = 0; i < 4; i++)
+                {
+                    array[i] = value;
+                }
+
+                return array;
+            };
+
+            TypeToClassFieldConverter<Vector2, Vector2[]> castBar = new TypeToClassFieldConverter<Vector2, Vector2[]>(
+                "CastBarOriginalPositions",
+                new Vector2[] { Vector2.Zero, Vector2.Zero, Vector2.Zero, Vector2.Zero },
+                func
+            );
+
+            TypeToClassFieldConverter<Vector2, Vector2[]> pullTimer = new TypeToClassFieldConverter<Vector2, Vector2[]>(
+                "PulltimerOriginalPositions",
+                new Vector2[] { Vector2.Zero, Vector2.Zero, Vector2.Zero, Vector2.Zero },
+                func
+            );
+
+            NewClassFieldConverter<Dictionary<string, Vector2>, Dictionary<string, Vector2>[]> jobGauge =
+                new NewClassFieldConverter<Dictionary<string, Vector2>, Dictionary<string, Vector2>[]>(
+                    "JobGaugeOriginalPositions",
+                    new Dictionary<string, Vector2>[] { new(), new(), new(), new() },
+                    (oldValue) =>
+                    {
+                        Dictionary<string, Vector2>[] array = new Dictionary<string, Vector2>[4];
+                        for (int i = 0; i < 4; i++)
+                        {
+                            array[i] = oldValue;
+                        }
+
+                        return array;
+                    });
+
+            FieldConvertersMap.Add("CastBarOriginalPosition", castBar);
+            FieldConvertersMap.Add("PulltimerOriginalPosition", pullTimer);
+            FieldConvertersMap.Add("JobGaugeOriginalPosition", jobGauge);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(HUDOptionsConfig);
+        }
     }
 }

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -38,6 +38,7 @@ namespace DelvUI.Interface
         private delegate void SetPositionDelegate(IntPtr addon, short x, short y);
         private delegate IntPtr GetBaseUIObjectDelegate();
         private delegate byte UpdateAddonPositionDelegate(IntPtr manager, IntPtr addon, byte clicked);
+        private delegate IntPtr GetFilePointerDelegate(byte index);
 
         private HUDOptionsConfig Config => ConfigurationManager.Instance.GetConfigObject<HUDOptionsConfig>();
 
@@ -48,6 +49,7 @@ namespace DelvUI.Interface
         private GetBaseUIObjectDelegate? _getBaseUIObject;
         private SetPositionDelegate? _setPosition;
         private UpdateAddonPositionDelegate? _updateAddonPosition;
+        private GetFilePointerDelegate? _getFilePointer = null;
 
         public HudHelper()
         {
@@ -103,6 +105,12 @@ namespace DelvUI.Interface
             */
             IntPtr updateAddonPositionPtr = Plugin.SigScanner.ScanText("E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? 33 D2 48 8B 01 FF 90 ?? ?? ?? ??");
             _updateAddonPosition = Marshal.GetDelegateForFunctionPointer<UpdateAddonPositionDelegate>(updateAddonPositionPtr);
+
+            var getFilePointerPtr = Plugin.SigScanner.ScanText("E8 ?? ?? ?? ?? 48 85 C0 74 14 83 7B 44 00");
+            if (getFilePointerPtr != IntPtr.Zero)
+            {
+                _getFilePointer = Marshal.GetDelegateForFunctionPointer<GetFilePointerDelegate>(getFilePointerPtr);
+            }
             #endregion
         }
 
@@ -111,6 +119,17 @@ namespace DelvUI.Interface
             // 40 57 48 83 EC 70 48 8B F9 E8 ?? ?? ?? ?? 81 BF ?? ?? ?? ?? ?? ?? ?? ??
             const int offset = 0x19A0;
             return Marshal.ReadByte(actor.Address + offset);
+        }
+
+        internal int GetActiveHUDLayoutIndex()
+        {
+            if (_getFilePointer == null) { return 0; }
+
+            IntPtr dataPtr = _getFilePointer.Invoke(0) + 0x50;
+            IntPtr slotPtr = Marshal.ReadIntPtr(dataPtr) + 0x59e8;
+            int index = Marshal.ReadInt32(slotPtr);
+
+            return Math.Clamp(index, 0, 3);
         }
 
         ~HudHelper()
@@ -318,17 +337,18 @@ namespace DelvUI.Interface
             AtkUnitBase* addon = (AtkUnitBase*)Plugin.GameGui.GetAddonByName("_CastBar", 1);
             if (addon == null) { return; }
 
-            Vector2 previousPos = Config.CastBarOriginalPosition;
-            bool isVisible = UpdateAddonOriginalPosition(addon, ref Config.CastBarOriginalPosition);
+            int index = GetActiveHUDLayoutIndex();
+            Vector2 previousPos = Config.CastBarOriginalPositions[index];
+            bool isVisible = UpdateAddonOriginalPosition(addon, ref Config.CastBarOriginalPositions[index]);
 
-            if (previousPos != Config.CastBarOriginalPosition)
+            if (previousPos != Config.CastBarOriginalPositions[index])
             {
                 ConfigurationManager.Instance.SaveConfigurations(true);
             }
 
             if (isVisible != Config.HideDefaultCastbar && !forceVisible) { return; }
 
-            SetAddonVisible((IntPtr)addon, forceVisible || !Config.HideDefaultCastbar, Config.CastBarOriginalPosition);
+            SetAddonVisible((IntPtr)addon, forceVisible || !Config.HideDefaultCastbar, Config.CastBarOriginalPositions[index]);
         }
 
         private unsafe void UpdateDefaultPulltimer(bool forceVisible = false)
@@ -336,40 +356,44 @@ namespace DelvUI.Interface
             AtkUnitBase* addon = (AtkUnitBase*)Plugin.GameGui.GetAddonByName("ScreenInfo_CountDown", 1);
             if (addon == null) { return; }
 
-            Vector2 previousPos = Config.PulltimerOriginalPosition;
-            bool isVisible = UpdateAddonOriginalPosition(addon, ref Config.PulltimerOriginalPosition);
+            int index = GetActiveHUDLayoutIndex();
+            Vector2 previousPos = Config.PulltimerOriginalPositions[index];
+            bool isVisible = UpdateAddonOriginalPosition(addon, ref Config.PulltimerOriginalPositions[index]);
 
-            if (previousPos != Config.PulltimerOriginalPosition)
+            if (previousPos != Config.PulltimerOriginalPositions[index])
             {
                 ConfigurationManager.Instance.SaveConfigurations(true);
             }
 
             if (isVisible != Config.HideDefaultPulltimer && !forceVisible) { return; }
 
-            SetAddonVisible((IntPtr)addon, forceVisible || !Config.HideDefaultPulltimer, Config.PulltimerOriginalPosition);
+            SetAddonVisible((IntPtr)addon, forceVisible || !Config.HideDefaultPulltimer, Config.PulltimerOriginalPositions[index]);
         }
 
         private unsafe void UpdateJobGauges(bool forceVisible = false)
         {
             var (addons, names) = FindAddonsStartingWith("JobHud");
 
+            int index = GetActiveHUDLayoutIndex();
+            Dictionary<string, Vector2> dict = Config.JobGaugeOriginalPositions[index];
+
             for (int i = 0; i < addons.Count; i++)
             {
                 AtkUnitBase* addon = (AtkUnitBase*)addons[i];
                 string name = names[i];
 
-                bool existed = Config.JobGaugeOriginalPosition.TryGetValue(name, out Vector2 pos);
+                bool existed = dict.TryGetValue(name, out Vector2 pos);
 
                 Vector2 previousPos = pos;
                 UpdateAddonOriginalPosition(addon, ref pos);
 
                 if (previousPos != pos || !existed)
                 {
-                    Config.JobGaugeOriginalPosition[name] = pos;
+                    dict[name] = pos;
                     ConfigurationManager.Instance.SaveConfigurations(true);
                 }
 
-                SetAddonVisible((IntPtr)addon, forceVisible || !Config.HideDefaultJobGauges, Config.JobGaugeOriginalPosition[name]);
+                SetAddonVisible((IntPtr)addon, forceVisible || !Config.HideDefaultJobGauges, dict[name]);
             }
         }
 

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -15,7 +15,8 @@ Features:
 Fixes: 
 - Fixed Bard's Soul Voice threshold not working.
 - Fixed settings not saving in some situations.
-- Fixed some more game windows not covering DelvUI elements
+- Fixed some more game windows not covering DelvUI elements.
+- Fixed losing the original positions of the game's default cast bar and job gauges when using the DelvUI hide options for them and also using multiple HUD layouts.
 
 # 0.4.0.2
 Fixes:


### PR DESCRIPTION
Tested a bit and seems fine.
I used 2 profiles with different positions for the job gauge. Swapped between them a bunch of times while toggling the hide settings.
Positions seemed to be correct every time.