### PR TITLE
Adding party cooldowns tooltips

### DIFF
--- a/DelvUI/Interface/PartyCooldowns/PartyCooldown.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldown.cs
@@ -1,6 +1,8 @@
 ﻿using DelvUI.Helpers;
 using DelvUI.Interface.Party;
 using ImGuiNET;
+using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace DelvUI.Interface.PartyCooldowns
 {
@@ -44,12 +46,16 @@ namespace DelvUI.Interface.PartyCooldowns
 
     public class PartyCooldownData
     {
+        public bool Enabled = true;
+
         public uint ActionId = 0;
-        public uint JobId = 0;
-        public JobRoles Role = JobRoles.Unknown;
         public uint RequiredLevel = 0;
 
-        public bool Enabled = true;
+        public uint JobId = 0; // keep this for backwards compatibility
+        public List<uint>? JobIds = null;
+
+        public JobRoles Role = JobRoles.Unknown; // keep this for backwards compatibility
+        public List<JobRoles>? Roles = null;
 
         public int CooldownDuration = 0;
         public int EffectDuration = 0;
@@ -57,11 +63,78 @@ namespace DelvUI.Interface.PartyCooldowns
         public int Priority = 0;
         public int Column = 1;
 
-        public uint IconId = 0;
+        [JsonIgnore] public uint IconId = 0;
+        [JsonIgnore] public string Name = "";
+
+        public string TooltipText()
+        {
+            string effectDuration = EffectDuration > 0 ? $"Duration: {EffectDuration}s \n" : "";
+            return $"{effectDuration}Recast Time: {CooldownDuration}s";
+        }
 
         public virtual bool IsUsableBy(uint jobId)
         {
-            return Role != JobRoles.Unknown ? JobsHelper.RoleForJob(jobId) == Role : JobId == jobId;
+            JobRoles roleForJob = JobsHelper.RoleForJob(jobId);
+
+            if (Roles != null)
+            {
+                foreach (JobRoles role in Roles)
+                {
+                    if (role == roleForJob)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            if (Role != JobRoles.Unknown)
+            {
+                return Role == roleForJob;
+            }
+
+            if (JobIds != null)
+            {
+                foreach (uint id in JobIds)
+                {
+                    if (id == jobId)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return JobId == jobId;
+        }
+
+        public bool HasRole(JobRoles role)
+        {
+            if (Roles != null)
+            {
+                return Roles.Contains(role);
+            }
+
+            if (Role != JobRoles.Unknown)
+            {
+                return Role == role;
+            }
+
+            if (JobIds != null)
+            {
+                foreach (uint jobId in JobIds)
+                {
+                    JobRoles roleForJob = JobsHelper.RoleForJob(jobId);
+                    if (roleForJob == role)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            return JobsHelper.RoleForJob(JobId) == role;
         }
     }
 }

--- a/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
@@ -234,6 +234,17 @@ namespace DelvUI.Interface.PartyCooldowns
                     }
                     _timeLabelHud.Draw(origin + pos, size, character);
 
+                    // tooltip
+                    pos = origin + new Vector2(Config.Position.X + offsetX, y);
+                    if (Config.ShowTooltips && ImGui.IsMouseHoveringRect(pos, pos + _barConfig.Size))
+                    {
+                        TooltipsHelper.Instance.ShowTooltipOnCursor(
+                            cooldown.Data.TooltipText(),
+                            cooldown.Data.Name,
+                            cooldown.Data.ActionId
+                        );
+                    }
+
                     i++;
                 }
 

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,4 +1,8 @@
 # 0.6.1.2
+Features:
+- Added tooltips for party cooldowns.
+- Added Rescue, Swiftcast and Tank's invulnerabilities as trackable party cooldowns (disabled by default).
+
 Fixes:
 - Fixed job and role colors not working on some job hud bars.
 - Fixed Summoner's Ifrit, Titan and Garuda bars "Hide When Inactive" not working.


### PR DESCRIPTION
Can't show the actual spell descriptions because the data we get is not very user friendly / readable.
Couldn't figure out how to deal with so for now it just shows name, duration and recast time.

Also adding rescue, swiftcast and tank invulns as tracked cooldowns