### PR TITLE
Passing player reference to EVERY job hud bar

### DIFF
--- a/DelvUI/DelvUI.csproj
+++ b/DelvUI/DelvUI.csproj
@@ -10,9 +10,9 @@
     <!-- Assembly Configuration -->
     <PropertyGroup>
         <AssemblyName>DelvUI</AssemblyName>
-        <AssemblyVersion>0.6.1.1</AssemblyVersion>
-        <FileVersion>0.6.1.1</FileVersion>
-        <InformationalVersion>0.6.1.1</InformationalVersion>
+        <AssemblyVersion>0.6.1.2</AssemblyVersion>
+        <FileVersion>0.6.1.2</FileVersion>
+        <InformationalVersion>0.6.1.2</InformationalVersion>
     </PropertyGroup>
 
     <!-- Build Configuration -->

--- a/DelvUI/Interface/Jobs/AstrologianHud.cs
+++ b/DelvUI/Interface/Jobs/AstrologianHud.cs
@@ -390,7 +390,8 @@ namespace DelvUI.Interface.Jobs
             }
 
             Config.LightspeedBar.Label.SetValue(lightspeedDuration);
-            BarUtilities.GetProgressBar(Config.LightspeedBar, lightspeedDuration, LIGHTSPEED_MAX_DURATION).Draw(origin);
+            BarUtilities.GetProgressBar(Config.LightspeedBar, lightspeedDuration, LIGHTSPEED_MAX_DURATION, 0, player)
+                .Draw(origin);
         }
 
         private void DrawStar(Vector2 origin, PlayerCharacter player)
@@ -407,7 +408,8 @@ namespace DelvUI.Interface.Jobs
             PluginConfigColor currentStarColor = starPreCookingBuff > 0 ? Config.StarBar.StarEarthlyColor : Config.StarBar.StarGiantColor;
 
             Config.StarBar.Label.SetValue(currentStarDuration);
-            BarUtilities.GetProgressBar(Config.StarBar, currentStarDuration, STAR_MAX_DURATION, 0f, player, currentStarColor, Config.StarBar.StarGlowConfig.Enabled && starPostCookingBuff > 0 ? Config.StarBar.StarGlowConfig : null).Draw(origin); // Star Countdown after Star is ready 
+            BarUtilities.GetProgressBar(Config.StarBar, currentStarDuration, STAR_MAX_DURATION, 0f, player, currentStarColor, Config.StarBar.StarGlowConfig.Enabled && starPostCookingBuff > 0 ? Config.StarBar.StarGlowConfig : null)
+                .Draw(origin); // Star Countdown after Star is ready 
         }
     }
 

--- a/DelvUI/Interface/Jobs/BardHud.cs
+++ b/DelvUI/Interface/Jobs/BardHud.cs
@@ -3,17 +3,15 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using DelvUI.Config;
 using DelvUI.Config.Attributes;
+using DelvUI.Enums;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using DelvUI.Interface.GeneralElements;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Numerics;
-using Dalamud.Logging;
-using DelvUI.Enums;
 
 namespace DelvUI.Interface.Jobs
 {
@@ -88,7 +86,7 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.SoulVoiceBar.Enabled)
             {
-                DrawSoulVoiceBar(pos);
+                DrawSoulVoiceBar(pos, player);
             }
 
             if (Config.CodaBar.Enabled)
@@ -162,7 +160,7 @@ namespace DelvUI.Interface.Jobs
                             );
                     }
 
-                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.WMColor);
+                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.WMColor, player);
 
                     break;
 
@@ -172,7 +170,7 @@ namespace DelvUI.Interface.Jobs
                         DrawBloodletterReady(origin, player);
                     }
 
-                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.MBColor);
+                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.MBColor, player);
 
                     break;
 
@@ -182,7 +180,7 @@ namespace DelvUI.Interface.Jobs
                         DrawStacksBar(origin, player, songStacks, 4, Config.StacksBar.APStackColor);
                     }
 
-                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.APColor);
+                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.APColor, player);
 
                     break;
 
@@ -192,7 +190,7 @@ namespace DelvUI.Interface.Jobs
                         DrawStacksBar(origin, player, 0, 3, Config.StacksBar.WMStackColor);
                     }
 
-                    DrawSongTimerBar(origin, 0, EmptyColor);
+                    DrawSongTimerBar(origin, 0, EmptyColor, player);
 
                     break;
 
@@ -202,7 +200,7 @@ namespace DelvUI.Interface.Jobs
                         DrawStacksBar(origin, player, 0, 3, Config.StacksBar.WMStackColor);
                     }
 
-                    DrawSongTimerBar(origin, 0, EmptyColor);
+                    DrawSongTimerBar(origin, 0, EmptyColor, player);
 
                     break;
             }
@@ -221,7 +219,7 @@ namespace DelvUI.Interface.Jobs
                 Config.StacksBar.MBGlowConfig.Enabled ? Config.StacksBar.MBGlowConfig : null);
         }
 
-        protected void DrawSongTimerBar(Vector2 origin, ushort songTimer, PluginConfigColor songColor)
+        protected void DrawSongTimerBar(Vector2 origin, ushort songTimer, PluginConfigColor songColor, PlayerCharacter player)
         {
 
             if (Config.SongGaugeBar.HideWhenInactive && songTimer == 0 || !Config.SongGaugeBar.Enabled)
@@ -232,11 +230,11 @@ namespace DelvUI.Interface.Jobs
             float duration = Math.Abs(songTimer / 1000f);
 
             Config.SongGaugeBar.Label.SetValue(duration);
-            BarUtilities.GetProgressBar(Config.SongGaugeBar, duration, 45f, 0f, null, songColor)
+            BarUtilities.GetProgressBar(Config.SongGaugeBar, duration, 45f, 0f, player, songColor)
                         .Draw(origin);
         }
 
-        protected void DrawSoulVoiceBar(Vector2 origin)
+        protected void DrawSoulVoiceBar(Vector2 origin, PlayerCharacter player)
         {
             BardSoulVoiceBarConfig config = Config.SoulVoiceBar;
             byte soulVoice = Plugin.JobGauges.Get<BRDGauge>().SoulVoice;
@@ -255,7 +253,7 @@ namespace DelvUI.Interface.Jobs
                 soulVoice,
                 100f,
                 0f,
-                null,
+                player,
                 config.FillColor,
                 soulVoice == 100f && config.GlowConfig.Enabled ? config.GlowConfig : null
             ).Draw(origin);
@@ -266,7 +264,7 @@ namespace DelvUI.Interface.Jobs
             BardStacksBarConfig config = Config.StacksBar;
 
             config.FillColor = stackColor;
-            BarUtilities.GetChunkedBars(Config.StacksBar, max, amount, max, 0F, glowConfig: glowConfig).
+            BarUtilities.GetChunkedBars(Config.StacksBar, max, amount, max, 0f, player, glowConfig: glowConfig).
                          Draw(origin);
         }
     }

--- a/DelvUI/Interface/Jobs/BlueMageHud.cs
+++ b/DelvUI/Interface/Jobs/BlueMageHud.cs
@@ -89,21 +89,21 @@ namespace DelvUI.Interface.Jobs
                 DrawTingleBar(pos, player);
             }
         }
+
         private static List<uint> BleedID = new List<uint> { 1714 };
         private static List<float> BleedDurations = new List<float> { 30, 60 };
+
         protected void DrawBleedBar(Vector2 origin, PlayerCharacter player)
         {
             var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
             BarUtilities.GetDoTBar(Config.BleedBar, player, target, BleedID, BleedDurations)?.Draw(origin);
-
         }
+
         protected void DrawWindburnBar(Vector2 origin, PlayerCharacter player)
         {
-            float featherRainCD = SpellHelper.Instance.GetSpellCooldown(11426);
             GameObject? target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
-            float current = 0f;
-            float max = 0f;
             bool dotExists = false;
+
             if (target != null && target is BattleChara targetChara)
             {
                 dotExists = targetChara.StatusList.FirstOrDefault(o => o.SourceID == player.ObjectId && o.StatusId == 1723) != null;
@@ -115,8 +115,10 @@ namespace DelvUI.Interface.Jobs
             }
             else
             {
-                max = 30f;
-                current = max - featherRainCD;
+                float featherRainCD = SpellHelper.Instance.GetSpellCooldown(11426);
+                float max = 30f;
+                float current = max - featherRainCD;
+
                 if (!Config.WindburnBar.HideWhenInactive || current < max)
                 {
                     Config.WindburnBar.Label.SetValue(max - current);
@@ -124,25 +126,25 @@ namespace DelvUI.Interface.Jobs
                     {
                         Config.WindburnBar.Label.SetText("Ready");
                     }
+
                     BarUtilities.GetProgressBar(Config.WindburnBar, current, max, 0f, player).Draw(origin);
                 }
             }
         }
+
         protected void DrawSurpanakhaBar(Vector2 origin, PlayerCharacter player)
         {
-            int surpanakhaStacks = SpellHelper.Instance.GetStackCount(4, 18323);
             float surpanakhaCD = SpellHelper.Instance.GetSpellCooldown(18323);
-            float current = 0f;
-            float max = 0f;
+            float max = 120f;
+            float current = max - surpanakhaCD;
 
-            max = 120f;
-            current = max - surpanakhaCD;
             if (!Config.SurpanakhaBar.HideWhenInactive || current < max)
             {
                 Config.SurpanakhaBar.Label.SetValue((max - current) % 30);
                 BarUtilities.GetChunkedProgressBars(Config.SurpanakhaBar, 4, current, max, 0f, player).Draw(origin);
             }
         }
+
         protected void DrawOffGuardBar(Vector2 origin, PlayerCharacter player)
         {
             var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
@@ -160,10 +162,11 @@ namespace DelvUI.Interface.Jobs
                     1727 => Config.MoonFluteBar.WaningCrescentColor,
                     _ => Config.MoonFluteBar.WaxingCrescentColor
                 } : Config.MoonFluteBar.WaxingCrescentColor;
+
                 float buffDuration = buff?.RemainingTime ?? 0f;
+
                 Config.MoonFluteBar.Label.SetValue(buffDuration);
                 BarUtilities.GetProgressBar(Config.MoonFluteBar, buffDuration, 15f, 0, player, fillColor: buffColor).Draw(origin);
-
             }
         }
 
@@ -178,7 +181,9 @@ namespace DelvUI.Interface.Jobs
                     1716 => Config.SpellAmpBar.WhistleColor,
                     _ => Config.SpellAmpBar.BristleColor
                 } : Config.SpellAmpBar.BristleColor;
+
                 float buffDuration = buff?.RemainingTime ?? 0f;
+
                 Config.SpellAmpBar.Label.SetValue(buffDuration);
                 BarUtilities.GetProgressBar(Config.SpellAmpBar, buffDuration, 30f, 0, player, fillColor: buffColor).Draw(origin);
 

--- a/DelvUI/Interface/Jobs/DancerHud.cs
+++ b/DelvUI/Interface/Jobs/DancerHud.cs
@@ -92,7 +92,7 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.EspritGauge.Enabled)
             {
-                DrawEspritBar(pos);
+                DrawEspritBar(pos, player);
             }
 
             if (Config.FeatherGauge.Enabled)
@@ -118,7 +118,7 @@ namespace DelvUI.Interface.Jobs
             bool showingStepBar = false;
             if (Config.StepsBar.Enabled)
             {
-                showingStepBar = DrawStepBar(pos);
+                showingStepBar = DrawStepBar(pos, player);
             }
 
             if (!showingStepBar || !Config.StepsBar.HideProcs)
@@ -132,16 +132,11 @@ namespace DelvUI.Interface.Jobs
 
         private void DrawProcBar(Vector2 origin, PlayerCharacter player, DancerProcBarConfig config, uint statusId)
         {
-            if (!config.Enabled)
-            {
-                return;
-            }
-
             BarUtilities.GetProcBar(config, player, statusId, 20f, !config.IgnoreBuffDuration)?.
                 Draw(origin);
         }
 
-        private unsafe bool DrawStepBar(Vector2 origin)
+        private unsafe bool DrawStepBar(Vector2 origin, PlayerCharacter player)
         {
             var gauge = Plugin.JobGauges.Get<DNCGauge>();
             if (!gauge.IsDancing)
@@ -205,20 +200,21 @@ namespace DelvUI.Interface.Jobs
                 }
             }
 
-            BarUtilities.GetChunkedBars(Config.StepsBar, chunks.ToArray(), null, Config.StepsBar.GlowConfig, glows.ToArray())
+            BarUtilities.GetChunkedBars(Config.StepsBar, chunks.ToArray(), player, Config.StepsBar.GlowConfig, glows.ToArray())
                 .Draw(origin);
 
             return true;
         }
 
-        private void DrawEspritBar(Vector2 origin)
+        private void DrawEspritBar(Vector2 origin, PlayerCharacter player)
         {
             DNCGauge gauge = Plugin.JobGauges.Get<DNCGauge>();
 
             if (Config.EspritGauge.HideWhenInactive && gauge.Esprit is 0) { return; }
 
             Config.EspritGauge.Label.SetValue(gauge.Esprit);
-            BarUtilities.GetChunkedProgressBars(Config.EspritGauge, 2, gauge.Esprit, 100, 0f).Draw(origin);
+            BarUtilities.GetChunkedProgressBars(Config.EspritGauge, 2, gauge.Esprit, 100, 0f, player)
+                .Draw(origin);
         }
 
         private void DrawFeathersBar(Vector2 origin, PlayerCharacter player)
@@ -239,7 +235,7 @@ namespace DelvUI.Interface.Jobs
             }
 
             BarGlowConfig? config = hasFlourishingBuff ? Config.FeatherGauge.GlowConfig : null;
-            BarUtilities.GetChunkedBars(Config.FeatherGauge, 4, gauge.Feathers, 4, glowConfig: config, chunksToGlow: glows)
+            BarUtilities.GetChunkedBars(Config.FeatherGauge, 4, gauge.Feathers, 4, 0, player, glowConfig: config, chunksToGlow: glows)
                 .Draw(origin);
         }
 
@@ -252,7 +248,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.TechnicalFinishBar.HideWhenInactive || technicalFinishDuration > 0)
             {
                 Config.TechnicalFinishBar.Label.SetValue(Math.Abs(technicalFinishDuration));
-                BarUtilities.GetProgressBar(Config.TechnicalFinishBar, technicalFinishDuration, 20f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.TechnicalFinishBar, technicalFinishDuration, 20f, 0f, player)
+                    .Draw(origin);
             }
         }
 
@@ -263,7 +260,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.DevilmentBar.HideWhenInactive || devilmentDuration > 0)
             {
                 Config.DevilmentBar.Label.SetValue(Math.Abs(devilmentDuration));
-                BarUtilities.GetProgressBar(Config.DevilmentBar, devilmentDuration, 20f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.DevilmentBar, devilmentDuration, 20f, 0f, player)
+                    .Draw(origin);
             }
         }
 
@@ -274,7 +272,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.StandardFinishBar.HideWhenInactive || standardFinishDuration > 0)
             {
                 Config.StandardFinishBar.Label.SetValue(Math.Abs(standardFinishDuration));
-                BarUtilities.GetProgressBar(Config.StandardFinishBar, standardFinishDuration, 60f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.StandardFinishBar, standardFinishDuration, 60f, 0f, player)
+                    .Draw(origin);
             }
         }
     }

--- a/DelvUI/Interface/Jobs/DarkKnightHud.cs
+++ b/DelvUI/Interface/Jobs/DarkKnightHud.cs
@@ -81,7 +81,7 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.DarksideBar.Enabled)
             {
-                DrawDarkside(pos);
+                DrawDarkside(pos, player);
             }
 
             if (Config.BloodWeaponBar.Enabled)
@@ -96,7 +96,7 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.LivingShadowBar.Enabled)
             {
-                DrawLivingShadowBar(pos);
+                DrawLivingShadowBar(pos, player);
             }
         }
 
@@ -127,14 +127,15 @@ namespace DelvUI.Interface.Jobs
                 ).Draw(origin);
         }
 
-        private void DrawDarkside(Vector2 origin)
+        private void DrawDarkside(Vector2 origin, PlayerCharacter player)
         {
             DRKGauge gauge = Plugin.JobGauges.Get<DRKGauge>();
             if (Config.DarksideBar.HideWhenInactive && gauge.DarksideTimeRemaining == 0) { return; };
 
             float timer = Math.Abs(gauge.DarksideTimeRemaining) / 1000;
+
             Config.DarksideBar.Label.SetValue(timer);
-            BarUtilities.GetProgressBar(Config.DarksideBar, timer, 60)
+            BarUtilities.GetProgressBar(Config.DarksideBar, timer, 60, 0, player)
                 .Draw(origin);
         }
 
@@ -144,7 +145,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.BloodGauge.HideWhenInactive || gauge.Blood > 0)
             {
                 Config.BloodGauge.Label.SetValue(gauge.Blood);
-                BarUtilities.GetChunkedProgressBars(Config.BloodGauge, 2, gauge.Blood, 100).Draw(origin);
+                BarUtilities.GetChunkedProgressBars(Config.BloodGauge, 2, gauge.Blood, 100, 0, player)
+                    .Draw(origin);
             }
         }
 
@@ -155,7 +157,7 @@ namespace DelvUI.Interface.Jobs
             if (Config.BloodWeaponBar.HideWhenInactive && bloodWeaponDuration is 0) { return; }
 
             Config.BloodWeaponBar.Label.SetValue(bloodWeaponDuration);
-            BarUtilities.GetProgressBar(Config.BloodWeaponBar, bloodWeaponDuration, 10, 0f)
+            BarUtilities.GetProgressBar(Config.BloodWeaponBar, bloodWeaponDuration, 10, 0f, player)
                 .Draw(origin);
         }
 
@@ -166,18 +168,19 @@ namespace DelvUI.Interface.Jobs
             if (Config.DeliriumBar.HideWhenInactive && deliriumDuration is 0) { return; }
 
             Config.DeliriumBar.Label.SetValue(deliriumDuration);
-            BarUtilities.GetProgressBar(Config.DeliriumBar, deliriumDuration, 10, 0f)
+            BarUtilities.GetProgressBar(Config.DeliriumBar, deliriumDuration, 10, 0f, player)
                 .Draw(origin);
         }
 
-        private void DrawLivingShadowBar(Vector2 origin)
+        private void DrawLivingShadowBar(Vector2 origin, PlayerCharacter player)
         {
             DRKGauge gauge = Plugin.JobGauges.Get<DRKGauge>();
             if (Config.LivingShadowBar.HideWhenInactive && gauge.ShadowTimeRemaining == 0) { return; }
 
             float timer = Math.Abs(gauge.ShadowTimeRemaining) / 1000;
             Config.LivingShadowBar.Label.SetValue(timer);
-            BarUtilities.GetProgressBar(Config.LivingShadowBar, timer, 24)
+
+            BarUtilities.GetProgressBar(Config.LivingShadowBar, timer, 24, 0, player)
                 .Draw(origin);
         }
     }

--- a/DelvUI/Interface/Jobs/DragoonHud.cs
+++ b/DelvUI/Interface/Jobs/DragoonHud.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using Dalamud.Game.ClientState.JobGauge.Types;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
 using DelvUI.Config;
@@ -10,6 +6,10 @@ using DelvUI.Config.Attributes;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 
 namespace DelvUI.Interface.Jobs
 {
@@ -77,12 +77,12 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.EyeOfTheDragonBar.Enabled)
             {
-                DrawEyeOfTheDragonBars(position);
+                DrawEyeOfTheDragonBars(position, player);
             }
 
             if (Config.FirstmindsFocusBar.Enabled)
             {
-                DrawFirstmindsFocusBars(position);
+                DrawFirstmindsFocusBars(position, player);
             }
 
             if (Config.LifeOfTheDragonBar.Enabled)
@@ -99,23 +99,25 @@ namespace DelvUI.Interface.Jobs
                 Draw(pos);
         }
 
-        private void DrawEyeOfTheDragonBars(Vector2 pos)
+        private void DrawEyeOfTheDragonBars(Vector2 pos, PlayerCharacter player)
         {
             DRGGauge gauge = Plugin.JobGauges.Get<DRGGauge>();
 
             if (!Config.EyeOfTheDragonBar.HideWhenInactive || gauge.EyeCount > 0)
             {
-                BarUtilities.GetChunkedBars(Config.EyeOfTheDragonBar, 2, gauge.EyeCount, 2).Draw(pos);
+                BarUtilities.GetChunkedBars(Config.EyeOfTheDragonBar, 2, gauge.EyeCount, 2, 0, player)
+                    .Draw(pos);
             }
         }
 
-        private void DrawFirstmindsFocusBars(Vector2 pos)
+        private void DrawFirstmindsFocusBars(Vector2 pos, PlayerCharacter player)
         {
             DRGGauge gauge = Plugin.JobGauges.Get<DRGGauge>();
 
             if (!Config.FirstmindsFocusBar.HideWhenInactive || gauge.FirstmindsFocusCount > 0)
             {
-                BarUtilities.GetChunkedBars(Config.FirstmindsFocusBar, 2, gauge.FirstmindsFocusCount, 2).Draw(pos);
+                BarUtilities.GetChunkedBars(Config.FirstmindsFocusBar, 2, gauge.FirstmindsFocusCount, 2, 0, player)
+                    .Draw(pos);
             }
         }
 
@@ -127,7 +129,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.LifeOfTheDragonBar.HideWhenInactive || duration > 0f)
             {
                 Config.LifeOfTheDragonBar.Label.SetValue(duration);
-                BarUtilities.GetProgressBar(Config.LifeOfTheDragonBar, duration, 30, 0f, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.LifeOfTheDragonBar, duration, 30, 0f, player)
+                    .Draw(pos);
             }
         }
 
@@ -137,7 +140,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.PowerSurgeBar.HideWhenInactive || duration > 0f)
             {
                 Config.PowerSurgeBar.Label.SetValue(duration);
-                BarUtilities.GetProgressBar(Config.PowerSurgeBar, duration, 30f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.PowerSurgeBar, duration, 30f, 0f, player)
+                    .Draw(origin);
             }
         }
     }

--- a/DelvUI/Interface/Jobs/GunbreakerHud.cs
+++ b/DelvUI/Interface/Jobs/GunbreakerHud.cs
@@ -1,12 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using Dalamud.Game.ClientState.JobGauge.Types;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using DelvUI.Config.Attributes;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 
 namespace DelvUI.Interface.Jobs
 {
@@ -55,7 +55,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.PowderGauge.HideWhenInactive || gauge.Ammo > 0)
             {
                 var maxCartridges = player.Level >= 88 ? 3 : 2;
-                BarUtilities.GetChunkedBars(Config.PowderGauge, maxCartridges, gauge.Ammo, maxCartridges).Draw(pos);
+                BarUtilities.GetChunkedBars(Config.PowderGauge, maxCartridges, gauge.Ammo, maxCartridges, 0, player)
+                    .Draw(pos);
             }
         }
 
@@ -65,7 +66,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.NoMercy.HideWhenInactive || noMercyDuration > 0)
             {
                 Config.NoMercy.Label.SetValue(noMercyDuration);
-                BarUtilities.GetProgressBar(Config.NoMercy, noMercyDuration, 20f, 0f, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.NoMercy, noMercyDuration, 20f, 0f, player)
+                    .Draw(pos);
             }
         }
     }

--- a/DelvUI/Interface/Jobs/MachinistHud.cs
+++ b/DelvUI/Interface/Jobs/MachinistHud.cs
@@ -4,7 +4,6 @@ using DelvUI.Config;
 using DelvUI.Config.Attributes;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
-using DelvUI.Interface.GeneralElements;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
@@ -55,12 +54,12 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.OverheatGauge.Enabled)
             {
-                DrawOverheatBar(pos);
+                DrawOverheatBar(pos, player);
             }
 
             if (Config.HeatGauge.Enabled)
             {
-                DrawHeatGauge(pos);
+                DrawHeatGauge(pos, player);
             }
 
             if (Config.BatteryGauge.Enabled)
@@ -74,14 +73,15 @@ namespace DelvUI.Interface.Jobs
             }
         }
 
-        private void DrawHeatGauge(Vector2 origin)
+        private void DrawHeatGauge(Vector2 origin, PlayerCharacter player)
         {
             MCHGauge gauge = Plugin.JobGauges.Get<MCHGauge>();
 
             if (!Config.HeatGauge.HideWhenInactive || gauge.Heat > 0)
             {
                 Config.HeatGauge.Label.SetValue(gauge.Heat);
-                BarUtilities.GetChunkedProgressBars(Config.HeatGauge, 2, gauge.Heat, 100).Draw(origin);
+                BarUtilities.GetChunkedProgressBars(Config.HeatGauge, 2, gauge.Heat, 100, 0, player)
+                    .Draw(origin);
             }
         }
 
@@ -92,7 +92,8 @@ namespace DelvUI.Interface.Jobs
             if ((!Config.BatteryGauge.HideWhenInactive || gauge.Battery > 0) && !gauge.IsRobotActive)
             {
                 Config.BatteryGauge.Label.SetValue(gauge.Battery);
-                BarUtilities.GetProgressBar(Config.BatteryGauge, gauge.Battery, 100f, 0f, player, Config.BatteryGauge.BatteryColor).Draw(origin);
+                BarUtilities.GetProgressBar(Config.BatteryGauge, gauge.Battery, 100f, 0f, player, Config.BatteryGauge.BatteryColor)
+                    .Draw(origin);
             }
 
             if (!gauge.IsRobotActive && _robotMaxDurationSet)
@@ -108,18 +109,20 @@ namespace DelvUI.Interface.Jobs
                 }
 
                 Config.BatteryGauge.Label.SetValue(gauge.SummonTimeRemaining / 1000f);
-                BarUtilities.GetProgressBar(Config.BatteryGauge, gauge.SummonTimeRemaining / 1000, _robotMaxDuration / 1000, 0f, player, Config.BatteryGauge.RobotColor).Draw(origin);
+                BarUtilities.GetProgressBar(Config.BatteryGauge, gauge.SummonTimeRemaining / 1000, _robotMaxDuration / 1000, 0f, player, Config.BatteryGauge.RobotColor)
+                    .Draw(origin);
             }
         }
 
-        private void DrawOverheatBar(Vector2 origin)
+        private void DrawOverheatBar(Vector2 origin, PlayerCharacter player)
         {
             MCHGauge gauge = Plugin.JobGauges.Get<MCHGauge>();
 
             if (!Config.OverheatGauge.HideWhenInactive || gauge.IsOverheated)
             {
                 Config.OverheatGauge.Label.SetValue(gauge.OverheatTimeRemaining / 1000f);
-                BarUtilities.GetProgressBar(Config.OverheatGauge, gauge.OverheatTimeRemaining / 1000f, 8, 0f).Draw(origin);
+                BarUtilities.GetProgressBar(Config.OverheatGauge, gauge.OverheatTimeRemaining / 1000f, 8, 0f, player)
+                    .Draw(origin);
             }
         }
 
@@ -130,7 +133,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.WildfireBar.HideWhenInactive || wildfireDuration > 0)
             {
                 Config.WildfireBar.Label.SetValue(wildfireDuration);
-                BarUtilities.GetProgressBar(Config.WildfireBar, wildfireDuration, 10, 0f).Draw(origin);
+                BarUtilities.GetProgressBar(Config.WildfireBar, wildfireDuration, 10, 0f, player)
+                    .Draw(origin);
             }
         }
     }

--- a/DelvUI/Interface/Jobs/MonkHud.cs
+++ b/DelvUI/Interface/Jobs/MonkHud.cs
@@ -84,7 +84,7 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.ChakraBar.Enabled)
             {
-                DrawChakraGauge(position);
+                DrawChakraGauge(position, player);
             }
 
             if (Config.MastersGauge.Enabled)
@@ -125,7 +125,8 @@ namespace DelvUI.Interface.Jobs
                 } : "";
 
                 Config.FormsBar.Label.SetText(label);
-                BarUtilities.GetProgressBar(Config.FormsBar, formDuration, 30f, 0, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.FormsBar, formDuration, 30f, 0, player)
+                    .Draw(pos);
             }
         }
 
@@ -147,16 +148,18 @@ namespace DelvUI.Interface.Jobs
                 }
 
                 Config.PerfectBalanceBar.PerfectBalanceLabel.SetValue(duration);
-                BarUtilities.GetChunkedBars(Config.PerfectBalanceBar, chunks, player).Draw(pos);
+                BarUtilities.GetChunkedBars(Config.PerfectBalanceBar, chunks, player)
+                    .Draw(pos);
             }
         }
 
-        private void DrawChakraGauge(Vector2 pos)
+        private void DrawChakraGauge(Vector2 pos, PlayerCharacter player)
         {
             var gauge = Plugin.JobGauges.Get<MNKGauge>();
             if (!Config.ChakraBar.HideWhenInactive || gauge.Chakra > 0)
             {
-                BarUtilities.GetChunkedBars(Config.ChakraBar, 5, gauge.Chakra, 5).Draw(pos);
+                BarUtilities.GetChunkedBars(Config.ChakraBar, 5, gauge.Chakra, 5, 0, player)
+                    .Draw(pos);
             }
         }
 
@@ -195,7 +198,8 @@ namespace DelvUI.Interface.Jobs
                 }
 
                 Config.MastersGauge.BlitzTimerLabel.SetValue(gauge.BlitzTimeRemaining / 1000);
-                BarUtilities.GetChunkedBars(Config.MastersGauge, chunks, player).Draw(pos);
+                BarUtilities.GetChunkedBars(Config.MastersGauge, chunks, player)
+                    .Draw(pos);
             }
         }
 
@@ -204,7 +208,7 @@ namespace DelvUI.Interface.Jobs
             BeastChakra.RAPTOR => Config.MastersGauge.RaptorChakraColor,
             BeastChakra.COEURL => Config.MastersGauge.CoeurlChakraColor,
             BeastChakra.OPOOPO => Config.MastersGauge.OpoopoChakraColor,
-            _                  => new PluginConfigColor(new(0, 0, 0, 0))
+            _ => new PluginConfigColor(new(0, 0, 0, 0))
         };
 
         private void DrawTwinSnakesBar(Vector2 pos, PlayerCharacter player)
@@ -213,7 +217,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.TwinSnakesBar.HideWhenInactive || twinSnakesDuration > 0)
             {
                 Config.TwinSnakesBar.Label.SetValue(twinSnakesDuration);
-                BarUtilities.GetProgressBar(Config.TwinSnakesBar, twinSnakesDuration, 15f, 0f, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.TwinSnakesBar, twinSnakesDuration, 15f, 0f, player)
+                    .Draw(pos);
             }
         }
 
@@ -223,7 +228,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.LeadenFistBar.HideWhenInactive || leadenFistDuration > 0)
             {
                 Config.LeadenFistBar.Label.SetValue(leadenFistDuration);
-                BarUtilities.GetProgressBar(Config.LeadenFistBar, leadenFistDuration, 30f, 0f, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.LeadenFistBar, leadenFistDuration, 30f, 0f, player)
+                    .Draw(pos);
             }
         }
 

--- a/DelvUI/Interface/Jobs/NinjaHud.cs
+++ b/DelvUI/Interface/Jobs/NinjaHud.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using Dalamud.Game.ClientState.JobGauge.Types;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Statuses;
@@ -12,6 +8,9 @@ using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using DelvUI.Interface.GeneralElements;
 using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 
 namespace DelvUI.Interface.Jobs
 {
@@ -157,7 +156,8 @@ namespace DelvUI.Interface.Jobs
                 if (!Config.MudraBar.HideWhenInactive || current < max)
                 {
                     Config.MudraBar.Label.SetValue((max - current) % 20);
-                    BarUtilities.GetChunkedProgressBars(Config.MudraBar, 2, current, max, 0f, player).Draw(pos);
+                    BarUtilities.GetChunkedProgressBars(Config.MudraBar, 2, current, max, 0f, player)
+                        .Draw(pos);
                 }
             }
         }
@@ -170,7 +170,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.HutonBar.HideWhenInactive || gauge.HutonTimer > 0)
             {
                 Config.HutonBar.Label.SetValue(hutonDuration);
-                BarUtilities.GetProgressBar(Config.HutonBar, hutonDuration, 60f, 0f, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.HutonBar, hutonDuration, 60f, 0f, player)
+                    .Draw(pos);
             }
         }
 
@@ -181,7 +182,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.NinkiBar.HideWhenInactive || gauge.Ninki > 0)
             {
                 Config.NinkiBar.Label.SetValue(gauge.Ninki);
-                BarUtilities.GetChunkedProgressBars(Config.NinkiBar, 2, gauge.Ninki, 100).Draw(pos);
+                BarUtilities.GetChunkedProgressBars(Config.NinkiBar, 2, gauge.Ninki, 100, 0, player)
+                    .Draw(pos);
             }
         }
 
@@ -198,7 +200,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.TrickAttackBar.HideWhenInactive || trickDuration > 0)
             {
                 Config.TrickAttackBar.Label.SetValue(trickDuration);
-                BarUtilities.GetProgressBar(Config.TrickAttackBar, trickDuration, 15f, 0f, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.TrickAttackBar, trickDuration, 15f, 0f, player)
+                    .Draw(pos);
             }
         }
 
@@ -209,7 +212,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.SuitonBar.HideWhenInactive || suitonDuration > 0)
             {
                 Config.SuitonBar.Label.SetValue(suitonDuration);
-                BarUtilities.GetProgressBar(Config.SuitonBar, suitonDuration, 20f, 0f, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.SuitonBar, suitonDuration, 20f, 0f, player)
+                    .Draw(pos);
             }
         }
 

--- a/DelvUI/Interface/Jobs/PaladinHud.cs
+++ b/DelvUI/Interface/Jobs/PaladinHud.cs
@@ -1,16 +1,16 @@
-﻿using DelvUI.Config;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.ClientState.Statuses;
+using DelvUI.Config;
 using DelvUI.Config.Attributes;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
+using DelvUI.Interface.GeneralElements;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using Dalamud.Game.ClientState.JobGauge.Types;
-using Dalamud.Game.ClientState.Objects.SubKinds;
-using Dalamud.Game.ClientState.Statuses;
-using DelvUI.Interface.GeneralElements;
 
 namespace DelvUI.Interface.Jobs
 {
@@ -64,7 +64,7 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.OathGauge.Enabled)
             {
-                DrawOathGauge(pos);
+                DrawOathGauge(pos, player);
             }
 
             if (Config.FightOrFlightBar.Enabled)
@@ -88,14 +88,15 @@ namespace DelvUI.Interface.Jobs
             }
         }
 
-        private void DrawOathGauge(Vector2 origin)
+        private void DrawOathGauge(Vector2 origin, PlayerCharacter player)
         {
             PLDGauge gauge = Plugin.JobGauges.Get<PLDGauge>();
 
             if (!Config.OathGauge.HideWhenInactive || gauge.OathGauge > 0)
             {
                 Config.OathGauge.Label.SetValue(gauge.OathGauge);
-                BarUtilities.GetChunkedProgressBars(Config.OathGauge, 2, gauge.OathGauge, 100).Draw(origin);
+                BarUtilities.GetChunkedProgressBars(Config.OathGauge, 2, gauge.OathGauge, 100, 0, player)
+                    .Draw(origin);
             }
         }
 
@@ -106,7 +107,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.FightOrFlightBar.HideWhenInactive || fightOrFlightDuration > 0)
             {
                 Config.FightOrFlightBar.Label.SetValue(fightOrFlightDuration);
-                BarUtilities.GetProgressBar(Config.FightOrFlightBar, fightOrFlightDuration, 25f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.FightOrFlightBar, fightOrFlightDuration, 25f, 0f, player)
+                    .Draw(origin);
             }
         }
 
@@ -137,7 +139,7 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.AtonementBar.HideWhenInactive && stackCount == 0) { return; };
 
-            BarUtilities.GetChunkedBars(Config.AtonementBar, 3, stackCount, 3f)
+            BarUtilities.GetChunkedBars(Config.AtonementBar, 3, stackCount, 3f, 0, player)
                 .Draw(origin);
         }
 

--- a/DelvUI/Interface/Jobs/ReaperHud.cs
+++ b/DelvUI/Interface/Jobs/ReaperHud.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using Dalamud.Game.ClientState.JobGauge.Types;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
 using DelvUI.Config;
@@ -12,6 +8,10 @@ using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using DelvUI.Interface.GeneralElements;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 
 namespace DelvUI.Interface.Jobs
 {
@@ -94,7 +94,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.DeathsDesignBar.HideWhenInactive || duration > 0)
             {
                 Config.DeathsDesignBar.Label.SetValue(duration);
-                BarUtilities.GetChunkedProgressBars(Config.DeathsDesignBar, 2, duration, 60f, 0f, player).Draw(pos);
+                BarUtilities.GetChunkedProgressBars(Config.DeathsDesignBar, 2, duration, 60f, 0f, player)
+                    .Draw(pos);
             }
         }
 
@@ -105,7 +106,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.SoulBar.HideWhenInactive || soul > 0)
             {
                 Config.SoulBar.Label.SetValue(soul);
-                BarUtilities.GetChunkedProgressBars(Config.SoulBar, 2, soul, 100f, 0f, player).Draw(pos);
+                BarUtilities.GetChunkedProgressBars(Config.SoulBar, 2, soul, 100f, 0f, player)
+                    .Draw(pos);
             }
         }
 
@@ -116,7 +118,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.ShroudBar.HideWhenInactive || shroud > 0)
             {
                 Config.ShroudBar.Label.SetValue(shroud);
-                BarUtilities.GetChunkedProgressBars(Config.ShroudBar, 2, shroud, 100f, 0f, player).Draw(pos);
+                BarUtilities.GetChunkedProgressBars(Config.ShroudBar, 2, shroud, 100f, 0f, player)
+                    .Draw(pos);
             }
         }
 
@@ -146,7 +149,8 @@ namespace DelvUI.Interface.Jobs
                 }
 
                 Config.DeathGauge.EnshroudTimerLabel.SetValue(gauge.EnshroudedTimeRemaining / 1000);
-                BarUtilities.GetChunkedBars(Config.DeathGauge, deathChunks, player).Draw(pos);
+                BarUtilities.GetChunkedBars(Config.DeathGauge, deathChunks, player)
+                    .Draw(pos);
             }
         }
     }

--- a/DelvUI/Interface/Jobs/RedMageHud.cs
+++ b/DelvUI/Interface/Jobs/RedMageHud.cs
@@ -7,7 +7,6 @@ using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using DelvUI.Interface.GeneralElements;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -78,17 +77,17 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.BalanceBar.Enabled)
             {
-                DrawBalanceBar(pos);
+                DrawBalanceBar(pos, player);
             }
 
             if (Config.WhiteManaBar.Enabled)
             {
-                DrawWhiteManaBar(pos);
+                DrawWhiteManaBar(pos, player);
             }
 
             if (Config.BlackManaBar.Enabled)
             {
-                DrawBlackManaBar(pos);
+                DrawBlackManaBar(pos, player);
             }
 
             if (Config.ManaStacksBar.Enabled)
@@ -112,7 +111,7 @@ namespace DelvUI.Interface.Jobs
             }
         }
 
-        private void DrawBalanceBar(Vector2 origin)
+        private void DrawBalanceBar(Vector2 origin, PlayerCharacter player)
         {
             RDMGauge gauge = Plugin.JobGauges.Get<RDMGauge>();
             float whiteGauge = (float)Plugin.JobGauges.Get<RDMGauge>().WhiteMana;
@@ -142,11 +141,11 @@ namespace DelvUI.Interface.Jobs
                 return;
             }
 
-            BarUtilities.GetBar(Config.BalanceBar, value, 1, fillColor: color)
+            BarUtilities.GetBar(Config.BalanceBar, value, 1, 0, player, color)
                 .Draw(origin);
         }
 
-        private void DrawWhiteManaBar(Vector2 origin)
+        private void DrawWhiteManaBar(Vector2 origin, PlayerCharacter player)
         {
             byte mana = Plugin.JobGauges.Get<RDMGauge>().WhiteMana;
             if (Config.WhiteManaBar.HideWhenInactive && mana == 0)
@@ -155,11 +154,11 @@ namespace DelvUI.Interface.Jobs
             }
 
             Config.WhiteManaBar.Label.SetValue(mana);
-            BarUtilities.GetProgressBar(Config.WhiteManaBar, mana, 100).
+            BarUtilities.GetProgressBar(Config.WhiteManaBar, mana, 100, 0, player).
                 Draw(origin);
         }
 
-        private void DrawBlackManaBar(Vector2 origin)
+        private void DrawBlackManaBar(Vector2 origin, PlayerCharacter player)
         {
             byte mana = Plugin.JobGauges.Get<RDMGauge>().BlackMana;
             if (Config.BlackManaBar.HideWhenInactive && mana == 0)
@@ -168,7 +167,7 @@ namespace DelvUI.Interface.Jobs
             }
 
             Config.BlackManaBar.Label.SetValue(mana);
-            BarUtilities.GetProgressBar(Config.BlackManaBar, mana, 100).
+            BarUtilities.GetProgressBar(Config.BlackManaBar, mana, 100, 0, player).
                 Draw(origin);
         }
 
@@ -180,7 +179,7 @@ namespace DelvUI.Interface.Jobs
                 return;
             }
 
-            BarUtilities.GetChunkedBars(Config.ManaStacksBar, 3, manaStacks, 3f)
+            BarUtilities.GetChunkedBars(Config.ManaStacksBar, 3, manaStacks, 3f, 0, player)
                 .Draw(origin);
         }
 
@@ -194,7 +193,7 @@ namespace DelvUI.Interface.Jobs
             };
 
             Config.DualcastBar.Label.SetValue(duration);
-            BarUtilities.GetProgressBar(Config.DualcastBar, duration, 15f).
+            BarUtilities.GetProgressBar(Config.DualcastBar, duration, 15f, 0, player).
                 Draw(origin);
         }
 

--- a/DelvUI/Interface/Jobs/SageHud.cs
+++ b/DelvUI/Interface/Jobs/SageHud.cs
@@ -1,15 +1,15 @@
-﻿using System.Numerics;
-using Dalamud.Game.ClientState.JobGauge.Types;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.ClientState.Objects.Types;
 using DelvUI.Config;
 using DelvUI.Config.Attributes;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
+using DelvUI.Interface.GeneralElements;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
-using Dalamud.Game.ClientState.Objects.SubKinds;
-using Dalamud.Game.ClientState.Objects.Types;
-using DelvUI.Interface.GeneralElements;
+using System.Numerics;
 
 namespace DelvUI.Interface.Jobs
 {
@@ -60,10 +60,25 @@ namespace DelvUI.Interface.Jobs
         {
             Vector2 pos = origin + Config.Position;
 
-            if (Config.AddersgallBar.Enabled) { DrawAddersgallBar(pos, player); }
-            if (Config.DotBar.Enabled) { DrawDotBar(pos, player); }
-            if (Config.KeracholeBar.Enabled) { DrawKeracholeBar(pos, player); }
-            if (Config.PhysisBar.Enabled) { DrawPhysisBar(pos, player); }
+            if (Config.AddersgallBar.Enabled)
+            {
+                DrawAddersgallBar(pos, player);
+            }
+
+            if (Config.DotBar.Enabled)
+            {
+                DrawDotBar(pos, player);
+            }
+
+            if (Config.KeracholeBar.Enabled)
+            {
+                DrawKeracholeBar(pos, player);
+            }
+
+            if (Config.PhysisBar.Enabled)
+            {
+                DrawPhysisBar(pos, player);
+            }
         }
 
         private void DrawDotBar(Vector2 origin, PlayerCharacter player)
@@ -86,12 +101,14 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.AddersgallBar.HideWhenInactive || adderScale > 0)
             {
-                BarUtilities.GetChunkedBars(Config.AddersgallBar, 3, adderScale, 3, glowConfig: glow, chunksToGlow: new[] { true, true, true }).Draw(origin);
+                BarUtilities.GetChunkedBars(Config.AddersgallBar, 3, adderScale, 3, 0, player, glowConfig: glow, chunksToGlow: new[] { true, true, true })
+                    .Draw(origin);
             }
 
             if (!Config.AdderstingBar.HideWhenInactive && Config.AdderstingBar.Enabled || gauge.Addersting > 0)
             {
-                BarUtilities.GetChunkedBars(Config.AdderstingBar, 3, gauge.Addersting, 3, glowConfig: glow, chunksToGlow: new[] { true, true, true }).Draw(origin);
+                BarUtilities.GetChunkedBars(Config.AdderstingBar, 3, gauge.Addersting, 3, 0, player, glowConfig: glow, chunksToGlow: new[] { true, true, true })
+                    .Draw(origin);
             }
         }
 
@@ -102,7 +119,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.PhysisBar.HideWhenInactive || physisDuration > 0)
             {
                 Config.PhysisBar.Label.SetValue(physisDuration);
-                BarUtilities.GetProgressBar(Config.PhysisBar, physisDuration, 15f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.PhysisBar, physisDuration, 15f, 0f, player)
+                    .Draw(origin);
             }
         }
 
@@ -115,8 +133,10 @@ namespace DelvUI.Interface.Jobs
             {
                 float duration = holosDuration > 0 ? holosDuration : keracholeDuration;
                 float maxDuration = holosDuration > 0 ? 20f : 15f;
+
                 Config.KeracholeBar.Label.SetValue(duration);
-                BarUtilities.GetProgressBar(Config.KeracholeBar, duration, maxDuration, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.KeracholeBar, duration, maxDuration, 0f, player)
+                    .Draw(origin);
             }
         }
     }

--- a/DelvUI/Interface/Jobs/SamuraiHud.cs
+++ b/DelvUI/Interface/Jobs/SamuraiHud.cs
@@ -91,7 +91,7 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.MeditationBar.Enabled)
             {
-                DrawMeditationBar(origin + Config.Position);
+                DrawMeditationBar(origin + Config.Position, player);
             }
 
             if (Config.HiganbanaBar.Enabled)
@@ -107,7 +107,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.KenkiBar.HideWhenInactive || gauge.Kenki > 0)
             {
                 Config.KenkiBar.Label.SetValue(gauge.Kenki);
-                BarUtilities.GetProgressBar(Config.KenkiBar, gauge.Kenki, 100f, 0f, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.KenkiBar, gauge.Kenki, 100f, 0f, player)
+                    .Draw(pos);
             }
         }
 
@@ -118,7 +119,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.ShifuBar.HideWhenInactive || shifuDuration > 0)
             {
                 Config.ShifuBar.Label.SetValue(shifuDuration);
-                BarUtilities.GetProgressBar(Config.ShifuBar, shifuDuration, 40f, 0f, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.ShifuBar, shifuDuration, 40f, 0f, player)
+                    .Draw(pos);
             }
         }
 
@@ -129,7 +131,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.JinpuBar.HideWhenInactive || jinpuDuration > 0)
             {
                 Config.JinpuBar.Label.SetValue(jinpuDuration);
-                BarUtilities.GetProgressBar(Config.JinpuBar, jinpuDuration, 40f, 0f, player).Draw(pos);
+                BarUtilities.GetProgressBar(Config.JinpuBar, jinpuDuration, 40f, 0f, player)
+                    .Draw(pos);
             }
         }
 
@@ -156,16 +159,18 @@ namespace DelvUI.Interface.Jobs
                     sen[i] = new Tuple<PluginConfigColor, float, LabelConfig?>(colors[order[i]], hasSen[order[i]], null);
                 }
 
-                BarUtilities.GetChunkedBars(Config.SenBar, sen, player).Draw(pos);
+                BarUtilities.GetChunkedBars(Config.SenBar, sen, player)
+                    .Draw(pos);
             }
         }
 
-        private void DrawMeditationBar(Vector2 pos)
+        private void DrawMeditationBar(Vector2 pos, PlayerCharacter player)
         {
             SAMGauge gauge = Plugin.JobGauges.Get<SAMGauge>();
             if (!Config.MeditationBar.HideWhenInactive || gauge.MeditationStacks > 0)
             {
-                BarUtilities.GetChunkedBars(Config.MeditationBar, 3, gauge.MeditationStacks, 3f).Draw(pos);
+                BarUtilities.GetChunkedBars(Config.MeditationBar, 3, gauge.MeditationStacks, 3f, 0, player)
+                    .Draw(pos);
             }
         }
     }

--- a/DelvUI/Interface/Jobs/ScholarHud.cs
+++ b/DelvUI/Interface/Jobs/ScholarHud.cs
@@ -59,10 +59,25 @@ namespace DelvUI.Interface.Jobs
         {
             Vector2 pos = origin + Config.Position;
 
-            if (Config.BioBar.Enabled) { DrawBioBar(pos, player); }
-            if (Config.FairyGaugeBar.Enabled) { DrawFairyGaugeBar(pos); }
-            if (Config.AetherflowBar.Enabled) { DrawAetherBar(pos, player); }
-            if (Config.SacredSoilBar.Enabled) { DrawSacredSoilBar(pos, player); }
+            if (Config.BioBar.Enabled)
+            {
+                DrawBioBar(pos, player);
+            }
+
+            if (Config.FairyGaugeBar.Enabled)
+            {
+                DrawFairyGaugeBar(pos, player);
+            }
+
+            if (Config.AetherflowBar.Enabled)
+            {
+                DrawAetherBar(pos, player);
+            }
+
+            if (Config.SacredSoilBar.Enabled)
+            {
+                DrawSacredSoilBar(pos, player);
+            }
         }
 
         private void DrawBioBar(Vector2 origin, PlayerCharacter player)
@@ -73,7 +88,7 @@ namespace DelvUI.Interface.Jobs
                 Draw(origin);
         }
 
-        private void DrawFairyGaugeBar(Vector2 origin)
+        private void DrawFairyGaugeBar(Vector2 origin, PlayerCharacter player)
         {
             byte fairyGauge = Plugin.JobGauges.Get<SCHGauge>().FairyGauge;
             short seraphDuration = Math.Abs(Plugin.JobGauges.Get<SCHGauge>().SeraphTimer);
@@ -86,13 +101,13 @@ namespace DelvUI.Interface.Jobs
             if (Config.FairyGaugeBar.ShowSeraph && seraphDuration > 0)
             {
                 Config.FairyGaugeBar.Label.SetValue(seraphDuration / 1000);
-                BarUtilities.GetProgressBar(Config.FairyGaugeBar, seraphDuration / 1000, 22, fillColor: Config.FairyGaugeBar.SeraphColor).
+                BarUtilities.GetProgressBar(Config.FairyGaugeBar, seraphDuration / 1000, 22, 0, player, Config.FairyGaugeBar.SeraphColor).
                     Draw(origin);
             }
             else
             {
                 Config.FairyGaugeBar.Label.SetValue(fairyGauge);
-                BarUtilities.GetProgressBar(Config.FairyGaugeBar, fairyGauge, 100).
+                BarUtilities.GetProgressBar(Config.FairyGaugeBar, fairyGauge, 100, 0, player).
                     Draw(origin);
             }
         }
@@ -106,7 +121,7 @@ namespace DelvUI.Interface.Jobs
                 return;
             };
 
-            BarUtilities.GetChunkedBars(Config.AetherflowBar, 3, stackCount, 3)
+            BarUtilities.GetChunkedBars(Config.AetherflowBar, 3, stackCount, 3, 0, player)
                 .Draw(origin);
         }
 
@@ -117,7 +132,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.SacredSoilBar.HideWhenInactive || sacredSoilDuration > 0)
             {
                 Config.SacredSoilBar.Label.SetValue(sacredSoilDuration);
-                BarUtilities.GetProgressBar(Config.SacredSoilBar, sacredSoilDuration, 15f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.SacredSoilBar, sacredSoilDuration, 15f, 0f, player)
+                    .Draw(origin);
             }
         }
     }

--- a/DelvUI/Interface/Jobs/WarriorHud.cs
+++ b/DelvUI/Interface/Jobs/WarriorHud.cs
@@ -4,7 +4,6 @@ using DelvUI.Config;
 using DelvUI.Config.Attributes;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
-using DelvUI.Interface.GeneralElements;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -74,7 +73,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.SurgingTempestBar.HideWhenInactive || surgingTempestDuration > 0)
             {
                 Config.SurgingTempestBar.Label.SetValue(surgingTempestDuration);
-                BarUtilities.GetProgressBar(Config.SurgingTempestBar, surgingTempestDuration, 60f).Draw(origin);
+                BarUtilities.GetProgressBar(Config.SurgingTempestBar, surgingTempestDuration, 60f, 0, player)
+                    .Draw(origin);
             }
         }
 
@@ -88,7 +88,7 @@ namespace DelvUI.Interface.Jobs
                 Config.BeastGauge.Label.SetValue(gauge.BeastGauge);
 
                 var color = nascentChaosDuration == 0 ? Config.BeastGauge.BeastGaugeColor : Config.BeastGauge.NascentChaosColor;
-                BarUtilities.GetChunkedProgressBars(Config.BeastGauge, 2, gauge.BeastGauge, 100, fillColor: color)
+                BarUtilities.GetChunkedProgressBars(Config.BeastGauge, 2, gauge.BeastGauge, 100, 0, player, fillColor: color)
                     .Draw(origin);
             }
         }
@@ -116,19 +116,41 @@ namespace DelvUI.Interface.Jobs
                 float maxDuration = SpellHelper.Instance.GetRecastTime(spellID);
                 float cooldown = SpellHelper.Instance.GetSpellCooldown(spellID);
                 float currentCooldown = maxDuration - cooldown;
+
                 Config.InnerReleaseBar.Label.SetValue(maxDuration - currentCooldown);
+
                 if (currentCooldown == maxDuration)
                 {
-                    if (Config.InnerReleaseBar.HideWhenInactive)
+                    if (!Config.InnerReleaseBar.HideWhenInactive)
                     {
-                        return;
+                        BarUtilities.GetChunkedProgressBars(
+                            Config.InnerReleaseBar,
+                            1,
+                            1,
+                            1,
+                            0,
+                            player,
+                            fillColor: Config.InnerReleaseBar.CooldownFinishedColor,
+                            glowConfig: primalRendGlow,
+                            chunksToGlow: new[] { true })
+                            .Draw(origin);
                     }
-                    BarUtilities.GetChunkedProgressBars(Config.InnerReleaseBar, 1, 1, 1, fillColor: Config.InnerReleaseBar.CooldownFinishedColor, glowConfig: primalRendGlow, chunksToGlow: new[] { true }).Draw(origin);
                 }
                 else
                 {
-                    BarUtilities.GetChunkedProgressBars(Config.InnerReleaseBar, 1, currentCooldown, maxDuration, fillColor: Config.InnerReleaseBar.CooldownInProgressColor, glowConfig: primalRendGlow, chunksToGlow: new[] { true }).Draw(origin);
+                    BarUtilities.GetChunkedProgressBars(
+                        Config.InnerReleaseBar,
+                        1,
+                        currentCooldown,
+                        maxDuration,
+                        0,
+                        player,
+                        fillColor: Config.InnerReleaseBar.CooldownInProgressColor,
+                        glowConfig: primalRendGlow,
+                        chunksToGlow: new[] { true })
+                        .Draw(origin);
                 }
+
                 return;
             }
 
@@ -146,7 +168,15 @@ namespace DelvUI.Interface.Jobs
                     innerReleaseDuration = Math.Min(innerReleaseDuration, innerReleaseMaxDuration);
                 }
 
-                BarUtilities.GetChunkedProgressBars(Config.InnerReleaseBar, 3, (innerReleaseStacks - 1) * innerReleaseMaxDuration + innerReleaseDuration, 3 * innerReleaseMaxDuration, glowConfig: primalRendGlow, chunksToGlow: new[] { true, true, true })
+                BarUtilities.GetChunkedProgressBars(
+                    Config.InnerReleaseBar,
+                    3,
+                    (innerReleaseStacks - 1) * innerReleaseMaxDuration + innerReleaseDuration,
+                    3 * innerReleaseMaxDuration,
+                    0,
+                    player,
+                    primalRendGlow,
+                    chunksToGlow: new[] { true, true, true })
                     .Draw(origin);
             }
         }

--- a/DelvUI/Interface/Jobs/WhiteMageHud.cs
+++ b/DelvUI/Interface/Jobs/WhiteMageHud.cs
@@ -1,15 +1,14 @@
-﻿using System;
-using System.Linq;
-using System.Numerics;
-using Dalamud.Game.ClientState.JobGauge.Types;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.Objects.SubKinds;
 using DelvUI.Config;
 using DelvUI.Config.Attributes;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
+using DelvUI.Interface.GeneralElements;
 using Newtonsoft.Json;
 using System.Collections.Generic;
-using Dalamud.Game.ClientState.Objects.SubKinds;
-using DelvUI.Interface.GeneralElements;
+using System.Linq;
+using System.Numerics;
 
 namespace DelvUI.Interface.Jobs
 {
@@ -72,12 +71,35 @@ namespace DelvUI.Interface.Jobs
         {
             Vector2 pos = origin + Config.Position;
 
-            if (Config.LilyBar.Enabled) { DrawLilyBar(pos, player); }
-            if (Config.DiaBar.Enabled) { DrawDiaBar(pos, player); }
-            if (Config.AsylumBar.Enabled) { DrawAsylumBar(pos, player); }
-            if (Config.PresenceOfMindBar.Enabled) { DrawPresenceOfMindBar(pos, player); }
-            if (Config.PlenaryBar.Enabled) { DrawPlenaryBar(pos, player); }
-            if (Config.TemperanceBar.Enabled) { DrawTemperanceBar(pos, player); }
+            if (Config.LilyBar.Enabled)
+            {
+                DrawLilyBar(pos, player);
+            }
+
+            if (Config.DiaBar.Enabled)
+            {
+                DrawDiaBar(pos, player);
+            }
+
+            if (Config.AsylumBar.Enabled)
+            {
+                DrawAsylumBar(pos, player);
+            }
+
+            if (Config.PresenceOfMindBar.Enabled)
+            {
+                DrawPresenceOfMindBar(pos, player);
+            }
+
+            if (Config.PlenaryBar.Enabled)
+            {
+                DrawPlenaryBar(pos, player);
+
+            }
+            if (Config.TemperanceBar.Enabled)
+            {
+                DrawTemperanceBar(pos, player);
+            }
         }
 
         private void DrawDiaBar(Vector2 origin, PlayerCharacter player)
@@ -99,12 +121,14 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.LilyBar.HideWhenInactive || lilyScale > 0)
             {
-                BarUtilities.GetChunkedBars(Config.LilyBar, 3, lilyScale, 3).Draw(origin);
+                BarUtilities.GetChunkedBars(Config.LilyBar, 3, lilyScale, 3, 0, player)
+                    .Draw(origin);
             }
 
             if (!Config.BloodLilyBar.HideWhenInactive && Config.BloodLilyBar.Enabled || gauge.BloodLily > 0)
             {
-                BarUtilities.GetChunkedBars(Config.BloodLilyBar, 3, gauge.BloodLily, 3).Draw(origin);
+                BarUtilities.GetChunkedBars(Config.BloodLilyBar, 3, gauge.BloodLily, 3, 0, player)
+                    .Draw(origin);
             }
         }
 
@@ -115,7 +139,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.AsylumBar.HideWhenInactive || asylymDuration > 0)
             {
                 Config.AsylumBar.Label.SetValue(asylymDuration);
-                BarUtilities.GetProgressBar(Config.AsylumBar, asylymDuration, 24f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.AsylumBar, asylymDuration, 24f, 0f, player)
+                    .Draw(origin);
             }
         }
 
@@ -126,7 +151,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.PresenceOfMindBar.HideWhenInactive || presenceOfMindDuration > 0)
             {
                 Config.PresenceOfMindBar.Label.SetValue(presenceOfMindDuration);
-                BarUtilities.GetProgressBar(Config.PresenceOfMindBar, presenceOfMindDuration, 15f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.PresenceOfMindBar, presenceOfMindDuration, 15f, 0f, player)
+                    .Draw(origin);
             }
         }
 
@@ -137,7 +163,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.PlenaryBar.HideWhenInactive || plenaryDuration > 0)
             {
                 Config.PlenaryBar.Label.SetValue(plenaryDuration);
-                BarUtilities.GetProgressBar(Config.PlenaryBar, plenaryDuration, 10f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.PlenaryBar, plenaryDuration, 10f, 0f, player)
+                    .Draw(origin);
             }
         }
 
@@ -148,7 +175,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.TemperanceBar.HideWhenInactive || temperanceDuration > 0)
             {
                 Config.TemperanceBar.Label.SetValue(temperanceDuration);
-                BarUtilities.GetProgressBar(Config.TemperanceBar, temperanceDuration, 20f, 0f, player).Draw(origin);
+                BarUtilities.GetProgressBar(Config.TemperanceBar, temperanceDuration, 20f, 0f, player)
+                    .Draw(origin);
             }
         }
     }

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -98,7 +98,7 @@ namespace DelvUI
                 AssemblyLocation = Assembly.GetExecutingAssembly().Location;
             }
 
-            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.6.1.1";
+            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.6.1.2";
 
             FontsManager.Initialize(AssemblyLocation);
             LoadBanner();

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,8 @@
+# 0.6.1.2
+Fixes:
+- Fixed job and role colors not working on some job hud bars.
+- Fixed Summoner's Ifrit, Titan and Garuda bars "Hide When Inactive" not working.
+
 # 0.6.1.1
 Features:
 - Sage Kerachole tracker now also tracks Holos uptime and the config option for this bar was renamed to show that.


### PR DESCRIPTION
This should fix job and role colors for all of them. I probably passed the reference to bars that didn't need it (aka bars without text), but that shouldn't break anything (it was the easiest way to make sure all of them got fixed without needing to test).
I had to basically touch every job hud file so editorconfig changes are included in this. I might've also made some minor styling changes on some files just for consistency.

Also fixed SMN primal bars "hide when inactive"