### PR TITLE
Fix tank invuln status checks

### DIFF
--- a/DelvUI/Helpers/Utils.cs
+++ b/DelvUI/Helpers/Utils.cs
@@ -359,7 +359,7 @@ namespace DelvUI.Helpers
             };
         }
 
-        public static Status? HasTankInvulnerability(BattleChara actor)
+        public static Status? GetTankInvulnerabilityID(BattleChara actor)
         {
             Status? tankInvulnBuff = actor.StatusList.FirstOrDefault(o => o.StatusId is 810 or 811 or 1302 or 409 or 1836 or 82);
 

--- a/DelvUI/Helpers/Utils.cs
+++ b/DelvUI/Helpers/Utils.cs
@@ -359,10 +359,11 @@ namespace DelvUI.Helpers
             };
         }
 
-        public static Status HasTankInvulnerability(BattleChara actor)
+        public static Status? HasTankInvulnerability(BattleChara actor)
         {
             Status? tankInvulnBuff = actor.StatusList.FirstOrDefault(o => o.StatusId is 810 or 811 or 1302 or 409 or 1836 or 82);
-            return tankInvulnBuff!;
+
+            return tankInvulnBuff;
         }
 
         public static bool IsOnCleanseJob()

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -243,7 +243,7 @@ namespace DelvUI.Interface.GeneralElements
         {
             if (Config.ShowTankInvulnerability && chara is BattleChara battleChara)
             {
-                Status tankInvuln = Utils.HasTankInvulnerability(battleChara);
+                Status? tankInvuln = Utils.HasTankInvulnerability(battleChara);
 
                 if (tankInvuln != null)
                 {

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -129,7 +129,7 @@ namespace DelvUI.Interface.GeneralElements
             {
                 Vector2 healthMissingSize = Config.Size - BarUtilities.GetFillDirectionOffset(healthFill.Size, Config.FillDirection);
                 Vector2 healthMissingPos = Config.FillDirection.IsInverted() ? Config.Position : Config.Position + BarUtilities.GetFillDirectionOffset(healthFill.Size, Config.FillDirection);
-                PluginConfigColor? color = Config.UseDeathIndicatorBackgroundColor && character.CurrentHp <= 0 ? Config.DeathIndicatorBackgroundColor : Config.HealthMissingColor;
+                PluginConfigColor? color = BackgroundColor(character);
                 bar.AddForegrounds(new Rect(healthMissingPos, healthMissingSize, color));
             }
 
@@ -243,7 +243,7 @@ namespace DelvUI.Interface.GeneralElements
         {
             if (Config.ShowTankInvulnerability && chara is BattleChara battleChara)
             {
-                Status? tankInvuln = Utils.HasTankInvulnerability(battleChara);
+                Status? tankInvuln = Utils.GetTankInvulnerabilityID(battleChara);
 
                 if (tankInvuln != null)
                 {
@@ -275,6 +275,10 @@ namespace DelvUI.Interface.GeneralElements
                 else if (Config.UseDeathIndicatorBackgroundColor && chara.CurrentHp <= 0)
                 {
                     return Config.DeathIndicatorBackgroundColor;
+                }
+                else if (Config.UseMissingHealthBar)
+                {
+                    return Config.HealthMissingColor;
                 }
                 else
                 {

--- a/DelvUI/Interface/Party/PartyFramesInvulnTracker.cs
+++ b/DelvUI/Interface/Party/PartyFramesInvulnTracker.cs
@@ -80,7 +80,7 @@ namespace DelvUI.Interface.Party
                 }
 
                 // check invuln buff
-                Status? tankInvuln = Utils.HasTankInvulnerability(battleChara);
+                Status? tankInvuln = Utils.GetTankInvulnerabilityID(battleChara);
                 if (tankInvuln == null)
                 {
                     member.InvulnStatus = null;

--- a/DelvUI/Interface/Party/PartyFramesInvulnTracker.cs
+++ b/DelvUI/Interface/Party/PartyFramesInvulnTracker.cs
@@ -80,7 +80,7 @@ namespace DelvUI.Interface.Party
                 }
 
                 // check invuln buff
-                Status tankInvuln = Utils.HasTankInvulnerability(battleChara);
+                Status? tankInvuln = Utils.HasTankInvulnerability(battleChara);
                 if (tankInvuln == null)
                 {
                     member.InvulnStatus = null;

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -11,6 +11,7 @@ Fixes:
 - Fixed mana bar not being visible by default for Summoner.
 - Fixed threshold values for some bars being incorrect.
 - Fixed disable for Sage Addersting and White Mage Blood Lily bars.
+- Fixed Tank Invulnerability Background Color so it now also works for unit frame profiles that use "Missing Health Color".
 
 # 0.6.0.3
 Features:


### PR DESCRIPTION
- changed the "HasTankInvulnerability" method that never returned to null to "GetTankInvulnerabilityID" that can return null so the checks that make use of it actually work
- fixed so tankinvulns also change color for profiles that use "missing health color"