### PR TITLE
Fix Enemy List not previewing Color Based on Value setting

### DIFF
--- a/DelvUI/Interface/EnemyList/EnemyListHud.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListHud.cs
@@ -248,7 +248,7 @@ namespace DelvUI.Interface.EnemyList
 
         private PluginConfigColor GetColor(Character? character, uint currentHp = 0, uint maxHp = 0)
         {
-            if (Configs.HealthBar.Colors.ColorByHealth.Enabled && character != null)
+            if (Configs.HealthBar.Colors.ColorByHealth.Enabled && (character != null || Config.Preview))
             {
                 var scale = (float)currentHp / Math.Max(1, maxHp);
                 return Utils.GetColorByScale(scale, Configs.HealthBar.Colors.ColorByHealth);


### PR DESCRIPTION
enemy list would just use fillcolor in preview even while color based on value setting was enabled