### PR TITLE
Add BRD Song Thresholds

### DIFF
--- a/DelvUI/Interface/Jobs/BardHud.cs
+++ b/DelvUI/Interface/Jobs/BardHud.cs
@@ -160,7 +160,7 @@ namespace DelvUI.Interface.Jobs
                             );
                     }
 
-                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.WMColor, player);
+                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.WMColor, Config.SongGaugeBar.WMThreshold, player);
 
                     break;
 
@@ -170,7 +170,7 @@ namespace DelvUI.Interface.Jobs
                         DrawBloodletterReady(origin, player);
                     }
 
-                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.MBColor, player);
+                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.MBColor, Config.SongGaugeBar.MBThreshold, player);
 
                     break;
 
@@ -180,7 +180,7 @@ namespace DelvUI.Interface.Jobs
                         DrawStacksBar(origin, player, songStacks, 4, Config.StacksBar.APStackColor);
                     }
 
-                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.APColor, player);
+                    DrawSongTimerBar(origin, songTimer, Config.SongGaugeBar.APColor, Config.SongGaugeBar.APThreshold, player);
 
                     break;
 
@@ -190,7 +190,7 @@ namespace DelvUI.Interface.Jobs
                         DrawStacksBar(origin, player, 0, 3, Config.StacksBar.WMStackColor);
                     }
 
-                    DrawSongTimerBar(origin, 0, EmptyColor, player);
+                    DrawSongTimerBar(origin, 0, EmptyColor, Config.SongGaugeBar.ThresholdConfig,  player);
 
                     break;
 
@@ -200,7 +200,7 @@ namespace DelvUI.Interface.Jobs
                         DrawStacksBar(origin, player, 0, 3, Config.StacksBar.WMStackColor);
                     }
 
-                    DrawSongTimerBar(origin, 0, EmptyColor, player);
+                    DrawSongTimerBar(origin, 0, EmptyColor, Config.SongGaugeBar.ThresholdConfig, player);
 
                     break;
             }
@@ -219,7 +219,7 @@ namespace DelvUI.Interface.Jobs
                 Config.StacksBar.MBGlowConfig.Enabled ? Config.StacksBar.MBGlowConfig : null);
         }
 
-        protected void DrawSongTimerBar(Vector2 origin, ushort songTimer, PluginConfigColor songColor, PlayerCharacter player)
+        protected void DrawSongTimerBar(Vector2 origin, ushort songTimer, PluginConfigColor songColor, ThresholdConfig songThreshold, PlayerCharacter player)
         {
 
             if (Config.SongGaugeBar.HideWhenInactive && songTimer == 0 || !Config.SongGaugeBar.Enabled)
@@ -230,6 +230,7 @@ namespace DelvUI.Interface.Jobs
             float duration = Math.Abs(songTimer / 1000f);
 
             Config.SongGaugeBar.Label.SetValue(duration);
+            Config.SongGaugeBar.ThresholdConfig = songThreshold;
             BarUtilities.GetProgressBar(Config.SongGaugeBar, duration, 45f, 0f, player, songColor)
                         .Draw(origin);
         }
@@ -345,7 +346,7 @@ namespace DelvUI.Interface.Jobs
         );
     }
 
-    [DisableParentSettings("FillColor")]
+    [DisableParentSettings("FillColor", "ThresholdConfig")]
     [Exportable(false)]
     public class BardSongBarConfig : ProgressBarConfig
     {
@@ -360,6 +361,33 @@ namespace DelvUI.Interface.Jobs
         [ColorEdit4("Army's Paeon" + "##Song")]
         [Order(33)]
         public PluginConfigColor APColor = new(new Vector4(207f / 255f, 205f / 255f, 52f / 255f, 100f / 100f));
+        
+        [NestedConfig("Wanderer's Minuet Threshold", 36, separator = false, spacing = true)]
+        public ThresholdConfig WMThreshold = new ThresholdConfig()
+        {
+            ChangeColor = true,
+            Enabled = true,
+            ThresholdType = ThresholdType.Below,
+            Value = 3
+        };
+
+        [NestedConfig("Mage's Ballad Threshold", 37, separator = false, spacing = true)]
+        public ThresholdConfig MBThreshold = new ThresholdConfig()
+        {
+            ChangeColor = true,
+            Enabled = true,
+            ThresholdType = ThresholdType.Below,
+            Value = 14
+        };
+        
+        [NestedConfig("Army's Paeon Threshold", 38, separator = false, spacing = true)]
+        public ThresholdConfig APThreshold = new ThresholdConfig()
+        {
+            ChangeColor = true,
+            Enabled = true,
+            ThresholdType = ThresholdType.Below,
+            Value = 3
+        };
 
         public BardSongBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)
             : base(position, size, fillColor)
@@ -370,7 +398,7 @@ namespace DelvUI.Interface.Jobs
     [Exportable(false)]
     public class BardSoulVoiceBarConfig : ProgressBarConfig
     {
-        [NestedConfig("Show Glow", 36, separator = false, spacing = true)]
+        [NestedConfig("Show Glow", 39, separator = false, spacing = true)]
         public BarGlowConfig GlowConfig = new BarGlowConfig();
 
         public BardSoulVoiceBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,4 +1,7 @@
 # 0.6.1.3
+Features:
+- Added Thresholds for Bard Songs with the recommended song rotation (43, 34, 43).  
+
 Fixes:
 - Fixed Dancer Proc Bars so they can be individually disabled.
 


### PR DESCRIPTION
![Advanced_Combat_Tracker_2021-12-26_15-22-39](https://user-images.githubusercontent.com/4972345/147410998-88aa2355-ff8f-48a6-a5c3-09f41b393ba6.png)

Implements Song Thresholds and sets default values to recommended Song rotation (43, 34, 43).