### PR TITLE
Fixing possible crash when load texture fails

### DIFF
--- a/DelvUI/Helpers/TexturesCache.cs
+++ b/DelvUI/Helpers/TexturesCache.cs
@@ -86,7 +86,13 @@ namespace DelvUI.Helpers
             }
             catch { }
 
-            return TextureLoader.LoadTexture(path, false);
+            try
+            {
+                return TextureLoader.LoadTexture(path, false);
+            }
+            catch { }
+
+            return null;
         }
 
         private void RemoveTexture<T>(uint rowId) where T : ExcelRow

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,6 +1,7 @@
 # 0.5.1.0
 - Improved UI of the main config window.
 - Font sizes can now go up to 100. Be aware that fonts are shared between all plugins. If you add too many big fonts it may cause issues with Dalamud or straight up crash the game.
+- Fixed possible crash when loading textures with a wrong format or corrupted files.
 
 # 0.5.0.3
 - Fixed more buff related crashes.


### PR DESCRIPTION
Happens to people with corrupted texture files