### PR TITLE
AST Minor Arcana timer when Crown Card is drawn

### DIFF
--- a/DelvUI/Interface/Jobs/AstrologianHud.cs
+++ b/DelvUI/Interface/Jobs/AstrologianHud.cs
@@ -344,13 +344,40 @@ namespace DelvUI.Interface.Jobs
 
             float crownCardPresent;
             float crownCardMax;
+            float maxDuration = SpellHelper.Instance.GetRecastTime(7443);
             float cooldown = _spellHelper.GetSpellCooldown(7443);
+            float currentCooldown = maxDuration - cooldown;
 
             if (crownCardDrawn != "")
             {
                 crownCardPresent = 1f;
                 crownCardMax = 1f;
                 Config.MinorArcanaBar.Label.SetText(crownCardDrawn);
+
+                if (Config.MinorArcanaBar.CrownDrawTimerLabel.Enabled)
+                {
+                    switch (cooldown)
+                    {
+                        case > 0:
+                            Config.MinorArcanaBar.CrownDrawTimerLabel.SetValue(maxDuration - currentCooldown);
+
+                            break;
+
+                        case 0 when gauge.DrawnCrownCard != CardType.NONE:
+                            Config.MinorArcanaBar.CrownDrawTimerLabel.SetText("READY (" + (maxDuration - currentCooldown).ToString("0") + ")");
+
+                            break;
+
+                        default:
+                            Config.MinorArcanaBar.CrownDrawTimerLabel.SetText("READY");
+
+                            break;
+                    }
+                }
+                else
+                {
+                    Config.MinorArcanaBar.CrownDrawTimerLabel.SetText("");
+                }
             }
             else
             {
@@ -365,11 +392,12 @@ namespace DelvUI.Interface.Jobs
                     Config.MinorArcanaBar.Label.SetText("READY");
                 }
 
+                Config.MinorArcanaBar.CrownDrawTimerLabel.SetText("");
                 crownCardColor = cooldown > 0 ? Config.MinorArcanaBar.CrownDrawCdColor : Config.MinorArcanaBar.CrownDrawCdReadyColor;
                 crownCardMax = cooldown > 0 ? 60f : 1f;
             }
 
-            LabelConfig[] labels = { Config.MinorArcanaBar.Label };
+            LabelConfig[] labels = { Config.MinorArcanaBar.Label, Config.MinorArcanaBar.CrownDrawTimerLabel };
             BarUtilities.GetBar(Config.MinorArcanaBar, crownCardPresent, crownCardMax, 0f, player, crownCardColor, labels: labels)
                 .Draw(pos);
         }
@@ -513,6 +541,9 @@ namespace DelvUI.Interface.Jobs
         [Exportable(false)]
         public class AstrologianCrownDrawBarConfig : ProgressBarConfig
         {
+            [NestedConfig("Minor Arcana Side Timer Label" + "##CrownDraw", 119, separator = false, spacing = true)]
+            public NumericLabelConfig CrownDrawTimerLabel = new(new Vector2(0, 0), "", DrawAnchor.Left, DrawAnchor.Left);
+
             [ColorEdit4("Minor Arcana on CD" + "##CrownDraw")]
             [Order(120)]
             public PluginConfigColor CrownDrawCdColor = new(new Vector4(26f / 255f, 167f / 255f, 109f / 255f, 100f / 100f));

--- a/DelvUI/Interface/Jobs/AstrologianHud.cs
+++ b/DelvUI/Interface/Jobs/AstrologianHud.cs
@@ -291,17 +291,17 @@ namespace DelvUI.Interface.Jobs
             {
                 cardPresent = drawCastInfo > 0 ? current : 1f;
 
-                if (drawCastInfo > 0 && drawCharges == 0)
+                switch (drawCastInfo)
                 {
-                    Config.DrawBar.Label.SetValue(current);
-                }
-                else if (drawCastInfo > 0 && drawCharges > 0)
-                {
-                    Config.DrawBar.Label.SetText("READY (" + current.ToString("0") + ")");
-                }
-                else
-                {
-                    Config.DrawBar.Label.SetText("READY");
+                    case > 0 when drawCharges == 0:
+                        Config.DrawBar.Label.SetValue(current);
+                        break;
+                    case > 0 when drawCharges > 0:
+                        Config.DrawBar.Label.SetText("READY (" + current.ToString("0") + ")");
+                        break;
+                    default:
+                        Config.DrawBar.Label.SetText("READY");
+                        break;
                 }
 
                 Config.DrawBar.DrawDrawLabel.SetText("");
@@ -344,9 +344,7 @@ namespace DelvUI.Interface.Jobs
 
             float crownCardPresent;
             float crownCardMax;
-            float maxDuration = SpellHelper.Instance.GetRecastTime(7443);
             float cooldown = _spellHelper.GetSpellCooldown(7443);
-            float currentCooldown = maxDuration - cooldown;
 
             if (crownCardDrawn != "")
             {
@@ -359,18 +357,10 @@ namespace DelvUI.Interface.Jobs
                     switch (cooldown)
                     {
                         case > 0:
-                            Config.MinorArcanaBar.CrownDrawTimerLabel.SetValue(maxDuration - currentCooldown);
-
+                            Config.MinorArcanaBar.CrownDrawTimerLabel.SetValue(cooldown);
                             break;
-
-                        case 0 when gauge.DrawnCrownCard != CardType.NONE:
-                            Config.MinorArcanaBar.CrownDrawTimerLabel.SetText("READY (" + (maxDuration - currentCooldown).ToString("0") + ")");
-
-                            break;
-
                         default:
                             Config.MinorArcanaBar.CrownDrawTimerLabel.SetText("READY");
-
                             break;
                     }
                 }

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,4 +1,7 @@
 # 0.6.1.2
+Features:
+- Astrologian Minor Arcana Bar now has a label to track cooldown of Minor Arcana whilst a Crown Card is drawn. Note that this will not work for users of the XIVCombo plugin that has selected the option to turn Minor Arcana into Crown Play.
+
 Fixes:
 - Fixed job and role colors not working on some job hud bars.
 - Fixed Summoner's Ifrit, Titan and Garuda bars "Hide When Inactive" not working.


### PR DESCRIPTION
Shows a timer on the left side of the bar to indicate recast timer of minor arcana when Lord/Lady is drawn.

NOTE: This won't work for users of XIVCombo that select the "Minor Arcana into Crown Play" option as it effectively changes the ability ID of Crown Play to 7443 which is normally Minor Arcana, and so the tracking will look at that.