### PR TITLE
Made default mana bar enabled by default on smn hud

### DIFF
--- a/DelvUI/Interface/Jobs/SummonerHud.cs
+++ b/DelvUI/Interface/Jobs/SummonerHud.cs
@@ -249,6 +249,7 @@ namespace DelvUI.Interface.Jobs
             var config = new SummonerConfig();
 
             config.TranceBar.Label.FontID = FontsConfig.DefaultMediumFontKey;
+            config.UseDefaultPrimaryResourceBar = true;
 
             return config;
         }


### PR DESCRIPTION
SMN was made mana negative in 6.0, Made the mana bar show up by default.