### PR TITLE
Strata levels

### DIFF
--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -228,7 +228,7 @@ namespace DelvUI.Config.Attributes
     {
         public int min;
         public int max;
-        public int velocity;
+        public float velocity;
 
         public DragIntAttribute(string friendlyName) : base(friendlyName)
         {
@@ -246,7 +246,7 @@ namespace DelvUI.Config.Attributes
             {
                 field.SetValue(config, intVal);
 
-                TriggerChangeEvent<float>(config, field.Name, intVal);
+                TriggerChangeEvent<int>(config, field.Name, intVal);
 
                 return true;
             }

--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using Dalamud.Interface;
+using DelvUI.Enums;
 using DelvUI.Helpers;
 using DelvUI.Interface.GeneralElements;
 using ImGuiNET;
@@ -641,9 +642,7 @@ namespace DelvUI.Config.Attributes
             return false;
         }
     }
-    #endregion
 
-    #region field ordering attributes
     [AttributeUsage(AttributeTargets.Field)]
     public class AnchorAttribute : ComboAttribute
     {
@@ -653,6 +652,41 @@ namespace DelvUI.Config.Attributes
         }
     }
 
+    [AttributeUsage(AttributeTargets.Field)]
+    public class StrataLevelAttribute : ConfigAttribute
+    {
+        private string[] options = { "Lowest", "Low", "Mid-Low", "Mid", "Mid-High", "High", "Highest" };
+
+        public StrataLevelAttribute(string friendlyName) : base(friendlyName)
+        {
+        }
+
+        public override bool DrawField(FieldInfo field, PluginConfigObject config, string? ID, bool collapsingHeader)
+        {
+            object? fieldVal = field.GetValue(config);
+
+            int intVal = 0;
+            if (fieldVal != null)
+            {
+                intVal = (int)fieldVal;
+            }
+
+            if (ImGui.Combo(friendlyName + IDText(ID), ref intVal, options, options.Length, 4))
+            {
+                field.SetValue(config, (StrataLevel?)intVal);
+
+                TriggerChangeEvent<int>(config, field.Name, intVal);
+                ConfigurationManager.Instance?.OnStrataLevelChanged(config);
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+    #endregion
+
+    #region field ordering attributes
     [AttributeUsage(AttributeTargets.Field)]
     public class OrderAttribute : Attribute
     {

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -172,7 +172,7 @@ namespace DelvUI.Config
         private void OnLogout(object? sender, EventArgs? args)
         {
             SaveConfigurations();
-            ProfilesManager.Instance.SaveCurrentProfile();
+            ProfilesManager.Instance?.SaveCurrentProfile();
         }
 
         private void OnJobChanged(uint jobId)

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -21,6 +21,7 @@ using System.Reflection;
 namespace DelvUI.Config
 {
     public delegate void ConfigurationManagerEventHandler(ConfigurationManager configurationManager);
+    public delegate void StrataLevelsEventHandler(ConfigurationManager configurationManager, PluginConfigObject config);
 
     public class ConfigurationManager : IDisposable
     {
@@ -92,6 +93,7 @@ namespace DelvUI.Config
         public event ConfigurationManagerEventHandler? ResetEvent;
         public event ConfigurationManagerEventHandler? LockEvent;
         public event ConfigurationManagerEventHandler? ConfigClosedEvent;
+        public event StrataLevelsEventHandler? StrataLevelsChangedEvent;
 
         public ConfigurationManager()
         {
@@ -229,6 +231,13 @@ namespace DelvUI.Config
                 PluginLog.Error("Error checking version: " + e.Message);
             }
         }
+
+        #region strata
+        public void OnStrataLevelChanged(PluginConfigObject config)
+        {
+            StrataLevelsChangedEvent?.Invoke(this, config);
+        }
+        #endregion
 
         #region windows
         public void ToggleConfigWindow()

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -339,10 +339,7 @@ namespace DelvUI.Config
 
             ConfigBaseNode.Save(ConfigDirectory);
 
-            if (ProfilesManager.Instance != null)
-            {
-                ProfilesManager.Instance.SaveCurrentProfile();
-            }
+            ProfilesManager.Instance?.SaveCurrentProfile();
 
             ConfigBaseNode.NeedsSave = false;
         }
@@ -356,7 +353,7 @@ namespace DelvUI.Config
                 return;
             }
 
-            ProfilesManager.Instance.UpdateCurrentProfile();
+            ProfilesManager.Instance?.UpdateCurrentProfile();
         }
 
         public string? ExportCurrentConfigs()
@@ -416,7 +413,11 @@ namespace DelvUI.Config
 
             string? oldSelection = ConfigBaseNode.SelectedOptionName;
             node.SelectedOptionName = oldSelection;
-            node.AddExtraSectionNode(ProfilesManager.Instance.ProfilesNode);
+
+            if (ProfilesManager.Instance != null)
+            {
+                node.AddExtraSectionNode(ProfilesManager.Instance.ProfilesNode);
+            }
 
             ConfigBaseNode.ConfigObjectResetEvent -= OnConfigObjectReset;
             ConfigBaseNode = node;

--- a/DelvUI/Config/PluginConfigObject.cs
+++ b/DelvUI/Config/PluginConfigObject.cs
@@ -139,6 +139,12 @@ namespace DelvUI.Config
         [JsonIgnore]
         public readonly string ID;
 
+        [StrataLevel("Strata Level")]
+        [Order(2)]
+        public StrataLevel? Strata;
+
+        public StrataLevel StrataLevel => Strata ?? StrataLevel.LOWEST;
+
         [DragInt2("Position", min = -4000, max = 4000)]
         [Order(5)]
         public Vector2 Position = Vector2.Zero;

--- a/DelvUI/DelvUI.csproj
+++ b/DelvUI/DelvUI.csproj
@@ -10,9 +10,9 @@
     <!-- Assembly Configuration -->
     <PropertyGroup>
         <AssemblyName>DelvUI</AssemblyName>
-        <AssemblyVersion>0.6.1.3</AssemblyVersion>
-        <FileVersion>0.6.1.3</FileVersion>
-        <InformationalVersion>0.6.1.3</InformationalVersion>
+        <AssemblyVersion>0.6.2.0</AssemblyVersion>
+        <FileVersion>0.6.2.0</FileVersion>
+        <InformationalVersion>0.6.2.0</InformationalVersion>
     </PropertyGroup>
 
     <!-- Build Configuration -->

--- a/DelvUI/Enums/StrataLevel.cs
+++ b/DelvUI/Enums/StrataLevel.cs
@@ -1,0 +1,13 @@
+﻿namespace DelvUI.Enums
+{
+    public enum StrataLevel
+    {
+        LOWEST = 0,
+        LOW,
+        MID_LOW,
+        MID,
+        MID_HIGH,
+        HIGH,
+        HIGHEST,
+    }
+}

--- a/DelvUI/Helpers/DraggablesHelper.cs
+++ b/DelvUI/Helpers/DraggablesHelper.cs
@@ -89,7 +89,7 @@ namespace DelvUI.Helpers
         public static void DrawElements(
             Vector2 origin,
             HudHelper hudHelper,
-            List<DraggableHudElement> elements,
+            IList<DraggableHudElement> elements,
             JobHud? jobHud,
             DraggableHudElement? selectedElement)
         {

--- a/DelvUI/Helpers/LayoutHelper.cs
+++ b/DelvUI/Helpers/LayoutHelper.cs
@@ -19,15 +19,6 @@ namespace DelvUI.Helpers
             RealColCount = realColCount;
             ContentSize = contentSize;
         }
-
-        public LayoutInfo(uint rows, uint columns, Vector2 contentSize)
-        {
-            TotalRowCount = rows;
-            TotalColCount = columns;
-            RealRowCount = rows;
-            RealColCount = columns;
-            ContentSize = contentSize;
-        }
     }
 
     public static class LayoutHelper

--- a/DelvUI/Helpers/LayoutHelper.cs
+++ b/DelvUI/Helpers/LayoutHelper.cs
@@ -19,6 +19,15 @@ namespace DelvUI.Helpers
             RealColCount = realColCount;
             ContentSize = contentSize;
         }
+
+        public LayoutInfo(uint rows, uint columns, Vector2 contentSize)
+        {
+            TotalRowCount = rows;
+            TotalColCount = columns;
+            RealRowCount = rows;
+            RealColCount = columns;
+            ContentSize = contentSize;
+        }
     }
 
     public static class LayoutHelper

--- a/DelvUI/Interface/Bars/BarHud.cs
+++ b/DelvUI/Interface/Bars/BarHud.cs
@@ -4,6 +4,7 @@ using DelvUI.Enums;
 using DelvUI.Helpers;
 using DelvUI.Interface.GeneralElements;
 using ImGuiNET;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 
@@ -100,12 +101,49 @@ namespace DelvUI.Interface.Bars
             return this;
         }
 
-        public void Draw(Vector2 origin, bool needsInput = false)
+        public void Draw(Vector2 origin)
         {
             var barPos = Utils.GetAnchoredPosition(origin, BackgroundRect.Size, Anchor);
             var backgroundPos = barPos + BackgroundRect.Position;
 
-            DrawHelper.DrawInWindow(ID, backgroundPos, BackgroundRect.Size, needsInput, false, (drawList) =>
+            DrawRects(barPos, backgroundPos);
+
+            // labels
+            foreach (LabelHud label in LabelHuds)
+            {
+                label.Draw(backgroundPos, BackgroundRect.Size, Actor, null, (uint?)Current, (uint?)Max);
+            }
+        }
+
+        public List<(PluginConfigObject, Action)> GetDrawActions(Vector2 origin, PluginConfigObject config)
+        {
+            List<(PluginConfigObject, Action)> drawActions = new List<(PluginConfigObject, Action)>();
+
+            var barPos = Utils.GetAnchoredPosition(origin, BackgroundRect.Size, Anchor);
+            var backgroundPos = barPos + BackgroundRect.Position;
+
+            drawActions.Add((config, () =>
+            {
+                DrawRects(barPos, backgroundPos);
+            }
+            ));
+
+            // labels
+            foreach (LabelHud label in LabelHuds)
+            {
+                drawActions.Add((label.GetConfig(), () =>
+                {
+                    label.Draw(backgroundPos, BackgroundRect.Size, Actor, null, (uint?)Current, (uint?)Max);
+                }
+                ));
+            }
+
+            return drawActions;
+        }
+
+        private void DrawRects(Vector2 barPos, Vector2 backgroundPos)
+        {
+            DrawHelper.DrawInWindow(ID, backgroundPos, BackgroundRect.Size, false, false, (drawList) =>
             {
                 // Draw background
                 drawList.AddRectFilled(backgroundPos, backgroundPos + BackgroundRect.Size, BackgroundRect.Color.Base);
@@ -131,12 +169,6 @@ namespace DelvUI.Interface.Bars
                     drawList.AddRect(glowPosition, glowPosition + glowSize, GlowColor.Base, 0, ImDrawFlags.None, GlowSize);
                 }
             });
-
-            // Draw Labels
-            foreach (LabelHud label in LabelHuds)
-            {
-                label.Draw(backgroundPos, BackgroundRect.Size, Actor, null, (uint?)Current, (uint?)Max);
-            }
         }
     }
 }

--- a/DelvUI/Interface/Bars/BarHud.cs
+++ b/DelvUI/Interface/Bars/BarHud.cs
@@ -115,14 +115,14 @@ namespace DelvUI.Interface.Bars
             }
         }
 
-        public List<(PluginConfigObject, Action)> GetDrawActions(Vector2 origin, PluginConfigObject config)
+        public List<(StrataLevel, Action)> GetDrawActions(Vector2 origin, StrataLevel strataLevel)
         {
-            List<(PluginConfigObject, Action)> drawActions = new List<(PluginConfigObject, Action)>();
+            List<(StrataLevel, Action)> drawActions = new List<(StrataLevel, Action)>();
 
             var barPos = Utils.GetAnchoredPosition(origin, BackgroundRect.Size, Anchor);
             var backgroundPos = barPos + BackgroundRect.Position;
 
-            drawActions.Add((config, () =>
+            drawActions.Add((strataLevel, () =>
             {
                 DrawRects(barPos, backgroundPos);
             }
@@ -131,7 +131,7 @@ namespace DelvUI.Interface.Bars
             // labels
             foreach (LabelHud label in LabelHuds)
             {
-                drawActions.Add((label.GetConfig(), () =>
+                drawActions.Add((label.GetConfig().StrataLevel, () =>
                 {
                     label.Draw(backgroundPos, BackgroundRect.Size, Actor, null, (uint?)Current, (uint?)Max);
                 }

--- a/DelvUI/Interface/DraggableHudElement.cs
+++ b/DelvUI/Interface/DraggableHudElement.cs
@@ -53,7 +53,7 @@ namespace DelvUI.Interface
         {
             if (_draggingEnabled)
             {
-                AddDrawAction(_config, () =>
+                AddDrawAction(_config.StrataLevel, () =>
                 {
                     DrawDraggableArea(origin);
                 });

--- a/DelvUI/Interface/DraggableHudElement.cs
+++ b/DelvUI/Interface/DraggableHudElement.cs
@@ -49,16 +49,21 @@ namespace DelvUI.Interface
 
         public virtual Vector2 ParentPos() { return Vector2.Zero; } // override
 
-        public sealed override void Draw(Vector2 origin)
+        protected sealed override void CreateDrawActions(Vector2 origin)
         {
             if (_draggingEnabled)
             {
-                DrawDraggableArea(origin);
+                AddDrawAction(_config, () =>
+                {
+                    DrawDraggableArea(origin);
+                });
                 return;
             }
 
             DrawChildren(origin);
         }
+
+        public virtual void DrawChildren(Vector2 origin) { }
 
         private bool CalculateNeedsInput(Vector2 pos, Vector2 size, bool selected)
         {
@@ -171,8 +176,6 @@ namespace DelvUI.Interface
             var textOutlineColor = Selected ? 0xFF000000 : 0xEE000000;
             DrawHelper.DrawOutlinedText(_displayName, contentPos + contentSize / 2f - textSize / 2f, textColor, textOutlineColor, drawList);
         }
-
-        public virtual void DrawChildren(Vector2 origin) { }
 
         #region draggable area
         protected Vector2? _minPos = null;

--- a/DelvUI/Interface/EnemyList/EnemyListHud.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListHud.cs
@@ -219,9 +219,9 @@ namespace DelvUI.Interface.EnemyList
                 });
 
                 string letter = Config.Preview || _helper.EnemiesData.ElementAt(i).Letter == null ? ((char)(i + 65)).ToString() : _helper.EnemiesData.ElementAt(i).Letter!;
-                Configs.HealthBar.OrderLetterLabel.SetText($"[{letter}]");
                 AddDrawAction(Configs.HealthBar.OrderLetterLabel.StrataLevel, () =>
                 {
+                    Configs.HealthBar.OrderLetterLabel.SetText($"[{letter}]");
                     _orderLabelHud.Draw(origin + pos, Configs.HealthBar.Size);
                 });
 

--- a/DelvUI/Interface/EnemyList/EnemyListHud.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListHud.cs
@@ -191,12 +191,12 @@ namespace DelvUI.Interface.EnemyList
                 {
                     var parentPos = Utils.GetAnchoredPosition(origin + pos, -Configs.HealthBar.Size, Configs.EnmityIcon.HealthBarAnchor);
                     var iconPos = Utils.GetAnchoredPosition(parentPos + Configs.EnmityIcon.Position, Configs.EnmityIcon.Size, Configs.EnmityIcon.Anchor);
+                    int enmityIndex = Config.Preview ? Math.Min(3, i) : _helper.EnemiesData.ElementAt(i).EnmityLevel - 1;
 
                     AddDrawAction(Configs.EnmityIcon.StrataLevel, () =>
                     {
                         DrawHelper.DrawInWindow(ID + "_enmityIcon", iconPos, Configs.EnmityIcon.Size, false, false, (drawList) =>
                         {
-                            int enmityIndex = Config.Preview ? Math.Min(3, i) : _helper.EnemiesData.ElementAt(i).EnmityLevel - 1;
                             float w = 48f / _iconsTexture.Width;
                             float h = 48f / _iconsTexture.Height;
                             Vector2 uv0 = new Vector2(w * enmityIndex, 0.48f);

--- a/DelvUI/Interface/EnemyList/EnemyListHud.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListHud.cs
@@ -184,7 +184,7 @@ namespace DelvUI.Interface.EnemyList
                     hovered = true;
                 }
 
-                bar.Draw(origin);
+                AddDrawActions(bar.GetDrawActions(origin, Configs.HealthBar.StrataLevel));
 
                 // enmity icon
                 if (_iconsTexture != null && Configs.EnmityIcon.Enabled)
@@ -192,39 +192,61 @@ namespace DelvUI.Interface.EnemyList
                     var parentPos = Utils.GetAnchoredPosition(origin + pos, -Configs.HealthBar.Size, Configs.EnmityIcon.HealthBarAnchor);
                     var iconPos = Utils.GetAnchoredPosition(parentPos + Configs.EnmityIcon.Position, Configs.EnmityIcon.Size, Configs.EnmityIcon.Anchor);
 
-                    DrawHelper.DrawInWindow(ID + "_enmityIcon", iconPos, Configs.EnmityIcon.Size, false, false, (drawList) =>
+                    AddDrawAction(Configs.EnmityIcon.StrataLevel, () =>
                     {
-                        int enmityIndex = Config.Preview ? Math.Min(3, i) : _helper.EnemiesData.ElementAt(i).EnmityLevel - 1;
-                        float w = 48f / _iconsTexture.Width;
-                        float h = 48f / _iconsTexture.Height;
-                        Vector2 uv0 = new Vector2(w * enmityIndex, 0.48f);
-                        Vector2 uv1 = new Vector2(w * (enmityIndex + 1), 0.48f + h);
-                        drawList.AddImage(_iconsTexture.ImGuiHandle, iconPos, iconPos + Configs.EnmityIcon.Size, uv0, uv1);
+                        DrawHelper.DrawInWindow(ID + "_enmityIcon", iconPos, Configs.EnmityIcon.Size, false, false, (drawList) =>
+                        {
+                            int enmityIndex = Config.Preview ? Math.Min(3, i) : _helper.EnemiesData.ElementAt(i).EnmityLevel - 1;
+                            float w = 48f / _iconsTexture.Width;
+                            float h = 48f / _iconsTexture.Height;
+                            Vector2 uv0 = new Vector2(w * enmityIndex, 0.48f);
+                            Vector2 uv1 = new Vector2(w * (enmityIndex + 1), 0.48f + h);
+                            drawList.AddImage(_iconsTexture.ImGuiHandle, iconPos, iconPos + Configs.EnmityIcon.Size, uv0, uv1);
+                        });
                     });
                 }
 
                 // labels
                 string? name = Config.Preview ? "Fake Name" : null;
-                _nameLabelHud.Draw(origin + pos, Configs.HealthBar.Size, character, name, currentHp, maxHp);
-                _healthLabelHud.Draw(origin + pos, Configs.HealthBar.Size, character, name, currentHp, maxHp);
+                AddDrawAction(Configs.HealthBar.NameLabel.StrataLevel, () =>
+                {
+                    _nameLabelHud.Draw(origin + pos, Configs.HealthBar.Size, character, name, currentHp, maxHp);
+                });
+
+                AddDrawAction(Configs.HealthBar.HealthLabel.StrataLevel, () =>
+                {
+                    _healthLabelHud.Draw(origin + pos, Configs.HealthBar.Size, character, name, currentHp, maxHp);
+                });
 
                 string letter = Config.Preview || _helper.EnemiesData.ElementAt(i).Letter == null ? ((char)(i + 65)).ToString() : _helper.EnemiesData.ElementAt(i).Letter!;
                 Configs.HealthBar.OrderLetterLabel.SetText($"[{letter}]");
-                _orderLabelHud.Draw(origin + pos, Configs.HealthBar.Size);
+                AddDrawAction(Configs.HealthBar.OrderLetterLabel.StrataLevel, () =>
+                {
+                    _orderLabelHud.Draw(origin + pos, Configs.HealthBar.Size);
+                });
 
                 // buffs / debuffs
                 var buffsPos = Utils.GetAnchoredPosition(origin + pos, -Configs.HealthBar.Size, Configs.Buffs.HealthBarAnchor);
                 _buffsListHud.Actor = character;
-                _buffsListHud.Draw(buffsPos);
+                AddDrawAction(Configs.Buffs.StrataLevel, () =>
+                {
+                    _buffsListHud.Draw(buffsPos);
+                });
 
                 var debuffsPos = Utils.GetAnchoredPosition(origin + pos, -Configs.HealthBar.Size, Configs.Debuffs.HealthBarAnchor);
                 _debuffsListHud.Actor = character;
-                _debuffsListHud.Draw(debuffsPos);
+                AddDrawAction(Configs.Debuffs.StrataLevel, () =>
+                {
+                    _debuffsListHud.Draw(debuffsPos);
+                });
 
                 // castbar
                 var castbarPos = Utils.GetAnchoredPosition(origin + pos, -Configs.HealthBar.Size, Configs.CastBar.HealthBarAnchor);
                 _castbarHud.Actor = character;
-                _castbarHud.Draw(castbarPos);
+                AddDrawAction(Configs.CastBar.StrataLevel, () =>
+                {
+                    _castbarHud.Draw(castbarPos);
+                });
             }
 
             // mouseover

--- a/DelvUI/Interface/GeneralElements/CastbarConfig.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarConfig.cs
@@ -169,11 +169,11 @@ namespace DelvUI.Interface.GeneralElements
     public abstract class CastbarConfig : BarConfig
     {
         [Checkbox("Preview")]
-        [Order(2)]
+        [Order(3)]
         public bool Preview = false;
 
         [Checkbox("Show Ability Icon")]
-        [Order(3)]
+        [Order(4)]
         public bool ShowIcon = true;
 
         [NestedConfig("Cast Name", 500)]
@@ -187,6 +187,8 @@ namespace DelvUI.Interface.GeneralElements
         {
             CastNameLabel = castNameConfig;
             CastTimeLabel = castTimeConfig;
+
+            Strata = StrataLevel.MID;
         }
     }
 

--- a/DelvUI/Interface/GeneralElements/CastbarHud.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarHud.cs
@@ -8,7 +8,6 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
@@ -74,24 +73,27 @@ namespace DelvUI.Interface.GeneralElements
             bar.AddForegrounds(progress);
 
             Vector2 pos = origin + ParentPos();
-            bar.Draw(pos);
+            AddDrawActions(bar.GetDrawActions(pos, Config.StrataLevel));
 
             // icon
             Vector2 startPos = Config.Position + Utils.GetAnchoredPosition(pos, Config.Size, Config.Anchor);
             if (Config.ShowIcon)
             {
-                DrawHelper.DrawInWindow(ID + "_icon", startPos, Config.Size, false, false, (drawList) =>
+                AddDrawAction(Config.StrataLevel, () =>
                 {
-                    if (validIcon)
+                    DrawHelper.DrawInWindow(ID + "_icon", startPos, Config.Size, false, false, (drawList) =>
                     {
-                        ImGui.SetCursorPos(startPos);
-                        ImGui.Image(LastUsedCast!.IconTexture!.ImGuiHandle, iconSize);
-                    }
+                        if (validIcon)
+                        {
+                            ImGui.SetCursorPos(startPos);
+                            ImGui.Image(LastUsedCast!.IconTexture!.ImGuiHandle, iconSize);
+                        }
 
-                    if (Config.DrawBorder)
-                    {
-                        drawList.AddRect(startPos, startPos + iconSize, Config.BorderColor.Base, 0, ImDrawFlags.None, Config.BorderThickness);
-                    }
+                        if (Config.DrawBorder)
+                        {
+                            drawList.AddRect(startPos, startPos + iconSize, Config.BorderColor.Base, 0, ImDrawFlags.None, Config.BorderThickness);
+                        }
+                    });
                 });
             }
 
@@ -100,14 +102,22 @@ namespace DelvUI.Interface.GeneralElements
             var namePos = Config.ShowIcon && isNameLeftAnchored ? startPos + new Vector2(iconSize.X, 0) : startPos;
             string? castName = LastUsedCast?.ActionText.CheckForUpperCase();
             Config.CastNameLabel.SetText(Config.Preview ? "Cast Name" : castName ?? "");
-            _castNameLabel.Draw(namePos, Config.Size, Actor);
+
+            AddDrawAction(Config.CastNameLabel.StrataLevel, () =>
+            {
+                _castNameLabel.Draw(namePos, Config.Size, Actor);
+            });
 
             // cast time
             bool isTimeLeftAnchored = Config.CastTimeLabel.TextAnchor == DrawAnchor.Left || Config.CastTimeLabel.TextAnchor == DrawAnchor.TopLeft || Config.CastTimeLabel.TextAnchor == DrawAnchor.BottomLeft;
             var timePos = Config.ShowIcon && isTimeLeftAnchored ? startPos + new Vector2(iconSize.X, 0) : startPos;
             float value = Config.Preview ? 0.5f : totalCastTime - currentCastTime;
             Config.CastTimeLabel.SetValue(value);
-            _castTimeLabel.Draw(timePos, Config.Size, Actor);
+
+            AddDrawAction(Config.CastTimeLabel.StrataLevel, () =>
+            {
+                _castTimeLabel.Draw(timePos, Config.Size, Actor);
+            });
         }
 
         private void UpdateCurrentCast(out float currentCastTime, out float totalCastTime)

--- a/DelvUI/Interface/GeneralElements/ExperienceBarHud.cs
+++ b/DelvUI/Interface/GeneralElements/ExperienceBarHud.cs
@@ -40,8 +40,11 @@ namespace DelvUI.Interface.GeneralElements
             var restedSize = Config.Size - BarUtilities.GetFillDirectionOffset(expBar.Size, Config.FillDirection);
             Rect restedBar = BarUtilities.GetFillRect(restedPos, restedSize, Config.FillDirection, Config.RestedExpColor, rested, required, 0f);
 
-            var bar = new BarHud(Config, Actor).AddForegrounds(expBar, restedBar).AddLabels(Config.LeftLabel, Config.RightLabel);
-            bar.Draw(origin);
+            BarHud bar = new BarHud(Config, Actor);
+            bar.AddForegrounds(expBar, restedBar);
+            bar.AddLabels(Config.LeftLabel, Config.RightLabel);
+
+            AddDrawActions(bar.GetDrawActions(origin, Config.StrataLevel));
         }
     }
 }

--- a/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
@@ -1,5 +1,6 @@
 using DelvUI.Config;
 using DelvUI.Config.Attributes;
+using DelvUI.Enums;
 using DelvUI.Interface.Bars;
 using System.Numerics;
 
@@ -11,11 +12,11 @@ namespace DelvUI.Interface.GeneralElements
     public class GCDIndicatorConfig : AnchorablePluginConfigObject
     {
         [Checkbox("Always Show")]
-        [Order(1)]
+        [Order(3)]
         public bool AlwaysShow = false;
 
         [Checkbox("Anchor To Mouse")]
-        [Order(2)]
+        [Order(4)]
         public bool AnchorToMouse = false;
 
         [ColorEdit4("Background Color")]
@@ -77,7 +78,7 @@ namespace DelvUI.Interface.GeneralElements
             new PluginConfigColor(Vector4.Zero)
         );
 
-        public new static GCDIndicatorConfig DefaultConfig() { return new GCDIndicatorConfig() { Enabled = false }; }
+        public new static GCDIndicatorConfig DefaultConfig() { return new GCDIndicatorConfig() { Enabled = false, Strata = StrataLevel.MID_HIGH }; }
     }
 
     [DisableParentSettings("Position", "Anchor", "HideWhenInactive", "FillColor", "BackgroundColor", "DrawBorder")]

--- a/DelvUI/Interface/GeneralElements/IconConfig.cs
+++ b/DelvUI/Interface/GeneralElements/IconConfig.cs
@@ -2,8 +2,9 @@
 using DelvUI.Config.Attributes;
 using DelvUI.Enums;
 using DelvUI.Interface.Party;
-using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
@@ -14,7 +15,11 @@ namespace DelvUI.Interface.GeneralElements
         [Order(15)]
         public DrawAnchor FrameAnchor = DrawAnchor.Center;
 
-        public IconConfig() { } // don't remove (used by json converter)
+        // don't remove (used by json converter)
+        public IconConfig()
+        {
+            Strata = StrataLevel.MID_HIGH;
+        }
 
         public IconConfig(Vector2 position, Vector2 size, DrawAnchor anchor, DrawAnchor frameAnchor)
         {
@@ -22,6 +27,8 @@ namespace DelvUI.Interface.GeneralElements
             Size = size;
             Anchor = anchor;
             FrameAnchor = frameAnchor;
+
+            Strata = StrataLevel.MID_HIGH;
         }
     }
 

--- a/DelvUI/Interface/GeneralElements/LabelConfig.cs
+++ b/DelvUI/Interface/GeneralElements/LabelConfig.cs
@@ -15,7 +15,8 @@ namespace DelvUI.Interface.GeneralElements
         [Order(10)]
         public string Text;
 
-        public EditableLabelConfig(Vector2 position, string text, DrawAnchor frameAnchor, DrawAnchor textAnchor) : base(position, text, frameAnchor, textAnchor)
+        public EditableLabelConfig(Vector2 position, string text, DrawAnchor frameAnchor, DrawAnchor textAnchor)
+            : base(position, text, frameAnchor, textAnchor)
         {
             Text = text;
         }
@@ -129,6 +130,8 @@ namespace DelvUI.Interface.GeneralElements
             FrameAnchor = frameAnchor;
             TextAnchor = textAnchor;
             Position = position;
+
+            Strata = StrataLevel.HIGHEST;
         }
 
         public virtual string GetText() => _text;

--- a/DelvUI/Interface/GeneralElements/LabelHud.cs
+++ b/DelvUI/Interface/GeneralElements/LabelHud.cs
@@ -15,6 +15,11 @@ namespace DelvUI.Interface.GeneralElements
         {
         }
 
+        protected override void CreateDrawActions(Vector2 origin)
+        {
+            // unused
+        }
+
         public override void Draw(Vector2 origin)
         {
             Draw(origin);

--- a/DelvUI/Interface/GeneralElements/LimitBreakHud.cs
+++ b/DelvUI/Interface/GeneralElements/LimitBreakHud.cs
@@ -1,12 +1,9 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
-using DelvUI.Config;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Numerics;
-using Dalamud.Logging;
 
 namespace DelvUI.Interface.GeneralElements
 {
@@ -45,9 +42,12 @@ namespace DelvUI.Interface.GeneralElements
 
             Config.Label.SetValue(helper.LimitBreakLevel / limitBreakChunks);
 
-            BarUtilities.GetChunkedProgressBars(Config, limitBreakChunks, currentLimitBreak, maxLimitBreak).Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config, limitBreakChunks, currentLimitBreak, maxLimitBreak);
+
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.StrataLevel));
+            }
         }
     }
-
-
 }

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
@@ -1,5 +1,4 @@
-﻿using DelvUI.Config;
-using DelvUI.Config.Attributes;
+﻿using DelvUI.Config.Attributes;
 using DelvUI.Enums;
 using DelvUI.Interface.Bars;
 using System.Numerics;
@@ -131,7 +130,7 @@ namespace DelvUI.Interface.GeneralElements
         public PrimaryResourceConfig(Vector2 position, Vector2 size)
             : base(position, size, new(new(0 / 255f, 162f / 255f, 252f / 255f, 100f / 100f)))
         {
-
+            Strata = StrataLevel.LOW;
         }
     }
 }

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
@@ -90,7 +90,8 @@ namespace DelvUI.Interface.GeneralElements
                 GetColor()
             );
 
-            bar.Draw(origin + ParentPos());
+            Vector2 pos = origin + ParentPos();
+            AddDrawActions(bar.GetDrawActions(pos, Config.StrataLevel));
         }
 
         private void GetResources(ref uint current, ref uint max, Character actor)

--- a/DelvUI/Interface/GeneralElements/PullTimerHud.cs
+++ b/DelvUI/Interface/GeneralElements/PullTimerHud.cs
@@ -31,7 +31,7 @@ namespace DelvUI.Interface.GeneralElements
             {
                 Config.Label.SetText("");
             }
-            
+
             if (!Config.Enabled || Actor is null)
             {
                 return;
@@ -42,11 +42,13 @@ namespace DelvUI.Interface.GeneralElements
                 return;
             }
 
-            var fillColor = Config.UseJobColor ? Utils.ColorForActor(Actor) : null;
-            
-            BarUtilities.GetProgressBar(Config, 
+            PluginConfigColor? fillColor = Config.UseJobColor ? Utils.ColorForActor(Actor) : null;
+
+            BarHud bar = BarUtilities.GetProgressBar(Config,
                 helper.CountDownValue,
-                helper.CountDownMax, 0F, Actor, fillColor).Draw(origin);
+                helper.CountDownMax, 0F, Actor, fillColor);
+
+            AddDrawActions(bar.GetDrawActions(origin, Config.StrataLevel));
         }
     }
 }

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -164,7 +164,7 @@ namespace DelvUI.Interface.GeneralElements
                 }
             }
 
-            bar.Draw(pos);
+            AddDrawActions(bar.GetDrawActions(pos, Config));
 
             // role/job icon
             if (Config.RoleIconConfig.Enabled && character is PlayerCharacter)
@@ -180,9 +180,12 @@ namespace DelvUI.Interface.GeneralElements
                     var parentPos = Utils.GetAnchoredPosition(barPos + Config.Position, -Config.Size, Config.RoleIconConfig.FrameAnchor);
                     var iconPos = Utils.GetAnchoredPosition(parentPos + Config.RoleIconConfig.Position, Config.RoleIconConfig.Size, Config.RoleIconConfig.Anchor);
 
-                    DrawHelper.DrawInWindow(ID + "_jobIcon", iconPos, Config.RoleIconConfig.Size, false, false, (drawList) =>
+                    AddDrawAction(Config.RoleIconConfig, () =>
                     {
-                        DrawHelper.DrawIcon(iconId, iconPos, Config.RoleIconConfig.Size, false, drawList);
+                        DrawHelper.DrawInWindow(ID + "_jobIcon", iconPos, Config.RoleIconConfig.Size, false, false, (drawList) =>
+                        {
+                            DrawHelper.DrawIcon(iconId, iconPos, Config.RoleIconConfig.Size, false, drawList);
+                        });
                     });
                 }
             }
@@ -351,48 +354,51 @@ namespace DelvUI.Interface.GeneralElements
             Vector2 startPos = new Vector2(Math.Min(pos.X, hEndPos.X), Math.Min(pos.Y, hEndPos.Y));
             Vector2 endPos = new Vector2(Math.Max(pos.X, hEndPos.X), Math.Max(pos.Y, hEndPos.Y)); ;
 
-            DrawHelper.DrawInWindow(ID + "_TankStance", startPos, endPos - startPos, false, false, (drawList) =>
+            AddDrawAction(config, () =>
             {
-                // TODO: clean up hacky math 
-                // there's some 1px errors prob due to negative sizes
-                // couldn't figure it out so I did the hacky fixes
-
-                // vertical
-                drawList.AddRectFilled(pos, vEndPos, color.Base);
-
-                if (config.Corner == TankStanceCorner.TopRight)
+                DrawHelper.DrawInWindow(ID + "_TankStance", startPos, endPos - startPos, false, false, (drawList) =>
                 {
-                    drawList.AddLine(pos, pos + new Vector2(0, vSize.Y + 1), 0xFF000000);
-                }
-                else
-                {
-                    drawList.AddLine(pos, pos + new Vector2(0, vSize.Y), 0xFF000000);
-                }
+                    // TODO: clean up hacky math 
+                    // there's some 1px errors prob due to negative sizes
+                    // couldn't figure it out so I did the hacky fixes
 
-                drawList.AddLine(pos + vSize, pos + vSize + new Vector2(-vSize.X, 0), 0xFF000000);
+                    // vertical
+                    drawList.AddRectFilled(pos, vEndPos, color.Base);
 
-                // horizontal
-                drawList.AddRectFilled(pos, hEndPos, color.Base);
+                    if (config.Corner == TankStanceCorner.TopRight)
+                    {
+                        drawList.AddLine(pos, pos + new Vector2(0, vSize.Y + 1), 0xFF000000);
+                    }
+                    else
+                    {
+                        drawList.AddLine(pos, pos + new Vector2(0, vSize.Y), 0xFF000000);
+                    }
 
-                if (config.Corner == TankStanceCorner.BottomLeft)
-                {
-                    drawList.AddLine(pos, pos + new Vector2(hSize.X + 1, 0), 0xFF000000);
-                }
-                else
-                {
-                    drawList.AddLine(pos, pos + new Vector2(hSize.X, 0), 0xFF000000);
-                }
+                    drawList.AddLine(pos + vSize, pos + vSize + new Vector2(-vSize.X, 0), 0xFF000000);
 
-                if (config.Corner == TankStanceCorner.BottomRight)
-                {
-                    drawList.AddLine(pos + new Vector2(0, 1), pos + new Vector2(0, hSize.Y), 0xFF000000);
-                }
-                else
-                {
-                    drawList.AddLine(pos, pos + new Vector2(0, hSize.Y), 0xFF000000);
-                }
+                    // horizontal
+                    drawList.AddRectFilled(pos, hEndPos, color.Base);
 
-                drawList.AddLine(pos + hSize, pos + hSize + new Vector2(0, -hSize.Y), 0xFF000000);
+                    if (config.Corner == TankStanceCorner.BottomLeft)
+                    {
+                        drawList.AddLine(pos, pos + new Vector2(hSize.X + 1, 0), 0xFF000000);
+                    }
+                    else
+                    {
+                        drawList.AddLine(pos, pos + new Vector2(hSize.X, 0), 0xFF000000);
+                    }
+
+                    if (config.Corner == TankStanceCorner.BottomRight)
+                    {
+                        drawList.AddLine(pos + new Vector2(0, 1), pos + new Vector2(0, hSize.Y), 0xFF000000);
+                    }
+                    else
+                    {
+                        drawList.AddLine(pos, pos + new Vector2(0, hSize.Y), 0xFF000000);
+                    }
+
+                    drawList.AddLine(pos + hSize, pos + hSize + new Vector2(0, -hSize.Y), 0xFF000000);
+                });
             });
         }
 

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -2,6 +2,7 @@
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Statuses;
 using DelvUI.Config;
+using DelvUI.Enums;
 using DelvUI.Helpers;
 using DelvUI.Interface.Bars;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
@@ -164,7 +165,7 @@ namespace DelvUI.Interface.GeneralElements
                 }
             }
 
-            AddDrawActions(bar.GetDrawActions(pos, Config));
+            AddDrawActions(bar.GetDrawActions(pos, Config.StrataLevel));
 
             // role/job icon
             if (Config.RoleIconConfig.Enabled && character is PlayerCharacter)
@@ -180,7 +181,7 @@ namespace DelvUI.Interface.GeneralElements
                     var parentPos = Utils.GetAnchoredPosition(barPos + Config.Position, -Config.Size, Config.RoleIconConfig.FrameAnchor);
                     var iconPos = Utils.GetAnchoredPosition(parentPos + Config.RoleIconConfig.Position, Config.RoleIconConfig.Size, Config.RoleIconConfig.Anchor);
 
-                    AddDrawAction(Config.RoleIconConfig, () =>
+                    AddDrawAction(Config.RoleIconConfig.StrataLevel, () =>
                     {
                         DrawHelper.DrawInWindow(ID + "_jobIcon", iconPos, Config.RoleIconConfig.Size, false, false, (drawList) =>
                         {
@@ -354,7 +355,7 @@ namespace DelvUI.Interface.GeneralElements
             Vector2 startPos = new Vector2(Math.Min(pos.X, hEndPos.X), Math.Min(pos.Y, hEndPos.Y));
             Vector2 endPos = new Vector2(Math.Max(pos.X, hEndPos.X), Math.Max(pos.Y, hEndPos.Y)); ;
 
-            AddDrawAction(config, () =>
+            AddDrawAction(StrataLevel.LOWEST, () =>
             {
                 DrawHelper.DrawInWindow(ID + "_TankStance", startPos, endPos - startPos, false, false, (drawList) =>
                 {

--- a/DelvUI/Interface/HudElement.cs
+++ b/DelvUI/Interface/HudElement.cs
@@ -2,6 +2,8 @@
 using System.Numerics;
 using Dalamud.Game.ClientState.Objects.Types;
 using System;
+using System.Collections.Generic;
+using DelvUI.Enums;
 
 namespace DelvUI.Interface
 {
@@ -12,12 +14,38 @@ namespace DelvUI.Interface
 
         public string ID => _config.ID;
 
+        private SortedList<PluginConfigObject, Action> _drawActions = new SortedList<PluginConfigObject, Action>(new StrataLevelComparer<PluginConfigObject>());
+
         public HudElement(MovablePluginConfigObject config)
         {
             _config = config;
         }
 
-        public abstract void Draw(Vector2 origin);
+        public virtual void Draw(Vector2 origin)
+        {
+            _drawActions.Clear();
+            CreateDrawActions(origin);
+
+            foreach (Action drawAction in _drawActions.Values)
+            {
+                drawAction();
+            }
+        }
+
+        protected void AddDrawAction(PluginConfigObject config, Action drawAction)
+        {
+            _drawActions.Add(config, drawAction);
+        }
+
+        protected void AddDrawActions(List<(PluginConfigObject, Action)> drawActions)
+        {
+            foreach ((PluginConfigObject config, Action drawAction) in drawActions)
+            {
+                _drawActions.Add(config, drawAction);
+            }
+        }
+
+        protected abstract void CreateDrawActions(Vector2 origin);
 
         ~HudElement()
         {

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -439,4 +439,29 @@ namespace DelvUI.Interface
 
         #endregion
     }
+
+    internal class StrataLevelComparer<TKey> : IComparer<TKey> where TKey : PluginConfigObject
+    {
+        public int Compare(TKey? a, TKey? b)
+        {
+            MovablePluginConfigObject? configA = a is MovablePluginConfigObject ? a as MovablePluginConfigObject : null;
+            MovablePluginConfigObject? configB = b is MovablePluginConfigObject ? b as MovablePluginConfigObject : null;
+
+            if (configA == null && configB == null) { return 0; }
+            if (configA == null && configB != null) { return -1; }
+            if (configA != null && configB == null) { return 1; }
+
+            if (configA!.StrataLevel == configB!.StrataLevel)
+            {
+                return configA.ID.CompareTo(configB.ID);
+            }
+
+            if (configA.StrataLevel < configB.StrataLevel)
+            {
+                return -1;
+            }
+
+            return 1;
+        }
+    }
 }

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -371,6 +371,10 @@ namespace DelvUI.Interface
 
             ClipRectsHelper.Instance.Update();
 
+            ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 0);
+            ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(0, 0));
+            ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0);
+
             ImGuiHelpers.ForceNextWindowMainViewport();
             ImGui.SetNextWindowPos(Vector2.Zero);
             ImGui.SetNextWindowSize(ImGui.GetMainViewport().Size);
@@ -388,6 +392,7 @@ namespace DelvUI.Interface
 
             if (!begin)
             {
+                ImGui.PopStyleVar(3);
                 ImGui.End();
                 return;
             }
@@ -427,6 +432,7 @@ namespace DelvUI.Interface
             // tooltip
             TooltipsHelper.Instance.Draw();
 
+            ImGui.PopStyleVar(3);
             ImGui.End();
         }
 

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -390,9 +390,10 @@ namespace DelvUI.Interface
               | ImGuiWindowFlags.NoSavedSettings
             );
 
+            ImGui.PopStyleVar(3);
+
             if (!begin)
             {
-                ImGui.PopStyleVar(3);
                 ImGui.End();
                 return;
             }
@@ -432,7 +433,6 @@ namespace DelvUI.Interface
             // tooltip
             TooltipsHelper.Instance.Draw();
 
-            ImGui.PopStyleVar(3);
             ImGui.End();
         }
 

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -12,6 +12,7 @@ using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 namespace DelvUI.Interface
@@ -22,7 +23,7 @@ namespace DelvUI.Interface
         private HUDOptionsConfig? _hudOptions;
         private DraggableHudElement? _selectedElement = null;
 
-        private List<DraggableHudElement> _hudElements = null!;
+        private SortedList<PluginConfigObject, DraggableHudElement> _hudElements = null!;
         private List<IHudElementWithActor> _hudElementsUsingPlayer = null!;
         private List<IHudElementWithActor> _hudElementsUsingTarget = null!;
         private List<IHudElementWithActor> _hudElementsUsingTargetOfTarget = null!;
@@ -53,6 +54,7 @@ namespace DelvUI.Interface
             ConfigurationManager.Instance.ResetEvent += OnConfigReset;
             ConfigurationManager.Instance.LockEvent += OnHUDLockChanged;
             ConfigurationManager.Instance.ConfigClosedEvent += OnConfingWindowClosed;
+            ConfigurationManager.Instance.StrataLevelsChangedEvent += OnStrataLevelsChanged;
 
             CreateHudElements();
         }
@@ -85,6 +87,8 @@ namespace DelvUI.Interface
 
             ConfigurationManager.Instance.ResetEvent -= OnConfigReset;
             ConfigurationManager.Instance.LockEvent -= OnHUDLockChanged;
+            ConfigurationManager.Instance.ConfigClosedEvent -= OnConfingWindowClosed;
+            ConfigurationManager.Instance.StrataLevelsChangedEvent -= OnStrataLevelsChanged;
         }
 
         private void OnConfigReset(ConfigurationManager sender)
@@ -97,7 +101,7 @@ namespace DelvUI.Interface
         {
             var draggingEnabled = !sender.LockHUD;
 
-            foreach (var element in _hudElements)
+            foreach (var element in _hudElements.Values)
             {
                 element.DraggingEnabled = draggingEnabled;
                 element.Selected = false;
@@ -124,9 +128,21 @@ namespace DelvUI.Interface
             }
         }
 
+        private void OnStrataLevelsChanged(ConfigurationManager sender, PluginConfigObject config)
+        {
+            SortedList<PluginConfigObject, DraggableHudElement> tmp = new SortedList<PluginConfigObject, DraggableHudElement>(new StrataLevelComparer<PluginConfigObject>());
+
+            foreach (DraggableHudElement element in _hudElements.Values)
+            {
+                tmp.Add(element.GetConfig(), element);
+            }
+
+            _hudElements = tmp;
+        }
+
         private void OnDraggableElementSelected(DraggableHudElement sender)
         {
-            foreach (var element in _hudElements)
+            foreach (var element in _hudElements.Values)
             {
                 element.Selected = element == sender;
             }
@@ -144,7 +160,7 @@ namespace DelvUI.Interface
             _gridConfig = ConfigurationManager.Instance.GetConfigObject<GridConfig>();
             _hudOptions = ConfigurationManager.Instance.GetConfigObject<HUDOptionsConfig>();
 
-            _hudElements = new List<DraggableHudElement>();
+            _hudElements = new SortedList<PluginConfigObject, DraggableHudElement>(new StrataLevelComparer<PluginConfigObject>());
             _hudElementsUsingPlayer = new List<IHudElementWithActor>();
             _hudElementsUsingTarget = new List<IHudElementWithActor>();
             _hudElementsUsingTargetOfTarget = new List<IHudElementWithActor>();
@@ -157,7 +173,7 @@ namespace DelvUI.Interface
             CreateStatusEffectsLists();
             CreateMiscElements();
 
-            foreach (var element in _hudElements)
+            foreach (var element in _hudElements.Values)
             {
                 element.SelectEvent += OnDraggableElementSelected;
             }
@@ -167,32 +183,32 @@ namespace DelvUI.Interface
         {
             var playerUnitFrameConfig = ConfigurationManager.Instance.GetConfigObject<PlayerUnitFrameConfig>();
             _playerUnitFrameHud = new PlayerUnitFrameHud(playerUnitFrameConfig, "Player");
-            _hudElements.Add(_playerUnitFrameHud);
+            _hudElements.Add(playerUnitFrameConfig, _playerUnitFrameHud);
             _hudElementsUsingPlayer.Add(_playerUnitFrameHud);
 
             var targetUnitFrameConfig = ConfigurationManager.Instance.GetConfigObject<TargetUnitFrameConfig>();
             _targetUnitFrameHud = new UnitFrameHud(targetUnitFrameConfig, "Target");
-            _hudElements.Add(_targetUnitFrameHud);
+            _hudElements.Add(targetUnitFrameConfig, _targetUnitFrameHud);
             _hudElementsUsingTarget.Add(_targetUnitFrameHud);
 
             var targetOfTargetUnitFrameConfig = ConfigurationManager.Instance.GetConfigObject<TargetOfTargetUnitFrameConfig>();
             _totUnitFrameHud = new UnitFrameHud(targetOfTargetUnitFrameConfig, "Target of Target");
-            _hudElements.Add(_totUnitFrameHud);
+            _hudElements.Add(targetOfTargetUnitFrameConfig, _totUnitFrameHud);
             _hudElementsUsingTargetOfTarget.Add(_totUnitFrameHud);
 
             var focusTargetUnitFrameConfig = ConfigurationManager.Instance.GetConfigObject<FocusTargetUnitFrameConfig>();
             _focusTargetUnitFrameHud = new UnitFrameHud(focusTargetUnitFrameConfig, "Focus Target");
-            _hudElements.Add(_focusTargetUnitFrameHud);
+            _hudElements.Add(focusTargetUnitFrameConfig, _focusTargetUnitFrameHud);
             _hudElementsUsingFocusTarget.Add(_focusTargetUnitFrameHud);
 
             var partyFramesConfig = ConfigurationManager.Instance.GetConfigObject<PartyFramesConfig>();
             var partyFramesHud = new PartyFramesHud(partyFramesConfig, "Party Frames");
-            _hudElements.Add(partyFramesHud);
+            _hudElements.Add(partyFramesConfig, partyFramesHud);
             _hudElementsWithPreview.Add(partyFramesHud);
 
             var enemyListConfig = ConfigurationManager.Instance.GetConfigObject<EnemyListConfig>();
             var enemyListHud = new EnemyListHud(enemyListConfig, "Enemy List");
-            _hudElements.Add(enemyListHud);
+            _hudElements.Add(enemyListConfig, enemyListHud);
             _hudElementsWithPreview.Add(enemyListHud);
         }
 
@@ -201,25 +217,25 @@ namespace DelvUI.Interface
             var playerManaBarConfig = ConfigurationManager.Instance.GetConfigObject<PlayerPrimaryResourceConfig>();
             _playerManaBarHud = new PrimaryResourceHud(playerManaBarConfig, "Player Mana Bar");
             _playerManaBarHud.ParentConfig = _playerUnitFrameHud.Config;
-            _hudElements.Add(_playerManaBarHud);
+            _hudElements.Add(playerManaBarConfig, _playerManaBarHud);
             _hudElementsUsingPlayer.Add(_playerManaBarHud);
 
             var targetManaBarConfig = ConfigurationManager.Instance.GetConfigObject<TargetPrimaryResourceConfig>();
             var targetManaBarHud = new PrimaryResourceHud(targetManaBarConfig, "Target Mana Bar");
             targetManaBarHud.ParentConfig = _targetUnitFrameHud.Config;
-            _hudElements.Add(targetManaBarHud);
+            _hudElements.Add(targetManaBarConfig, targetManaBarHud);
             _hudElementsUsingTarget.Add(targetManaBarHud);
 
             var totManaBarConfig = ConfigurationManager.Instance.GetConfigObject<TargetOfTargetPrimaryResourceConfig>();
             var totManaBarHud = new PrimaryResourceHud(totManaBarConfig, "ToT Mana Bar");
             totManaBarHud.ParentConfig = _totUnitFrameHud.Config;
-            _hudElements.Add(totManaBarHud);
+            _hudElements.Add(totManaBarConfig, totManaBarHud);
             _hudElementsUsingTargetOfTarget.Add(totManaBarHud);
 
             var focusManaBarConfig = ConfigurationManager.Instance.GetConfigObject<FocusTargetPrimaryResourceConfig>();
             var focusManaBarHud = new PrimaryResourceHud(focusManaBarConfig, "Focus Mana Bar");
             focusManaBarHud.ParentConfig = _focusTargetUnitFrameHud.Config;
-            _hudElements.Add(focusManaBarHud);
+            _hudElements.Add(focusManaBarConfig, focusManaBarHud);
             _hudElementsUsingFocusTarget.Add(focusManaBarHud);
         }
 
@@ -228,28 +244,28 @@ namespace DelvUI.Interface
             var playerCastbarConfig = ConfigurationManager.Instance.GetConfigObject<PlayerCastbarConfig>();
             _playerCastbarHud = new PlayerCastbarHud(playerCastbarConfig, "Player Castbar");
             _playerCastbarHud.ParentConfig = _playerUnitFrameHud.Config;
-            _hudElements.Add(_playerCastbarHud);
+            _hudElements.Add(playerCastbarConfig, _playerCastbarHud);
             _hudElementsUsingPlayer.Add(_playerCastbarHud);
             _hudElementsWithPreview.Add(_playerCastbarHud);
 
             var targetCastbarConfig = ConfigurationManager.Instance.GetConfigObject<TargetCastbarConfig>();
             var targetCastbar = new TargetCastbarHud(targetCastbarConfig, "Target Castbar");
             targetCastbar.ParentConfig = _targetUnitFrameHud.Config;
-            _hudElements.Add(targetCastbar);
+            _hudElements.Add(targetCastbarConfig, targetCastbar);
             _hudElementsUsingTarget.Add(targetCastbar);
             _hudElementsWithPreview.Add(targetCastbar);
 
             var targetOfTargetCastbarConfig = ConfigurationManager.Instance.GetConfigObject<TargetOfTargetCastbarConfig>();
             var targetOfTargetCastbar = new TargetCastbarHud(targetOfTargetCastbarConfig, "ToT Castbar");
             targetOfTargetCastbar.ParentConfig = _totUnitFrameHud.Config;
-            _hudElements.Add(targetOfTargetCastbar);
+            _hudElements.Add(targetOfTargetCastbarConfig, targetOfTargetCastbar);
             _hudElementsUsingTargetOfTarget.Add(targetOfTargetCastbar);
             _hudElementsWithPreview.Add(targetOfTargetCastbar);
 
             var focusTargetCastbarConfig = ConfigurationManager.Instance.GetConfigObject<FocusTargetCastbarConfig>();
             var focusTargetCastbar = new TargetCastbarHud(focusTargetCastbarConfig, "Focus Castbar");
             focusTargetCastbar.ParentConfig = _focusTargetUnitFrameHud.Config;
-            _hudElements.Add(focusTargetCastbar);
+            _hudElements.Add(focusTargetCastbarConfig, focusTargetCastbar);
             _hudElementsUsingFocusTarget.Add(focusTargetCastbar);
             _hudElementsWithPreview.Add(focusTargetCastbar);
         }
@@ -259,48 +275,48 @@ namespace DelvUI.Interface
             var playerBuffsConfig = ConfigurationManager.Instance.GetConfigObject<PlayerBuffsListConfig>();
             var playerBuffs = new StatusEffectsListHud(playerBuffsConfig, "Buffs");
             playerBuffs.ParentConfig = _playerUnitFrameHud.Config;
-            _hudElements.Add(playerBuffs);
+            _hudElements.Add(playerBuffsConfig, playerBuffs);
             _hudElementsUsingPlayer.Add(playerBuffs);
             _hudElementsWithPreview.Add(playerBuffs);
 
             var playerDebuffsConfig = ConfigurationManager.Instance.GetConfigObject<PlayerDebuffsListConfig>();
             var playerDebuffs = new StatusEffectsListHud(playerDebuffsConfig, "Debufffs");
             playerDebuffs.ParentConfig = _playerUnitFrameHud.Config;
-            _hudElements.Add(playerDebuffs);
+            _hudElements.Add(playerDebuffsConfig, playerDebuffs);
             _hudElementsUsingPlayer.Add(playerDebuffs);
             _hudElementsWithPreview.Add(playerDebuffs);
 
             var targetBuffsConfig = ConfigurationManager.Instance.GetConfigObject<TargetBuffsListConfig>();
             var targetBuffs = new StatusEffectsListHud(targetBuffsConfig, "Target Buffs");
             targetBuffs.ParentConfig = _targetUnitFrameHud.Config;
-            _hudElements.Add(targetBuffs);
+            _hudElements.Add(targetBuffsConfig, targetBuffs);
             _hudElementsUsingTarget.Add(targetBuffs);
             _hudElementsWithPreview.Add(targetBuffs);
 
             var targetDebuffsConfig = ConfigurationManager.Instance.GetConfigObject<TargetDebuffsListConfig>();
             var targetDebuffs = new StatusEffectsListHud(targetDebuffsConfig, "Target Debuffs");
             targetDebuffs.ParentConfig = _targetUnitFrameHud.Config;
-            _hudElements.Add(targetDebuffs);
+            _hudElements.Add(targetDebuffsConfig, targetDebuffs);
             _hudElementsUsingTarget.Add(targetDebuffs);
             _hudElementsWithPreview.Add(targetDebuffs);
 
             var focusTargetBuffsConfig = ConfigurationManager.Instance.GetConfigObject<FocusTargetBuffsListConfig>();
             var focusTargetBuffs = new StatusEffectsListHud(focusTargetBuffsConfig, "focusTarget Buffs");
             focusTargetBuffs.ParentConfig = _focusTargetUnitFrameHud.Config;
-            _hudElements.Add(focusTargetBuffs);
+            _hudElements.Add(focusTargetBuffsConfig, focusTargetBuffs);
             _hudElementsUsingFocusTarget.Add(focusTargetBuffs);
             _hudElementsWithPreview.Add(focusTargetBuffs);
 
             var focusTargetDebuffsConfig = ConfigurationManager.Instance.GetConfigObject<FocusTargetDebuffsListConfig>();
             var focusTargetDebuffs = new StatusEffectsListHud(focusTargetDebuffsConfig, "focusTarget Debuffs");
             focusTargetDebuffs.ParentConfig = _focusTargetUnitFrameHud.Config;
-            _hudElements.Add(focusTargetDebuffs);
+            _hudElements.Add(focusTargetDebuffsConfig, focusTargetDebuffs);
             _hudElementsUsingFocusTarget.Add(focusTargetDebuffs);
             _hudElementsWithPreview.Add(focusTargetDebuffs);
 
             var custonEffectsConfig = ConfigurationManager.Instance.GetConfigObject<CustomEffectsListConfig>();
             _customEffectsHud = new CustomEffectsListHud(custonEffectsConfig, "Custom Effects");
-            _hudElements.Add(_customEffectsHud);
+            _hudElements.Add(custonEffectsConfig, _customEffectsHud);
             _hudElementsUsingPlayer.Add(_customEffectsHud);
             _hudElementsWithPreview.Add(_customEffectsHud);
         }
@@ -309,31 +325,31 @@ namespace DelvUI.Interface
         {
             var gcdIndicatorConfig = ConfigurationManager.Instance.GetConfigObject<GCDIndicatorConfig>();
             var gcdIndicator = new GCDIndicatorHud(gcdIndicatorConfig, "GCD Indicator");
-            _hudElements.Add(gcdIndicator);
+            _hudElements.Add(gcdIndicatorConfig, gcdIndicator);
             _hudElementsUsingPlayer.Add(gcdIndicator);
 
             var mpTickerConfig = ConfigurationManager.Instance.GetConfigObject<MPTickerConfig>();
             var mpTicker = new MPTickerHud(mpTickerConfig, "MP Ticker");
-            _hudElements.Add(mpTicker);
+            _hudElements.Add(mpTickerConfig, mpTicker);
             _hudElementsUsingPlayer.Add(mpTicker);
 
             var expBarConfig = ConfigurationManager.Instance.GetConfigObject<ExperienceBarConfig>();
             var expBarHud = new ExperienceBarHud(expBarConfig, "Experience Bar");
-            _hudElements.Add(expBarHud);
+            _hudElements.Add(expBarConfig, expBarHud);
             _hudElementsUsingPlayer.Add(expBarHud);
 
             var pullTimerConfig = ConfigurationManager.Instance.GetConfigObject<PullTimerConfig>();
             var pullTimerHud = new PullTimerHud(pullTimerConfig, "Pull Timer");
-            _hudElements.Add(pullTimerHud);
+            _hudElements.Add(pullTimerConfig, pullTimerHud);
             _hudElementsUsingPlayer.Add(pullTimerHud);
 
             var limitBreakConfig = ConfigurationManager.Instance.GetConfigObject<LimitBreakConfig>();
             var limitBreakHud = new LimitBreakHud(limitBreakConfig, "Limit Break");
-            _hudElements.Add(limitBreakHud);
+            _hudElements.Add(limitBreakConfig, limitBreakHud);
 
             var partyCooldownsConfig = ConfigurationManager.Instance.GetConfigObject<PartyCooldownsConfig>();
             var partyCooldownsHud = new PartyCooldownsHud(partyCooldownsConfig, "Party Cooldowns");
-            _hudElements.Add(partyCooldownsHud);
+            _hudElements.Add(partyCooldownsConfig, partyCooldownsHud);
             _hudElementsWithPreview.Add(partyCooldownsHud);
         }
 
@@ -405,7 +421,7 @@ namespace DelvUI.Interface
             // draw elements
             lock (_hudElements)
             {
-                DraggablesHelper.DrawElements(origin, _hudHelper, _hudElements, _jobHud, _selectedElement);
+                DraggablesHelper.DrawElements(origin, _hudHelper, _hudElements.Values, _jobHud, _selectedElement);
             }
 
             // tooltip

--- a/DelvUI/Interface/Jobs/AstrologianHud.cs
+++ b/DelvUI/Interface/Jobs/AstrologianHud.cs
@@ -196,8 +196,11 @@ namespace DelvUI.Interface.Jobs
                 new(chunkColors[1], chunkColors[1] != EmptyColor ? 1f : 0f, Config.AstrodyneBar.Label),
                 new(chunkColors[2], chunkColors[2] != EmptyColor ? 1f : 0f, null) };
 
-            BarUtilities.GetChunkedBars(Config.AstrodyneBar, astrodyneChunks, player, Config.AstrodyneBar.AstrodyneGlowConfig, chucksToGlow)
-                .Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.AstrodyneBar, astrodyneChunks, player, Config.AstrodyneBar.AstrodyneGlowConfig, chucksToGlow);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.AstrodyneBar.StrataLevel));
+            }
         }
 
         private void DrawDraw(Vector2 origin, PlayerCharacter player)
@@ -313,8 +316,8 @@ namespace DelvUI.Interface.Jobs
             LabelConfig[] labels = new LabelConfig[] { Config.DrawBar.Label, Config.DrawBar.DrawDrawChargesLabel, Config.DrawBar.DrawDrawLabel };
             BarGlowConfig? glowConfig = Config.DrawBar.DrawGlowConfig.Enabled && Math.Abs(cardMax - 1f) == 0f ? Config.DrawBar.DrawGlowConfig : null;
 
-            BarUtilities.GetBar(Config.DrawBar, cardPresent, cardMax, 0f, player, cardColor, glowConfig, labels)
-                .Draw(origin);
+            BarHud bar = BarUtilities.GetBar(Config.DrawBar, cardPresent, cardMax, 0f, player, cardColor, glowConfig, labels);
+            AddDrawActions(bar.GetDrawActions(origin, Config.DrawBar.StrataLevel));
         }
 
         private void DrawMinorArcana(Vector2 pos, PlayerCharacter player)
@@ -388,14 +391,18 @@ namespace DelvUI.Interface.Jobs
             }
 
             LabelConfig[] labels = { Config.MinorArcanaBar.Label, Config.MinorArcanaBar.CrownDrawTimerLabel };
-            BarUtilities.GetBar(Config.MinorArcanaBar, crownCardPresent, crownCardMax, 0f, player, crownCardColor, labels: labels)
-                .Draw(pos);
+            BarHud bar = BarUtilities.GetBar(Config.MinorArcanaBar, crownCardPresent, crownCardMax, 0f, player, crownCardColor, labels: labels);
+            AddDrawActions(bar.GetDrawActions(pos, Config.MinorArcanaBar.StrataLevel));
         }
 
         private void DrawDot(Vector2 origin, PlayerCharacter player)
         {
             GameObject? target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
-            BarUtilities.GetDoTBar(Config.DotBar, player, target, DotIDs, DotDuration)?.Draw(origin);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.DotBar, player, target, DotIDs, DotDuration);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.DotBar.StrataLevel));
+            }
         }
 
         private void DrawLightspeed(Vector2 origin, PlayerCharacter player)
@@ -408,8 +415,9 @@ namespace DelvUI.Interface.Jobs
             }
 
             Config.LightspeedBar.Label.SetValue(lightspeedDuration);
-            BarUtilities.GetProgressBar(Config.LightspeedBar, lightspeedDuration, LIGHTSPEED_MAX_DURATION, 0, player)
-                .Draw(origin);
+
+            BarHud bar = BarUtilities.GetProgressBar(Config.LightspeedBar, lightspeedDuration, LIGHTSPEED_MAX_DURATION, 0, player);
+            AddDrawActions(bar.GetDrawActions(origin, Config.LightspeedBar.StrataLevel));
         }
 
         private void DrawStar(Vector2 origin, PlayerCharacter player)
@@ -426,8 +434,10 @@ namespace DelvUI.Interface.Jobs
             PluginConfigColor currentStarColor = starPreCookingBuff > 0 ? Config.StarBar.StarEarthlyColor : Config.StarBar.StarGiantColor;
 
             Config.StarBar.Label.SetValue(currentStarDuration);
-            BarUtilities.GetProgressBar(Config.StarBar, currentStarDuration, STAR_MAX_DURATION, 0f, player, currentStarColor, Config.StarBar.StarGlowConfig.Enabled && starPostCookingBuff > 0 ? Config.StarBar.StarGlowConfig : null)
-                .Draw(origin); // Star Countdown after Star is ready 
+
+            // Star Countdown after Star is ready 
+            BarHud bar = BarUtilities.GetProgressBar(Config.StarBar, currentStarDuration, STAR_MAX_DURATION, 0f, player, currentStarColor, Config.StarBar.StarGlowConfig.Enabled && starPostCookingBuff > 0 ? Config.StarBar.StarGlowConfig : null);
+            AddDrawActions(bar.GetDrawActions(origin, Config.StarBar.StrataLevel));
         }
     }
 

--- a/DelvUI/Interface/Jobs/BardHud.cs
+++ b/DelvUI/Interface/Jobs/BardHud.cs
@@ -112,7 +112,11 @@ namespace DelvUI.Interface.Jobs
                     coda[i] = new Tuple<PluginConfigColor, float, LabelConfig?>(colors[order[i]], containsCoda[order[i]], null);
                 }
 
-                BarUtilities.GetChunkedBars(Config.CodaBar, coda, player).Draw(origin);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.CodaBar, coda, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.CodaBar.StrataLevel));
+                }
             }
         }
 
@@ -123,8 +127,11 @@ namespace DelvUI.Interface.Jobs
         {
             var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
 
-            BarUtilities.GetDoTBar(Config.CausticBiteDoTBar, player, target, CausticBiteDoTIDs, CausticBiteDoTDurations)?.
-                         Draw(origin);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.CausticBiteDoTBar, player, target, CausticBiteDoTIDs, CausticBiteDoTDurations);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.CausticBiteDoTBar.StrataLevel));
+            }
         }
 
         private static List<uint> StormbiteDoTIDs = new List<uint> { 129, 1201 };
@@ -134,8 +141,11 @@ namespace DelvUI.Interface.Jobs
         {
             var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
 
-            BarUtilities.GetDoTBar(Config.StormbiteDoTBar, player, target, StormbiteDoTIDs, StormbiteDoTDurations)?.
-                         Draw(origin);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.StormbiteDoTBar, player, target, StormbiteDoTIDs, StormbiteDoTDurations);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.StormbiteDoTBar.StrataLevel));
+            }
         }
 
         private void HandleCurrentSong(Vector2 origin, PlayerCharacter player)
@@ -190,7 +200,7 @@ namespace DelvUI.Interface.Jobs
                         DrawStacksBar(origin, player, 0, 3, Config.StacksBar.WMStackColor);
                     }
 
-                    DrawSongTimerBar(origin, 0, EmptyColor, Config.SongGaugeBar.ThresholdConfig,  player);
+                    DrawSongTimerBar(origin, 0, EmptyColor, Config.SongGaugeBar.ThresholdConfig, player);
 
                     break;
 
@@ -231,8 +241,9 @@ namespace DelvUI.Interface.Jobs
 
             Config.SongGaugeBar.Label.SetValue(duration);
             Config.SongGaugeBar.ThresholdConfig = songThreshold;
-            BarUtilities.GetProgressBar(Config.SongGaugeBar, duration, 45f, 0f, player, songColor)
-                        .Draw(origin);
+
+            BarHud bar = BarUtilities.GetProgressBar(Config.SongGaugeBar, duration, 45f, 0f, player, songColor);
+            AddDrawActions(bar.GetDrawActions(origin, Config.SongGaugeBar.StrataLevel));
         }
 
         protected void DrawSoulVoiceBar(Vector2 origin, PlayerCharacter player)
@@ -247,7 +258,7 @@ namespace DelvUI.Interface.Jobs
 
             config.Label.SetValue(soulVoice);
 
-            BarUtilities.GetProgressBar(
+            BarHud bar = BarUtilities.GetProgressBar(
                 config,
                 config.ThresholdConfig,
                 new LabelConfig[] { config.Label },
@@ -257,7 +268,9 @@ namespace DelvUI.Interface.Jobs
                 player,
                 config.FillColor,
                 soulVoice == 100f && config.GlowConfig.Enabled ? config.GlowConfig : null
-            ).Draw(origin);
+            );
+
+            AddDrawActions(bar.GetDrawActions(origin, config.StrataLevel));
         }
 
         private void DrawStacksBar(Vector2 origin, PlayerCharacter player, int amount, int max, PluginConfigColor stackColor, BarGlowConfig? glowConfig = null)
@@ -265,8 +278,12 @@ namespace DelvUI.Interface.Jobs
             BardStacksBarConfig config = Config.StacksBar;
 
             config.FillColor = stackColor;
-            BarUtilities.GetChunkedBars(Config.StacksBar, max, amount, max, 0f, player, glowConfig: glowConfig).
-                         Draw(origin);
+
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.StacksBar, max, amount, max, 0f, player, glowConfig: glowConfig);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.CodaBar.StrataLevel));
+            }
         }
     }
 
@@ -361,7 +378,7 @@ namespace DelvUI.Interface.Jobs
         [ColorEdit4("Army's Paeon" + "##Song")]
         [Order(33)]
         public PluginConfigColor APColor = new(new Vector4(207f / 255f, 205f / 255f, 52f / 255f, 100f / 100f));
-        
+
         [NestedConfig("Wanderer's Minuet Threshold", 36, separator = false, spacing = true)]
         public ThresholdConfig WMThreshold = new ThresholdConfig()
         {
@@ -379,7 +396,7 @@ namespace DelvUI.Interface.Jobs
             ThresholdType = ThresholdType.Below,
             Value = 14
         };
-        
+
         [NestedConfig("Army's Paeon Threshold", 38, separator = false, spacing = true)]
         public ThresholdConfig APThreshold = new ThresholdConfig()
         {

--- a/DelvUI/Interface/Jobs/BlackMageHud.cs
+++ b/DelvUI/Interface/Jobs/BlackMageHud.cs
@@ -186,7 +186,7 @@ namespace DelvUI.Interface.Jobs
                 gauge.InAstralFire ? config.FireColor : gauge.InUmbralIce ? config.IceColor : config.FillColor
             );
 
-            bar.Draw(origin);
+            AddDrawActions(bar.GetDrawActions(origin, config.StrataLevel));
         }
 
         protected void DrawStacksBar(Vector2 origin)
@@ -200,8 +200,11 @@ namespace DelvUI.Interface.Jobs
             PluginConfigColor color = gauge.UmbralIceStacks > 0 ? Config.StacksBar.IceColor : Config.StacksBar.FireColor;
             byte stacks = gauge.UmbralIceStacks > 0 ? gauge.UmbralIceStacks : gauge.AstralFireStacks;
 
-            BarUtilities.GetChunkedBars(Config.StacksBar, 3, stacks, 3f, fillColor: color)
-                .Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.StacksBar, 3, stacks, 3f, fillColor: color);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.StacksBar.StrataLevel));
+            }
         }
 
         protected void DrawUmbralHeartBar(Vector2 origin)
@@ -212,8 +215,11 @@ namespace DelvUI.Interface.Jobs
                 return;
             };
 
-            BarUtilities.GetChunkedBars(Config.UmbralHeartBar, 3, gauge.UmbralHearts, 3f)
-                .Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.UmbralHeartBar, 3, gauge.UmbralHearts, 3f);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.UmbralHeartBar.StrataLevel));
+            }
         }
 
         protected void DrawTripleCastBar(Vector2 origin, PlayerCharacter player)
@@ -225,8 +231,11 @@ namespace DelvUI.Interface.Jobs
                 return;
             };
 
-            BarUtilities.GetChunkedBars(Config.TriplecastBar, 3, stackCount, 3f)
-                .Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.TriplecastBar, 3, stackCount, 3f);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.TriplecastBar.StrataLevel));
+            }
         }
 
         protected void DrawEnochianBar(Vector2 origin, PlayerCharacter player)
@@ -240,8 +249,9 @@ namespace DelvUI.Interface.Jobs
 
             float timer = gauge.IsEnochianActive ? (30000f - gauge.EnochianTimer) : 0f;
             Config.EnochianBar.Label.SetValue(timer / 1000);
-            BarUtilities.GetProgressBar(Config.EnochianBar, timer / 1000, 30, 0f, player)
-                .Draw(origin);
+
+            BarHud bar = BarUtilities.GetProgressBar(Config.EnochianBar, timer / 1000, 30, 0f, player);
+            AddDrawActions(bar.GetDrawActions(origin, Config.EnochianBar.StrataLevel));
         }
 
         protected void DrawPolyglotBar(Vector2 origin, PlayerCharacter player)
@@ -257,15 +267,18 @@ namespace DelvUI.Interface.Jobs
             if (player.Level < 80)
             {
                 BarGlowConfig? glow = gauge.PolyglotStacks == 1 && Config.PolyglotBar.GlowConfig.Enabled ? Config.PolyglotBar.GlowConfig : null;
-                BarUtilities.GetBar(Config.PolyglotBar, gauge.PolyglotStacks, 1, 0, glowConfig: glow)
-                    .Draw(origin);
+                BarHud bar = BarUtilities.GetBar(Config.PolyglotBar, gauge.PolyglotStacks, 1, 0, glowConfig: glow);
+                AddDrawActions(bar.GetDrawActions(origin, Config.PolyglotBar.StrataLevel));
             }
             // 2 stacks for level 80+
             else
             {
                 BarGlowConfig? glow = Config.PolyglotBar.GlowConfig.Enabled ? Config.PolyglotBar.GlowConfig : null;
-                BarUtilities.GetChunkedBars(Config.PolyglotBar, 2, gauge.PolyglotStacks, 2f, 0, glowConfig: glow)
-                    .Draw(origin);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.PolyglotBar, 2, gauge.PolyglotStacks, 2f, 0, glowConfig: glow);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.PolyglotBar.StrataLevel));
+                }
             }
         }
 
@@ -279,28 +292,37 @@ namespace DelvUI.Interface.Jobs
             };
 
             BarGlowConfig? glow = gauge.IsParadoxActive && Config.ParadoxBar.GlowConfig.Enabled ? Config.ParadoxBar.GlowConfig : null;
-            BarUtilities.GetBar(Config.ParadoxBar, gauge.IsParadoxActive ? 1 : 0, 1, 0, glowConfig: glow)
-                .Draw(origin);
+            BarHud bar = BarUtilities.GetBar(Config.ParadoxBar, gauge.IsParadoxActive ? 1 : 0, 1, 0, glowConfig: glow);
+            AddDrawActions(bar.GetDrawActions(origin, Config.ParadoxBar.StrataLevel));
         }
 
         protected void DrawThundercloudBar(Vector2 origin, PlayerCharacter player)
         {
-            BarUtilities.GetProcBar(Config.ThundercloudBar, player, 164, 40f)?
-                .Draw(origin);
+            BarHud? bar = BarUtilities.GetProcBar(Config.ThundercloudBar, player, 164, 40f);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.ThundercloudBar.StrataLevel));
+            }
         }
 
         protected void DrawFirestarterBar(Vector2 origin, PlayerCharacter player)
         {
-            BarUtilities.GetProcBar(Config.FirestarterBar, player, 165, 30f)?
-                .Draw(origin);
+            BarHud? bar = BarUtilities.GetProcBar(Config.FirestarterBar, player, 165, 30f);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.FirestarterBar.StrataLevel));
+            }
         }
 
         protected void DrawThunderDoTBar(Vector2 origin, PlayerCharacter player)
         {
             GameObject? target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
 
-            BarUtilities.GetDoTBar(Config.ThunderDoTBar, player, target, ThunderDoTIDs, ThunderDoTDurations)?.
-                Draw(origin);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.ThunderDoTBar, player, target, ThunderDoTIDs, ThunderDoTDurations);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.ThunderDoTBar.StrataLevel));
+            }
         }
     }
 

--- a/DelvUI/Interface/Jobs/BlueMageHud.cs
+++ b/DelvUI/Interface/Jobs/BlueMageHud.cs
@@ -96,7 +96,11 @@ namespace DelvUI.Interface.Jobs
         protected void DrawBleedBar(Vector2 origin, PlayerCharacter player)
         {
             var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
-            BarUtilities.GetDoTBar(Config.BleedBar, player, target, BleedID, BleedDurations)?.Draw(origin);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.BleedBar, player, target, BleedID, BleedDurations);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.BleedBar.StrataLevel));
+            }
         }
 
         protected void DrawWindburnBar(Vector2 origin, PlayerCharacter player)
@@ -111,7 +115,11 @@ namespace DelvUI.Interface.Jobs
 
             if (dotExists)
             {
-                BarUtilities.GetDoTBar(Config.WindburnBar, player, target, 1723, 6f)?.Draw(origin);
+                BarHud? bar = BarUtilities.GetDoTBar(Config.WindburnBar, player, target, 1723, 6f);
+                if (bar != null)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.WindburnBar.StrataLevel));
+                }
             }
             else
             {
@@ -127,7 +135,8 @@ namespace DelvUI.Interface.Jobs
                         Config.WindburnBar.Label.SetText("Ready");
                     }
 
-                    BarUtilities.GetProgressBar(Config.WindburnBar, current, max, 0f, player).Draw(origin);
+                    BarHud bar = BarUtilities.GetProgressBar(Config.WindburnBar, current, max, 0f, player);
+                    AddDrawActions(bar.GetDrawActions(origin, Config.WindburnBar.StrataLevel));
                 }
             }
         }
@@ -141,14 +150,24 @@ namespace DelvUI.Interface.Jobs
             if (!Config.SurpanakhaBar.HideWhenInactive || current < max)
             {
                 Config.SurpanakhaBar.Label.SetValue((max - current) % 30);
-                BarUtilities.GetChunkedProgressBars(Config.SurpanakhaBar, 4, current, max, 0f, player).Draw(origin);
+
+                BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.SurpanakhaBar, 4, current, max, 0f, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.SurpanakhaBar.StrataLevel));
+                }
             }
         }
 
         protected void DrawOffGuardBar(Vector2 origin, PlayerCharacter player)
         {
             var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
-            BarUtilities.GetDoTBar(Config.OffGuardBar, player, target, 1717, 15f)?.Draw(origin);
+
+            BarHud? bar = BarUtilities.GetDoTBar(Config.OffGuardBar, player, target, 1717, 15f);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.OffGuardBar.StrataLevel));
+            }
         }
 
         protected void DrawMoonFluteBar(Vector2 origin, PlayerCharacter player)
@@ -166,7 +185,9 @@ namespace DelvUI.Interface.Jobs
                 float buffDuration = buff?.RemainingTime ?? 0f;
 
                 Config.MoonFluteBar.Label.SetValue(buffDuration);
-                BarUtilities.GetProgressBar(Config.MoonFluteBar, buffDuration, 15f, 0, player, fillColor: buffColor).Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.MoonFluteBar, buffDuration, 15f, 0, player, fillColor: buffColor);
+                AddDrawActions(bar.GetDrawActions(origin, Config.MoonFluteBar.StrataLevel));
             }
         }
 
@@ -185,14 +206,19 @@ namespace DelvUI.Interface.Jobs
                 float buffDuration = buff?.RemainingTime ?? 0f;
 
                 Config.SpellAmpBar.Label.SetValue(buffDuration);
-                BarUtilities.GetProgressBar(Config.SpellAmpBar, buffDuration, 30f, 0, player, fillColor: buffColor).Draw(origin);
 
+                BarHud bar = BarUtilities.GetProgressBar(Config.SpellAmpBar, buffDuration, 30f, 0, player, fillColor: buffColor);
+                AddDrawActions(bar.GetDrawActions(origin, Config.SpellAmpBar.StrataLevel));
             }
         }
 
         protected void DrawTingleBar(Vector2 origin, PlayerCharacter player)
         {
-            BarUtilities.GetProcBar(Config.TingleBar, player, 2492, 15f)?.Draw(origin);
+            BarHud? bar = BarUtilities.GetProcBar(Config.TingleBar, player, 2492, 15f);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.TingleBar.StrataLevel));
+            }
         }
     }
 

--- a/DelvUI/Interface/Jobs/DancerHud.cs
+++ b/DelvUI/Interface/Jobs/DancerHud.cs
@@ -132,8 +132,11 @@ namespace DelvUI.Interface.Jobs
 
         private void DrawProcBar(Vector2 origin, PlayerCharacter player, DancerProcBarConfig config, uint statusId)
         {
-            BarUtilities.GetProcBar(config, player, statusId, 20f, !config.IgnoreBuffDuration)?.
-                Draw(origin);
+            BarHud? bar = BarUtilities.GetProcBar(config, player, statusId, 20f, !config.IgnoreBuffDuration);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, config.StrataLevel));
+            }
         }
 
         private unsafe bool DrawStepBar(Vector2 origin, PlayerCharacter player)
@@ -200,8 +203,11 @@ namespace DelvUI.Interface.Jobs
                 }
             }
 
-            BarUtilities.GetChunkedBars(Config.StepsBar, chunks.ToArray(), player, Config.StepsBar.GlowConfig, glows.ToArray())
-                .Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.StepsBar, chunks.ToArray(), player, Config.StepsBar.GlowConfig, glows.ToArray());
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.StepsBar.StrataLevel));
+            }
 
             return true;
         }
@@ -213,8 +219,12 @@ namespace DelvUI.Interface.Jobs
             if (Config.EspritGauge.HideWhenInactive && gauge.Esprit is 0) { return; }
 
             Config.EspritGauge.Label.SetValue(gauge.Esprit);
-            BarUtilities.GetChunkedProgressBars(Config.EspritGauge, 2, gauge.Esprit, 100, 0f, player)
-                .Draw(origin);
+
+            BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.EspritGauge, 2, gauge.Esprit, 100, 0f, player);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.EspritGauge.StrataLevel));
+            }
         }
 
         private void DrawFeathersBar(Vector2 origin, PlayerCharacter player)
@@ -235,8 +245,11 @@ namespace DelvUI.Interface.Jobs
             }
 
             BarGlowConfig? config = hasFlourishingBuff ? Config.FeatherGauge.GlowConfig : null;
-            BarUtilities.GetChunkedBars(Config.FeatherGauge, 4, gauge.Feathers, 4, 0, player, glowConfig: config, chunksToGlow: glows)
-                .Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.FeatherGauge, 4, gauge.Feathers, 4, 0, player, glowConfig: config, chunksToGlow: glows);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.FeatherGauge.StrataLevel));
+            }
         }
 
         private void DrawTechnicalBar(Vector2 origin, PlayerCharacter player)
@@ -248,8 +261,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.TechnicalFinishBar.HideWhenInactive || technicalFinishDuration > 0)
             {
                 Config.TechnicalFinishBar.Label.SetValue(Math.Abs(technicalFinishDuration));
-                BarUtilities.GetProgressBar(Config.TechnicalFinishBar, technicalFinishDuration, 20f, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.TechnicalFinishBar, technicalFinishDuration, 20f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.TechnicalFinishBar.StrataLevel));
             }
         }
 
@@ -260,8 +274,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.DevilmentBar.HideWhenInactive || devilmentDuration > 0)
             {
                 Config.DevilmentBar.Label.SetValue(Math.Abs(devilmentDuration));
-                BarUtilities.GetProgressBar(Config.DevilmentBar, devilmentDuration, 20f, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.DevilmentBar, devilmentDuration, 20f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.DevilmentBar.StrataLevel));
             }
         }
 
@@ -272,8 +287,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.StandardFinishBar.HideWhenInactive || standardFinishDuration > 0)
             {
                 Config.StandardFinishBar.Label.SetValue(Math.Abs(standardFinishDuration));
-                BarUtilities.GetProgressBar(Config.StandardFinishBar, standardFinishDuration, 60f, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.StandardFinishBar, standardFinishDuration, 60f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.StandardFinishBar.StrataLevel));
             }
         }
     }

--- a/DelvUI/Interface/Jobs/DarkKnightHud.cs
+++ b/DelvUI/Interface/Jobs/DarkKnightHud.cs
@@ -112,7 +112,7 @@ namespace DelvUI.Interface.Jobs
             Config.ManaBar.Label.SetValue(player.CurrentMp);
 
             // hardcoded 9k as maxMP so the chunks are each 3k since that's what a DRK wants to see
-            BarUtilities.GetChunkedProgressBars(
+            BarHud[] bars = BarUtilities.GetChunkedProgressBars(
                 Config.ManaBar,
                 gauge.HasDarkArts ? 1 : 3,
                 player.CurrentMp,
@@ -121,7 +121,12 @@ namespace DelvUI.Interface.Jobs
                 player,
                 null,
                 gauge.HasDarkArts ? Config.ManaBar.DarkArtsColor : Config.ManaBar.FillColor
-                ).Draw(origin);
+            );
+
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.ManaBar.StrataLevel));
+            }
         }
 
         private void DrawDarkside(Vector2 origin, PlayerCharacter player)
@@ -132,8 +137,9 @@ namespace DelvUI.Interface.Jobs
             float timer = Math.Abs(gauge.DarksideTimeRemaining) / 1000;
 
             Config.DarksideBar.Label.SetValue(timer);
-            BarUtilities.GetProgressBar(Config.DarksideBar, timer, 60, 0, player)
-                .Draw(origin);
+
+            BarHud bar = BarUtilities.GetProgressBar(Config.DarksideBar, timer, 60, 0, player);
+            AddDrawActions(bar.GetDrawActions(origin, Config.DarksideBar.StrataLevel));
         }
 
         private void DrawBloodGauge(Vector2 origin, PlayerCharacter player)
@@ -142,8 +148,12 @@ namespace DelvUI.Interface.Jobs
             if (!Config.BloodGauge.HideWhenInactive || gauge.Blood > 0)
             {
                 Config.BloodGauge.Label.SetValue(gauge.Blood);
-                BarUtilities.GetChunkedProgressBars(Config.BloodGauge, 2, gauge.Blood, 100, 0, player)
-                    .Draw(origin);
+
+                BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.BloodGauge, 2, gauge.Blood, 100, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.BloodGauge.StrataLevel));
+                }
             }
         }
 
@@ -154,8 +164,9 @@ namespace DelvUI.Interface.Jobs
             if (Config.BloodWeaponBar.HideWhenInactive && bloodWeaponDuration is 0) { return; }
 
             Config.BloodWeaponBar.Label.SetValue(bloodWeaponDuration);
-            BarUtilities.GetProgressBar(Config.BloodWeaponBar, bloodWeaponDuration, 10, 0f, player)
-                .Draw(origin);
+
+            BarHud bar = BarUtilities.GetProgressBar(Config.BloodWeaponBar, bloodWeaponDuration, 10, 0f, player);
+            AddDrawActions(bar.GetDrawActions(origin, Config.BloodWeaponBar.StrataLevel));
         }
 
         private void DrawDeliriumBar(Vector2 origin, PlayerCharacter player)
@@ -174,8 +185,12 @@ namespace DelvUI.Interface.Jobs
                 }
 
                 Config.DeliriumBar.Label.SetValue(deliriumDuration);
-                BarUtilities.GetChunkedBars(Config.DeliriumBar, chunks, player)
-                            .Draw(origin);
+
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.DeliriumBar, chunks, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.DeliriumBar.StrataLevel));
+                }
             }
         }
 
@@ -187,8 +202,8 @@ namespace DelvUI.Interface.Jobs
             float timer = Math.Abs(gauge.ShadowTimeRemaining) / 1000;
             Config.LivingShadowBar.Label.SetValue(timer);
 
-            BarUtilities.GetProgressBar(Config.LivingShadowBar, timer, 24, 0, player)
-                .Draw(origin);
+            BarHud bar = BarUtilities.GetProgressBar(Config.LivingShadowBar, timer, 24, 0, player);
+            AddDrawActions(bar.GetDrawActions(origin, Config.LivingShadowBar.StrataLevel));
         }
     }
 

--- a/DelvUI/Interface/Jobs/DragoonHud.cs
+++ b/DelvUI/Interface/Jobs/DragoonHud.cs
@@ -91,37 +91,46 @@ namespace DelvUI.Interface.Jobs
             }
         }
 
-        private void DrawChaosThrustBar(Vector2 pos, PlayerCharacter player)
+        private void DrawChaosThrustBar(Vector2 origin, PlayerCharacter player)
         {
             GameObject? target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
 
-            BarUtilities.GetDoTBar(Config.ChaosThrustBar, player, target, ChaosThrustIDs, ChaosThrustDurations)?.
-                Draw(pos);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.ChaosThrustBar, player, target, ChaosThrustIDs, ChaosThrustDurations);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.ChaosThrustBar.StrataLevel));
+            }
         }
 
-        private void DrawEyeOfTheDragonBars(Vector2 pos, PlayerCharacter player)
+        private void DrawEyeOfTheDragonBars(Vector2 origin, PlayerCharacter player)
         {
             DRGGauge gauge = Plugin.JobGauges.Get<DRGGauge>();
 
             if (!Config.EyeOfTheDragonBar.HideWhenInactive || gauge.EyeCount > 0)
             {
-                BarUtilities.GetChunkedBars(Config.EyeOfTheDragonBar, 2, gauge.EyeCount, 2, 0, player)
-                    .Draw(pos);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.EyeOfTheDragonBar, 2, gauge.EyeCount, 2, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.EyeOfTheDragonBar.StrataLevel));
+                }
             }
         }
 
-        private void DrawFirstmindsFocusBars(Vector2 pos, PlayerCharacter player)
+        private void DrawFirstmindsFocusBars(Vector2 origin, PlayerCharacter player)
         {
             DRGGauge gauge = Plugin.JobGauges.Get<DRGGauge>();
 
             if (!Config.FirstmindsFocusBar.HideWhenInactive || gauge.FirstmindsFocusCount > 0)
             {
-                BarUtilities.GetChunkedBars(Config.FirstmindsFocusBar, 2, gauge.FirstmindsFocusCount, 2, 0, player)
-                    .Draw(pos);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.FirstmindsFocusBar, 2, gauge.FirstmindsFocusCount, 2, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.FirstmindsFocusBar.StrataLevel));
+                }
             }
         }
 
-        private void DrawBloodOfTheDragonBar(Vector2 pos, PlayerCharacter player)
+        private void DrawBloodOfTheDragonBar(Vector2 origin, PlayerCharacter player)
         {
             DRGGauge gauge = Plugin.JobGauges.Get<DRGGauge>();
             float duration = gauge.LOTDTimer / 1000f;
@@ -129,8 +138,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.LifeOfTheDragonBar.HideWhenInactive || duration > 0f)
             {
                 Config.LifeOfTheDragonBar.Label.SetValue(duration);
-                BarUtilities.GetProgressBar(Config.LifeOfTheDragonBar, duration, 30, 0f, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.LifeOfTheDragonBar, duration, 30, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.LifeOfTheDragonBar.StrataLevel));
             }
         }
 
@@ -140,8 +150,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.PowerSurgeBar.HideWhenInactive || duration > 0f)
             {
                 Config.PowerSurgeBar.Label.SetValue(duration);
-                BarUtilities.GetProgressBar(Config.PowerSurgeBar, duration, 30f, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.PowerSurgeBar, duration, 30f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.PowerSurgeBar.StrataLevel));
             }
         }
     }

--- a/DelvUI/Interface/Jobs/GunbreakerHud.cs
+++ b/DelvUI/Interface/Jobs/GunbreakerHud.cs
@@ -49,25 +49,29 @@ namespace DelvUI.Interface.Jobs
             }
         }
 
-        private void DrawPowderGauge(Vector2 pos, PlayerCharacter player)
+        private void DrawPowderGauge(Vector2 origin, PlayerCharacter player)
         {
             var gauge = Plugin.JobGauges.Get<GNBGauge>();
             if (!Config.PowderGauge.HideWhenInactive || gauge.Ammo > 0)
             {
                 var maxCartridges = player.Level >= 88 ? 3 : 2;
-                BarUtilities.GetChunkedBars(Config.PowderGauge, maxCartridges, gauge.Ammo, maxCartridges, 0, player)
-                    .Draw(pos);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.PowderGauge, maxCartridges, gauge.Ammo, maxCartridges, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.PowderGauge.StrataLevel));
+                }
             }
         }
 
-        private void DrawNoMercyBar(Vector2 pos, PlayerCharacter player)
+        private void DrawNoMercyBar(Vector2 origin, PlayerCharacter player)
         {
             float noMercyDuration = player.StatusList.FirstOrDefault(o => o.StatusId == 1831 && o.RemainingTime > 0f)?.RemainingTime ?? 0f;
             if (!Config.NoMercy.HideWhenInactive || noMercyDuration > 0)
             {
                 Config.NoMercy.Label.SetValue(noMercyDuration);
-                BarUtilities.GetProgressBar(Config.NoMercy, noMercyDuration, 20f, 0f, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.NoMercy, noMercyDuration, 20f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.NoMercy.StrataLevel));
             }
         }
     }

--- a/DelvUI/Interface/Jobs/MachinistHud.cs
+++ b/DelvUI/Interface/Jobs/MachinistHud.cs
@@ -80,8 +80,12 @@ namespace DelvUI.Interface.Jobs
             if (!Config.HeatGauge.HideWhenInactive || gauge.Heat > 0)
             {
                 Config.HeatGauge.Label.SetValue(gauge.Heat);
-                BarUtilities.GetChunkedProgressBars(Config.HeatGauge, 2, gauge.Heat, 100, 0, player)
-                    .Draw(origin);
+
+                BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.HeatGauge, 2, gauge.Heat, 100, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.HeatGauge.StrataLevel));
+                }
             }
         }
 
@@ -92,14 +96,16 @@ namespace DelvUI.Interface.Jobs
             if ((!Config.BatteryGauge.HideWhenInactive || gauge.Battery > 0) && !gauge.IsRobotActive)
             {
                 Config.BatteryGauge.Label.SetValue(gauge.Battery);
-                BarUtilities.GetProgressBar(Config.BatteryGauge, gauge.Battery, 100f, 0f, player, Config.BatteryGauge.BatteryColor)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.BatteryGauge, gauge.Battery, 100f, 0f, player, Config.BatteryGauge.BatteryColor);
+                AddDrawActions(bar.GetDrawActions(origin, Config.BatteryGauge.StrataLevel));
             }
 
             if (!gauge.IsRobotActive && _robotMaxDurationSet)
             {
                 _robotMaxDurationSet = false;
             }
+
             if (gauge.IsRobotActive)
             {
                 if (!_robotMaxDurationSet)
@@ -109,8 +115,9 @@ namespace DelvUI.Interface.Jobs
                 }
 
                 Config.BatteryGauge.Label.SetValue(gauge.SummonTimeRemaining / 1000f);
-                BarUtilities.GetProgressBar(Config.BatteryGauge, gauge.SummonTimeRemaining / 1000, _robotMaxDuration / 1000, 0f, player, Config.BatteryGauge.RobotColor)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.BatteryGauge, gauge.SummonTimeRemaining / 1000, _robotMaxDuration / 1000, 0f, player, Config.BatteryGauge.RobotColor);
+                AddDrawActions(bar.GetDrawActions(origin, Config.BatteryGauge.StrataLevel));
             }
         }
 
@@ -121,8 +128,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.OverheatGauge.HideWhenInactive || gauge.IsOverheated)
             {
                 Config.OverheatGauge.Label.SetValue(gauge.OverheatTimeRemaining / 1000f);
-                BarUtilities.GetProgressBar(Config.OverheatGauge, gauge.OverheatTimeRemaining / 1000f, 8, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.OverheatGauge, gauge.OverheatTimeRemaining / 1000f, 8, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.OverheatGauge.StrataLevel));
             }
         }
 
@@ -133,8 +141,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.WildfireBar.HideWhenInactive || wildfireDuration > 0)
             {
                 Config.WildfireBar.Label.SetValue(wildfireDuration);
-                BarUtilities.GetProgressBar(Config.WildfireBar, wildfireDuration, 10, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.WildfireBar, wildfireDuration, 10, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.WildfireBar.StrataLevel));
             }
         }
     }

--- a/DelvUI/Interface/Jobs/MonkHud.cs
+++ b/DelvUI/Interface/Jobs/MonkHud.cs
@@ -108,7 +108,7 @@ namespace DelvUI.Interface.Jobs
             }
         }
 
-        private void DrawFormsBar(Vector2 pos, PlayerCharacter player)
+        private void DrawFormsBar(Vector2 origin, PlayerCharacter player)
         {
             Status? form = player.StatusList.FirstOrDefault(o => o.StatusId is 107 or 108 or 109 or 2513 && o.RemainingTime > 0f);
 
@@ -125,12 +125,13 @@ namespace DelvUI.Interface.Jobs
                 } : "";
 
                 Config.FormsBar.Label.SetText(label);
-                BarUtilities.GetProgressBar(Config.FormsBar, formDuration, 30f, 0, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.FormsBar, formDuration, 30f, 0, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.FormsBar.StrataLevel));
             }
         }
 
-        private void DrawPerfectBalanceBar(Vector2 pos, PlayerCharacter player)
+        private void DrawPerfectBalanceBar(Vector2 origin, PlayerCharacter player)
         {
             Status? perfectBalance = player.StatusList.Where(o => o.StatusId is 110 && o.RemainingTime > 0f).FirstOrDefault();
             if (!Config.PerfectBalanceBar.HideWhenInactive || perfectBalance is not null)
@@ -148,22 +149,29 @@ namespace DelvUI.Interface.Jobs
                 }
 
                 Config.PerfectBalanceBar.PerfectBalanceLabel.SetValue(duration);
-                BarUtilities.GetChunkedBars(Config.PerfectBalanceBar, chunks, player)
-                    .Draw(pos);
+
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.PerfectBalanceBar, chunks, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.PerfectBalanceBar.StrataLevel));
+                }
             }
         }
 
-        private void DrawChakraGauge(Vector2 pos, PlayerCharacter player)
+        private void DrawChakraGauge(Vector2 origin, PlayerCharacter player)
         {
             var gauge = Plugin.JobGauges.Get<MNKGauge>();
             if (!Config.ChakraBar.HideWhenInactive || gauge.Chakra > 0)
             {
-                BarUtilities.GetChunkedBars(Config.ChakraBar, 5, gauge.Chakra, 5, 0, player)
-                    .Draw(pos);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.ChakraBar, 5, gauge.Chakra, 5, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.ChakraBar.StrataLevel));
+                }
             }
         }
 
-        private void DrawBeastChakraGauge(Vector2 pos, PlayerCharacter player)
+        private void DrawBeastChakraGauge(Vector2 origin, PlayerCharacter player)
         {
             var gauge = Plugin.JobGauges.Get<MNKGauge>();
             if (!Config.MastersGauge.HideWhenInactive ||
@@ -198,8 +206,12 @@ namespace DelvUI.Interface.Jobs
                 }
 
                 Config.MastersGauge.BlitzTimerLabel.SetValue(gauge.BlitzTimeRemaining / 1000);
-                BarUtilities.GetChunkedBars(Config.MastersGauge, chunks, player)
-                    .Draw(pos);
+
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.MastersGauge, chunks, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.MastersGauge.StrataLevel));
+                }
             }
         }
 
@@ -211,34 +223,39 @@ namespace DelvUI.Interface.Jobs
             _ => new PluginConfigColor(new(0, 0, 0, 0))
         };
 
-        private void DrawTwinSnakesBar(Vector2 pos, PlayerCharacter player)
+        private void DrawTwinSnakesBar(Vector2 origin, PlayerCharacter player)
         {
             float twinSnakesDuration = player.StatusList.FirstOrDefault(o => o.StatusId is 3001 && o.RemainingTime > 0)?.RemainingTime ?? 0f;
             if (!Config.TwinSnakesBar.HideWhenInactive || twinSnakesDuration > 0)
             {
                 Config.TwinSnakesBar.Label.SetValue(twinSnakesDuration);
-                BarUtilities.GetProgressBar(Config.TwinSnakesBar, twinSnakesDuration, 15f, 0f, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.TwinSnakesBar, twinSnakesDuration, 15f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.TwinSnakesBar.StrataLevel));
             }
         }
 
-        private void DrawLeadenFistBar(Vector2 pos, PlayerCharacter player)
+        private void DrawLeadenFistBar(Vector2 origin, PlayerCharacter player)
         {
             float leadenFistDuration = player.StatusList.FirstOrDefault(o => o.StatusId is 1861 && o.RemainingTime > 0)?.RemainingTime ?? 0f;
             if (!Config.LeadenFistBar.HideWhenInactive || leadenFistDuration > 0)
             {
                 Config.LeadenFistBar.Label.SetValue(leadenFistDuration);
-                BarUtilities.GetProgressBar(Config.LeadenFistBar, leadenFistDuration, 30f, 0f, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.LeadenFistBar, leadenFistDuration, 30f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.LeadenFistBar.StrataLevel));
             }
         }
 
-        private void DrawDemolishBar(Vector2 pos, PlayerCharacter player)
+        private void DrawDemolishBar(Vector2 origin, PlayerCharacter player)
         {
             GameObject? target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
 
-            BarUtilities.GetDoTBar(Config.DemolishBar, player, target, 246, 18f)?.
-                Draw(pos);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.DemolishBar, player, target, 246, 18f);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.DemolishBar.StrataLevel));
+            }
         }
     }
 

--- a/DelvUI/Interface/Jobs/NinjaHud.cs
+++ b/DelvUI/Interface/Jobs/NinjaHud.cs
@@ -106,7 +106,7 @@ namespace DelvUI.Interface.Jobs
             return (ninjutsuBuff is not null, kassatsuBuff is not null, tcjBuff is not null);
         }
 
-        private void DrawMudraBars(Vector2 pos, PlayerCharacter player)
+        private void DrawMudraBars(Vector2 origin, PlayerCharacter player)
         {
             var (hasNinjutsuBuff, hasKassatsuBuff, hasTCJBuff) = GetMudraBuffs(player, out Status? ninjutsuBuff, out Status? kassatsuBuff, out Status? tcjBuff);
 
@@ -145,8 +145,11 @@ namespace DelvUI.Interface.Jobs
                 PluginConfigColor fillColor = hasTCJBuff ? Config.MudraBar.TCJBarColor : hasKassatsuBuff ? Config.MudraBar.KassatsuBarColor : Config.MudraBar.FillColor;
                 Rect foreground = BarUtilities.GetFillRect(Config.MudraBar.Position, Config.MudraBar.Size, Config.MudraBar.FillDirection, fillColor, current, max);
 
-                BarHud bar = new BarHud(Config.MudraBar, player).AddForegrounds(foreground).AddLabels(Config.MudraBar.Label);
-                bar.Draw(pos);
+                BarHud bar = new BarHud(Config.MudraBar, player);
+                bar.AddForegrounds(foreground);
+                bar.AddLabels(Config.MudraBar.Label);
+
+                AddDrawActions(bar.GetDrawActions(origin, Config.MudraBar.StrataLevel));
             }
             else
             {
@@ -156,13 +159,17 @@ namespace DelvUI.Interface.Jobs
                 if (!Config.MudraBar.HideWhenInactive || current < max)
                 {
                     Config.MudraBar.Label.SetValue((max - current) % 20);
-                    BarUtilities.GetChunkedProgressBars(Config.MudraBar, 2, current, max, 0f, player)
-                        .Draw(pos);
+
+                    BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.MudraBar, 2, current, max, 0f, player);
+                    foreach (BarHud bar in bars)
+                    {
+                        AddDrawActions(bar.GetDrawActions(origin, Config.MudraBar.StrataLevel));
+                    }
                 }
             }
         }
 
-        private void DrawHutonGauge(Vector2 pos, PlayerCharacter player)
+        private void DrawHutonGauge(Vector2 origin, PlayerCharacter player)
         {
             NINGauge gauge = Plugin.JobGauges.Get<NINGauge>();
             float hutonDuration = gauge.HutonTimer / 1000f;
@@ -170,24 +177,29 @@ namespace DelvUI.Interface.Jobs
             if (!Config.HutonBar.HideWhenInactive || gauge.HutonTimer > 0)
             {
                 Config.HutonBar.Label.SetValue(hutonDuration);
-                BarUtilities.GetProgressBar(Config.HutonBar, hutonDuration, 60f, 0f, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.HutonBar, hutonDuration, 60f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.HutonBar.StrataLevel));
             }
         }
 
-        private void DrawNinkiGauge(Vector2 pos, PlayerCharacter player)
+        private void DrawNinkiGauge(Vector2 origin, PlayerCharacter player)
         {
             NINGauge gauge = Plugin.JobGauges.Get<NINGauge>();
 
             if (!Config.NinkiBar.HideWhenInactive || gauge.Ninki > 0)
             {
                 Config.NinkiBar.Label.SetValue(gauge.Ninki);
-                BarUtilities.GetChunkedProgressBars(Config.NinkiBar, 2, gauge.Ninki, 100, 0, player)
-                    .Draw(pos);
+
+                BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.NinkiBar, 2, gauge.Ninki, 100, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.NinkiBar.StrataLevel));
+                }
             }
         }
 
-        private void DrawTrickAttackBar(Vector2 pos, PlayerCharacter player)
+        private void DrawTrickAttackBar(Vector2 origin, PlayerCharacter player)
         {
             GameObject? actor = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
             float trickDuration = 0f;
@@ -200,20 +212,22 @@ namespace DelvUI.Interface.Jobs
             if (!Config.TrickAttackBar.HideWhenInactive || trickDuration > 0)
             {
                 Config.TrickAttackBar.Label.SetValue(trickDuration);
-                BarUtilities.GetProgressBar(Config.TrickAttackBar, trickDuration, 15f, 0f, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.TrickAttackBar, trickDuration, 15f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.TrickAttackBar.StrataLevel));
             }
         }
 
-        private void DrawSuitonBar(Vector2 pos, PlayerCharacter player)
+        private void DrawSuitonBar(Vector2 origin, PlayerCharacter player)
         {
             float suitonDuration = player.StatusList.FirstOrDefault(o => o.StatusId == 507 && o.RemainingTime > 0)?.RemainingTime ?? 0f;
 
             if (!Config.SuitonBar.HideWhenInactive || suitonDuration > 0)
             {
                 Config.SuitonBar.Label.SetValue(suitonDuration);
-                BarUtilities.GetProgressBar(Config.SuitonBar, suitonDuration, 20f, 0f, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.SuitonBar, suitonDuration, 20f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.SuitonBar.StrataLevel));
             }
         }
 

--- a/DelvUI/Interface/Jobs/PaladinHud.cs
+++ b/DelvUI/Interface/Jobs/PaladinHud.cs
@@ -95,8 +95,12 @@ namespace DelvUI.Interface.Jobs
             if (!Config.OathGauge.HideWhenInactive || gauge.OathGauge > 0)
             {
                 Config.OathGauge.Label.SetValue(gauge.OathGauge);
-                BarUtilities.GetChunkedProgressBars(Config.OathGauge, 2, gauge.OathGauge, 100, 0, player)
-                    .Draw(origin);
+
+                BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.OathGauge, 2, gauge.OathGauge, 100, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.OathGauge.StrataLevel));
+                }
             }
         }
 
@@ -107,8 +111,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.FightOrFlightBar.HideWhenInactive || fightOrFlightDuration > 0)
             {
                 Config.FightOrFlightBar.Label.SetValue(fightOrFlightDuration);
-                BarUtilities.GetProgressBar(Config.FightOrFlightBar, fightOrFlightDuration, 25f, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.FightOrFlightBar, fightOrFlightDuration, 25f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.FightOrFlightBar.StrataLevel));
             }
         }
 
@@ -128,8 +133,12 @@ namespace DelvUI.Interface.Jobs
                 }
 
                 Config.RequiescatStacksBar.Label.SetValue(requiescatDuration);
-                BarUtilities.GetChunkedBars(Config.RequiescatStacksBar, chunks, player)
-                    .Draw(origin);
+
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.RequiescatStacksBar, chunks, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.RequiescatStacksBar.StrataLevel));
+                }
             }
         }
 
@@ -139,16 +148,22 @@ namespace DelvUI.Interface.Jobs
 
             if (Config.AtonementBar.HideWhenInactive && stackCount == 0) { return; };
 
-            BarUtilities.GetChunkedBars(Config.AtonementBar, 3, stackCount, 3f, 0, player)
-                .Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.AtonementBar, 3, stackCount, 3f, 0, player);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.AtonementBar.StrataLevel));
+            }
         }
 
         private void DrawDoTBar(Vector2 origin, PlayerCharacter player)
         {
             var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
 
-            BarUtilities.GetDoTBar(Config.GoringBladeBar, player, target, DoTIDs, DoTDurations)?.
-                Draw(origin);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.GoringBladeBar, player, target, DoTIDs, DoTDurations);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.GoringBladeBar.StrataLevel));
+            }
         }
     }
 

--- a/DelvUI/Interface/Jobs/ReaperHud.cs
+++ b/DelvUI/Interface/Jobs/ReaperHud.cs
@@ -81,7 +81,7 @@ namespace DelvUI.Interface.Jobs
             }
         }
 
-        private void DrawDeathsDesignBar(Vector2 pos, PlayerCharacter player)
+        private void DrawDeathsDesignBar(Vector2 origin, PlayerCharacter player)
         {
             GameObject? actor = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
             float duration = 0f;
@@ -94,36 +94,48 @@ namespace DelvUI.Interface.Jobs
             if (!Config.DeathsDesignBar.HideWhenInactive || duration > 0)
             {
                 Config.DeathsDesignBar.Label.SetValue(duration);
-                BarUtilities.GetChunkedProgressBars(Config.DeathsDesignBar, 2, duration, 60f, 0f, player)
-                    .Draw(pos);
+
+                BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.DeathsDesignBar, 2, duration, 60f, 0f, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.DeathsDesignBar.StrataLevel));
+                }
             }
         }
 
-        private void DrawSoulGauge(Vector2 pos, RPRGauge gauge, PlayerCharacter player)
+        private void DrawSoulGauge(Vector2 origin, RPRGauge gauge, PlayerCharacter player)
         {
             float soul = gauge.Soul;
 
             if (!Config.SoulBar.HideWhenInactive || soul > 0)
             {
                 Config.SoulBar.Label.SetValue(soul);
-                BarUtilities.GetChunkedProgressBars(Config.SoulBar, 2, soul, 100f, 0f, player)
-                    .Draw(pos);
+
+                BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.SoulBar, 2, soul, 100f, 0f, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.SoulBar.StrataLevel));
+                }
             }
         }
 
-        private void DrawShroudGauge(Vector2 pos, RPRGauge gauge, PlayerCharacter player)
+        private void DrawShroudGauge(Vector2 origin, RPRGauge gauge, PlayerCharacter player)
         {
             float shroud = gauge.Shroud;
 
             if (!Config.ShroudBar.HideWhenInactive || shroud > 0)
             {
                 Config.ShroudBar.Label.SetValue(shroud);
-                BarUtilities.GetChunkedProgressBars(Config.ShroudBar, 2, shroud, 100f, 0f, player)
-                    .Draw(pos);
+
+                BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.ShroudBar, 2, shroud, 100f, 0f, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.ShroudBar.StrataLevel));
+                }
             }
         }
 
-        private void DrawDeathGauge(Vector2 pos, RPRGauge gauge, PlayerCharacter player)
+        private void DrawDeathGauge(Vector2 origin, RPRGauge gauge, PlayerCharacter player)
         {
             var lemureShroud = gauge.LemureShroud;
             var voidShroud = gauge.VoidShroud;
@@ -149,8 +161,12 @@ namespace DelvUI.Interface.Jobs
                 }
 
                 Config.DeathGauge.EnshroudTimerLabel.SetValue(gauge.EnshroudedTimeRemaining / 1000);
-                BarUtilities.GetChunkedBars(Config.DeathGauge, deathChunks, player)
-                    .Draw(pos);
+
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.DeathGauge, deathChunks, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.DeathGauge.StrataLevel));
+                }
             }
         }
     }

--- a/DelvUI/Interface/Jobs/RedMageHud.cs
+++ b/DelvUI/Interface/Jobs/RedMageHud.cs
@@ -141,8 +141,8 @@ namespace DelvUI.Interface.Jobs
                 return;
             }
 
-            BarUtilities.GetBar(Config.BalanceBar, value, 1, 0, player, color)
-                .Draw(origin);
+            BarHud bar = BarUtilities.GetBar(Config.BalanceBar, value, 1, 0, player, color);
+            AddDrawActions(bar.GetDrawActions(origin, Config.BalanceBar.StrataLevel));
         }
 
         private void DrawWhiteManaBar(Vector2 origin, PlayerCharacter player)
@@ -154,8 +154,9 @@ namespace DelvUI.Interface.Jobs
             }
 
             Config.WhiteManaBar.Label.SetValue(mana);
-            BarUtilities.GetProgressBar(Config.WhiteManaBar, mana, 100, 0, player).
-                Draw(origin);
+
+            BarHud bar = BarUtilities.GetProgressBar(Config.WhiteManaBar, mana, 100, 0, player);
+            AddDrawActions(bar.GetDrawActions(origin, Config.WhiteManaBar.StrataLevel));
         }
 
         private void DrawBlackManaBar(Vector2 origin, PlayerCharacter player)
@@ -167,8 +168,9 @@ namespace DelvUI.Interface.Jobs
             }
 
             Config.BlackManaBar.Label.SetValue(mana);
-            BarUtilities.GetProgressBar(Config.BlackManaBar, mana, 100, 0, player).
-                Draw(origin);
+
+            BarHud bar = BarUtilities.GetProgressBar(Config.BlackManaBar, mana, 100, 0, player);
+            AddDrawActions(bar.GetDrawActions(origin, Config.BlackManaBar.StrataLevel));
         }
 
         private void DrawManaStacksBarBar(Vector2 origin, PlayerCharacter player)
@@ -179,8 +181,11 @@ namespace DelvUI.Interface.Jobs
                 return;
             }
 
-            BarUtilities.GetChunkedBars(Config.ManaStacksBar, 3, manaStacks, 3f, 0, player)
-                .Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.ManaStacksBar, 3, manaStacks, 3f, 0, player);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.ManaStacksBar.StrataLevel));
+            }
         }
 
         private void DrawDualCastBar(Vector2 origin, PlayerCharacter player)
@@ -193,20 +198,27 @@ namespace DelvUI.Interface.Jobs
             };
 
             Config.DualcastBar.Label.SetValue(duration);
-            BarUtilities.GetProgressBar(Config.DualcastBar, duration, 15f, 0, player).
-                Draw(origin);
+
+            BarHud bar = BarUtilities.GetProgressBar(Config.DualcastBar, duration, 15f, 0, player);
+            AddDrawActions(bar.GetDrawActions(origin, Config.DualcastBar.StrataLevel));
         }
 
         private void DrawVerstoneBar(Vector2 origin, PlayerCharacter player)
         {
-            BarUtilities.GetProcBar(Config.VerstoneBar, player, 1235, 30)?
-                .Draw(origin);
+            BarHud? bar = BarUtilities.GetProcBar(Config.VerstoneBar, player, 1235, 30);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.VerstoneBar.StrataLevel));
+            }
         }
 
         private void DrawVerfireBar(Vector2 origin, PlayerCharacter player)
         {
-            BarUtilities.GetProcBar(Config.VerfireBar, player, 1234, 30)?
-                .Draw(origin);
+            BarHud? bar = BarUtilities.GetProcBar(Config.VerfireBar, player, 1234, 30);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.VerfireBar.StrataLevel));
+            }
         }
     }
 

--- a/DelvUI/Interface/Jobs/SageHud.cs
+++ b/DelvUI/Interface/Jobs/SageHud.cs
@@ -85,8 +85,11 @@ namespace DelvUI.Interface.Jobs
         {
             GameObject? target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
 
-            BarUtilities.GetDoTBar(Config.DotBar, player, target, DotIDs, DotDurations)?.
-                    Draw(origin);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.DotBar, player, target, DotIDs, DotDurations);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.DotBar.StrataLevel));
+            }
         }
 
         private void DrawAddersgallBar(Vector2 origin, PlayerCharacter player)
@@ -101,14 +104,20 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.AddersgallBar.HideWhenInactive || adderScale > 0)
             {
-                BarUtilities.GetChunkedBars(Config.AddersgallBar, 3, adderScale, 3, 0, player, glowConfig: glow, chunksToGlow: new[] { true, true, true })
-                    .Draw(origin);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.AddersgallBar, 3, adderScale, 3, 0, player, glowConfig: glow, chunksToGlow: new[] { true, true, true });
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.AddersgallBar.StrataLevel));
+                }
             }
 
             if (!Config.AdderstingBar.HideWhenInactive && Config.AdderstingBar.Enabled || gauge.Addersting > 0)
             {
-                BarUtilities.GetChunkedBars(Config.AdderstingBar, 3, gauge.Addersting, 3, 0, player, glowConfig: glow, chunksToGlow: new[] { true, true, true })
-                    .Draw(origin);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.AdderstingBar, 3, gauge.Addersting, 3, 0, player, glowConfig: glow, chunksToGlow: new[] { true, true, true });
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.AdderstingBar.StrataLevel));
+                }
             }
         }
 
@@ -119,8 +128,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.PhysisBar.HideWhenInactive || physisDuration > 0)
             {
                 Config.PhysisBar.Label.SetValue(physisDuration);
-                BarUtilities.GetProgressBar(Config.PhysisBar, physisDuration, 15f, 0f, player)
-                    .Draw(origin);
+                BarHud bar = BarUtilities.GetProgressBar(Config.PhysisBar, physisDuration, 15f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.PhysisBar.StrataLevel));
             }
         }
 
@@ -135,8 +144,8 @@ namespace DelvUI.Interface.Jobs
                 float maxDuration = holosDuration > 0 ? 20f : 15f;
 
                 Config.KeracholeBar.Label.SetValue(duration);
-                BarUtilities.GetProgressBar(Config.KeracholeBar, duration, maxDuration, 0f, player)
-                    .Draw(origin);
+                BarHud bar = BarUtilities.GetProgressBar(Config.KeracholeBar, duration, maxDuration, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.KeracholeBar.StrataLevel));
             }
         }
     }

--- a/DelvUI/Interface/Jobs/SamuraiHud.cs
+++ b/DelvUI/Interface/Jobs/SamuraiHud.cs
@@ -100,51 +100,57 @@ namespace DelvUI.Interface.Jobs
             }
         }
 
-        private void DrawKenkiBar(Vector2 pos, PlayerCharacter player)
+        private void DrawKenkiBar(Vector2 origin, PlayerCharacter player)
         {
             SAMGauge gauge = Plugin.JobGauges.Get<SAMGauge>();
 
             if (!Config.KenkiBar.HideWhenInactive || gauge.Kenki > 0)
             {
                 Config.KenkiBar.Label.SetValue(gauge.Kenki);
-                BarUtilities.GetProgressBar(Config.KenkiBar, gauge.Kenki, 100f, 0f, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.KenkiBar, gauge.Kenki, 100f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.KenkiBar.StrataLevel));
             }
         }
 
-        private void DrawShifuBar(Vector2 pos, PlayerCharacter player)
+        private void DrawShifuBar(Vector2 origin, PlayerCharacter player)
         {
             float shifuDuration = player.StatusList.FirstOrDefault(o => o.StatusId is 1299)?.RemainingTime ?? 0f;
 
             if (!Config.ShifuBar.HideWhenInactive || shifuDuration > 0)
             {
                 Config.ShifuBar.Label.SetValue(shifuDuration);
-                BarUtilities.GetProgressBar(Config.ShifuBar, shifuDuration, 40f, 0f, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.ShifuBar, shifuDuration, 40f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.ShifuBar.StrataLevel));
             }
         }
 
-        private void DrawJinpuBar(Vector2 pos, PlayerCharacter player)
+        private void DrawJinpuBar(Vector2 origin, PlayerCharacter player)
         {
             float jinpuDuration = player.StatusList.FirstOrDefault(o => o.StatusId is 1298)?.RemainingTime ?? 0f;
 
             if (!Config.JinpuBar.HideWhenInactive || jinpuDuration > 0)
             {
                 Config.JinpuBar.Label.SetValue(jinpuDuration);
-                BarUtilities.GetProgressBar(Config.JinpuBar, jinpuDuration, 40f, 0f, player)
-                    .Draw(pos);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.JinpuBar, jinpuDuration, 40f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.JinpuBar.StrataLevel));
             }
         }
 
-        private void DrawHiganbanaBar(Vector2 pos, PlayerCharacter player)
+        private void DrawHiganbanaBar(Vector2 origin, PlayerCharacter player)
         {
             var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
 
-            BarUtilities.GetDoTBar(Config.HiganbanaBar, player, target, HiganbanaIDs, HiganabaDurations)?.
-                Draw(pos);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.HiganbanaBar, player, target, HiganbanaIDs, HiganabaDurations);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.HiganbanaBar.StrataLevel));
+            }
         }
 
-        private void DrawSenBar(Vector2 pos, PlayerCharacter player)
+        private void DrawSenBar(Vector2 origin, PlayerCharacter player)
         {
             SAMGauge gauge = Plugin.JobGauges.Get<SAMGauge>();
             if (!Config.SenBar.HideWhenInactive || gauge.HasSetsu || gauge.HasGetsu || gauge.HasKa)
@@ -159,18 +165,24 @@ namespace DelvUI.Interface.Jobs
                     sen[i] = new Tuple<PluginConfigColor, float, LabelConfig?>(colors[order[i]], hasSen[order[i]], null);
                 }
 
-                BarUtilities.GetChunkedBars(Config.SenBar, sen, player)
-                    .Draw(pos);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.SenBar, sen, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.SenBar.StrataLevel));
+                }
             }
         }
 
-        private void DrawMeditationBar(Vector2 pos, PlayerCharacter player)
+        private void DrawMeditationBar(Vector2 origin, PlayerCharacter player)
         {
             SAMGauge gauge = Plugin.JobGauges.Get<SAMGauge>();
             if (!Config.MeditationBar.HideWhenInactive || gauge.MeditationStacks > 0)
             {
-                BarUtilities.GetChunkedBars(Config.MeditationBar, 3, gauge.MeditationStacks, 3f, 0, player)
-                    .Draw(pos);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.MeditationBar, 3, gauge.MeditationStacks, 3f, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.MeditationBar.StrataLevel));
+                }
             }
         }
     }

--- a/DelvUI/Interface/Jobs/ScholarHud.cs
+++ b/DelvUI/Interface/Jobs/ScholarHud.cs
@@ -84,8 +84,11 @@ namespace DelvUI.Interface.Jobs
         {
             var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
 
-            BarUtilities.GetDoTBar(Config.BioBar, player, target, BioDoTIDs, BioDoTDurations)?.
-                Draw(origin);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.BioBar, player, target, BioDoTIDs, BioDoTDurations);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.BioBar.StrataLevel));
+            }
         }
 
         private void DrawFairyGaugeBar(Vector2 origin, PlayerCharacter player)
@@ -101,14 +104,16 @@ namespace DelvUI.Interface.Jobs
             if (Config.FairyGaugeBar.ShowSeraph && seraphDuration > 0)
             {
                 Config.FairyGaugeBar.Label.SetValue(seraphDuration / 1000);
-                BarUtilities.GetProgressBar(Config.FairyGaugeBar, seraphDuration / 1000, 22, 0, player, Config.FairyGaugeBar.SeraphColor).
-                    Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.FairyGaugeBar, seraphDuration / 1000, 22, 0, player, Config.FairyGaugeBar.SeraphColor);
+                AddDrawActions(bar.GetDrawActions(origin, Config.FairyGaugeBar.StrataLevel));
             }
             else
             {
                 Config.FairyGaugeBar.Label.SetValue(fairyGauge);
-                BarUtilities.GetProgressBar(Config.FairyGaugeBar, fairyGauge, 100, 0, player).
-                    Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.FairyGaugeBar, fairyGauge, 100, 0, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.FairyGaugeBar.StrataLevel));
             }
         }
 
@@ -121,8 +126,11 @@ namespace DelvUI.Interface.Jobs
                 return;
             };
 
-            BarUtilities.GetChunkedBars(Config.AetherflowBar, 3, stackCount, 3, 0, player)
-                .Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.AetherflowBar, 3, stackCount, 3, 0, player);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.AetherflowBar.StrataLevel));
+            }
         }
 
         private void DrawSacredSoilBar(Vector2 origin, PlayerCharacter player)
@@ -132,8 +140,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.SacredSoilBar.HideWhenInactive || sacredSoilDuration > 0)
             {
                 Config.SacredSoilBar.Label.SetValue(sacredSoilDuration);
-                BarUtilities.GetProgressBar(Config.SacredSoilBar, sacredSoilDuration, 15f, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.SacredSoilBar, sacredSoilDuration, 15f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.SacredSoilBar.StrataLevel));
             }
         }
     }

--- a/DelvUI/Interface/Jobs/SummonerHud.cs
+++ b/DelvUI/Interface/Jobs/SummonerHud.cs
@@ -106,8 +106,11 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.IfritBar.HideWhenInactive || stackCount > 1)
             {
-                BarUtilities.GetChunkedBars(Config.IfritBar, 1, stackCount, 1, 0, player)
-                    .Draw(origin);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.IfritBar, 1, stackCount, 1, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.IfritBar.StrataLevel));
+                }
             }
         }
 
@@ -118,8 +121,11 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.TitanBar.HideWhenInactive || stackCount > 1)
             {
-                BarUtilities.GetChunkedBars(Config.TitanBar, 1, stackCount, 1, 0, player)
-                    .Draw(origin);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.TitanBar, 1, stackCount, 1, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.TitanBar.StrataLevel));
+                }
             }
         }
 
@@ -130,8 +136,11 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.GarudaBar.HideWhenInactive || stackCount > 1)
             {
-                BarUtilities.GetChunkedBars(Config.GarudaBar, 1, stackCount, 1, 0, player)
-                    .Draw(origin);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.GarudaBar, 1, stackCount, 1, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.GarudaBar.StrataLevel));
+                }
             }
         }
 
@@ -167,8 +176,11 @@ namespace DelvUI.Interface.Jobs
                 return;
             }
 
-            BarUtilities.GetChunkedBars(Config.AetherflowBar, 2, stackCount, 2, 0, player)
-                .Draw(origin);
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.AetherflowBar, 2, stackCount, 2, 0, player);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.AetherflowBar.StrataLevel));
+            }
         }
 
         private void DrawTranceBar(Vector2 origin, PlayerCharacter player)
@@ -211,9 +223,11 @@ namespace DelvUI.Interface.Jobs
                 {
                     return;
                 }
+
                 Config.TranceBar.Label.SetValue(tranceDuration / 1000f);
-                BarUtilities.GetProgressBar(Config.TranceBar, tranceDuration / 1000f, maxDuration, 0, player, tranceColor).
-                    Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.TranceBar, tranceDuration / 1000f, maxDuration, 0, player, tranceColor);
+                AddDrawActions(bar.GetDrawActions(origin, Config.TranceBar.StrataLevel));
             }
             else
             {
@@ -231,8 +245,8 @@ namespace DelvUI.Interface.Jobs
                             Config.TranceBar.Label.SetText("READY");
                         }
 
-                        BarUtilities.GetProgressBar(Config.TranceBar, currentCooldown, maxDuration, 0, player, tranceColor)
-                            .Draw(origin);
+                        BarHud bar = BarUtilities.GetProgressBar(Config.TranceBar, currentCooldown, maxDuration, 0, player, tranceColor);
+                        AddDrawActions(bar.GetDrawActions(origin, Config.TranceBar.StrataLevel));
                     }
                 }
             }
@@ -243,8 +257,12 @@ namespace DelvUI.Interface.Jobs
             SummonerStacksBarConfig config = Config.StacksBar;
 
             config.FillColor = stackColor;
-            BarUtilities.GetChunkedBars(Config.StacksBar, max, amount, max, 0f, player, glowConfig: glowConfig).
-                         Draw(origin);
+
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.StacksBar, max, amount, max, 0f, player, glowConfig: glowConfig);
+            foreach (BarHud bar in bars)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.StacksBar.StrataLevel));
+            }
         }
     }
 

--- a/DelvUI/Interface/Jobs/WarriorHud.cs
+++ b/DelvUI/Interface/Jobs/WarriorHud.cs
@@ -73,8 +73,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.SurgingTempestBar.HideWhenInactive || surgingTempestDuration > 0)
             {
                 Config.SurgingTempestBar.Label.SetValue(surgingTempestDuration);
-                BarUtilities.GetProgressBar(Config.SurgingTempestBar, surgingTempestDuration, 60f, 0, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.SurgingTempestBar, surgingTempestDuration, 60f, 0, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.SurgingTempestBar.StrataLevel));
             }
         }
 
@@ -88,8 +89,11 @@ namespace DelvUI.Interface.Jobs
                 Config.BeastGauge.Label.SetValue(gauge.BeastGauge);
 
                 var color = nascentChaosDuration == 0 ? Config.BeastGauge.BeastGaugeColor : Config.BeastGauge.NascentChaosColor;
-                BarUtilities.GetChunkedProgressBars(Config.BeastGauge, 2, gauge.BeastGauge, 100, 0, player, fillColor: color)
-                    .Draw(origin);
+                BarHud[] bars = BarUtilities.GetChunkedProgressBars(Config.BeastGauge, 2, gauge.BeastGauge, 100, 0, player, fillColor: color);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.BeastGauge.StrataLevel));
+                }
             }
         }
 
@@ -123,7 +127,7 @@ namespace DelvUI.Interface.Jobs
                 {
                     if (!Config.InnerReleaseBar.HideWhenInactive)
                     {
-                        BarUtilities.GetChunkedProgressBars(
+                        BarHud[] bars = BarUtilities.GetChunkedProgressBars(
                             Config.InnerReleaseBar,
                             1,
                             1,
@@ -132,13 +136,18 @@ namespace DelvUI.Interface.Jobs
                             player,
                             fillColor: Config.InnerReleaseBar.CooldownFinishedColor,
                             glowConfig: primalRendGlow,
-                            chunksToGlow: new[] { true })
-                            .Draw(origin);
+                            chunksToGlow: new[] { true }
+                        );
+
+                        foreach (BarHud bar in bars)
+                        {
+                            AddDrawActions(bar.GetDrawActions(origin, Config.InnerReleaseBar.StrataLevel));
+                        }
                     }
                 }
                 else
                 {
-                    BarUtilities.GetChunkedProgressBars(
+                    BarHud[] bars = BarUtilities.GetChunkedProgressBars(
                         Config.InnerReleaseBar,
                         1,
                         currentCooldown,
@@ -147,8 +156,13 @@ namespace DelvUI.Interface.Jobs
                         player,
                         fillColor: Config.InnerReleaseBar.CooldownInProgressColor,
                         glowConfig: primalRendGlow,
-                        chunksToGlow: new[] { true })
-                        .Draw(origin);
+                        chunksToGlow: new[] { true }
+                    );
+
+                    foreach (BarHud bar in bars)
+                    {
+                        AddDrawActions(bar.GetDrawActions(origin, Config.InnerReleaseBar.StrataLevel));
+                    }
                 }
 
                 return;
@@ -168,7 +182,7 @@ namespace DelvUI.Interface.Jobs
                     innerReleaseDuration = Math.Min(innerReleaseDuration, innerReleaseMaxDuration);
                 }
 
-                BarUtilities.GetChunkedProgressBars(
+                BarHud[] bars = BarUtilities.GetChunkedProgressBars(
                     Config.InnerReleaseBar,
                     3,
                     (innerReleaseStacks - 1) * innerReleaseMaxDuration + innerReleaseDuration,
@@ -176,8 +190,13 @@ namespace DelvUI.Interface.Jobs
                     0,
                     player,
                     primalRendGlow,
-                    chunksToGlow: new[] { true, true, true })
-                    .Draw(origin);
+                    chunksToGlow: new[] { true, true, true }
+                );
+
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.InnerReleaseBar.StrataLevel));
+                }
             }
         }
     }

--- a/DelvUI/Interface/Jobs/WhiteMageHud.cs
+++ b/DelvUI/Interface/Jobs/WhiteMageHud.cs
@@ -106,8 +106,11 @@ namespace DelvUI.Interface.Jobs
         {
             var target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
 
-            BarUtilities.GetDoTBar(Config.DiaBar, player, target, DiaIDs, DiaDurations)?.
-                Draw(origin);
+            BarHud? bar = BarUtilities.GetDoTBar(Config.DiaBar, player, target, DiaIDs, DiaDurations);
+            if (bar != null)
+            {
+                AddDrawActions(bar.GetDrawActions(origin, Config.DiaBar.StrataLevel));
+            }
         }
 
         private void DrawLilyBar(Vector2 origin, PlayerCharacter player)
@@ -121,14 +124,20 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.LilyBar.HideWhenInactive || lilyScale > 0)
             {
-                BarUtilities.GetChunkedBars(Config.LilyBar, 3, lilyScale, 3, 0, player)
-                    .Draw(origin);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.LilyBar, 3, lilyScale, 3, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.LilyBar.StrataLevel));
+                }
             }
 
             if (!Config.BloodLilyBar.HideWhenInactive && Config.BloodLilyBar.Enabled || gauge.BloodLily > 0)
             {
-                BarUtilities.GetChunkedBars(Config.BloodLilyBar, 3, gauge.BloodLily, 3, 0, player)
-                    .Draw(origin);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.BloodLilyBar, 3, gauge.BloodLily, 3, 0, player);
+                foreach (BarHud bar in bars)
+                {
+                    AddDrawActions(bar.GetDrawActions(origin, Config.BloodLilyBar.StrataLevel));
+                }
             }
         }
 
@@ -139,8 +148,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.AsylumBar.HideWhenInactive || asylymDuration > 0)
             {
                 Config.AsylumBar.Label.SetValue(asylymDuration);
-                BarUtilities.GetProgressBar(Config.AsylumBar, asylymDuration, 24f, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.AsylumBar, asylymDuration, 24f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.AsylumBar.StrataLevel));
             }
         }
 
@@ -151,8 +161,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.PresenceOfMindBar.HideWhenInactive || presenceOfMindDuration > 0)
             {
                 Config.PresenceOfMindBar.Label.SetValue(presenceOfMindDuration);
-                BarUtilities.GetProgressBar(Config.PresenceOfMindBar, presenceOfMindDuration, 15f, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.PresenceOfMindBar, presenceOfMindDuration, 15f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.PresenceOfMindBar.StrataLevel));
             }
         }
 
@@ -163,8 +174,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.PlenaryBar.HideWhenInactive || plenaryDuration > 0)
             {
                 Config.PlenaryBar.Label.SetValue(plenaryDuration);
-                BarUtilities.GetProgressBar(Config.PlenaryBar, plenaryDuration, 10f, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.PlenaryBar, plenaryDuration, 10f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.PlenaryBar.StrataLevel));
             }
         }
 
@@ -175,8 +187,9 @@ namespace DelvUI.Interface.Jobs
             if (!Config.TemperanceBar.HideWhenInactive || temperanceDuration > 0)
             {
                 Config.TemperanceBar.Label.SetValue(temperanceDuration);
-                BarUtilities.GetProgressBar(Config.TemperanceBar, temperanceDuration, 20f, 0f, player)
-                    .Draw(origin);
+
+                BarHud bar = BarUtilities.GetProgressBar(Config.TemperanceBar, temperanceDuration, 20f, 0f, player);
+                AddDrawActions(bar.GetDrawActions(origin, Config.TemperanceBar.StrataLevel));
             }
         }
     }

--- a/DelvUI/Interface/Party/PartyFramesConfig.cs
+++ b/DelvUI/Interface/Party/PartyFramesConfig.cs
@@ -13,7 +13,6 @@ using System.Numerics;
 namespace DelvUI.Interface.Party
 {
     [Exportable(false)]
-    [DisableParentSettings("Position")]
     [Section("Party Frames", true)]
     [SubSection("General", 0)]
     public class PartyFramesConfig : MovablePluginConfigObject
@@ -21,16 +20,22 @@ namespace DelvUI.Interface.Party
         public new static PartyFramesConfig DefaultConfig()
         {
             var config = new PartyFramesConfig();
-            config.Position = new Vector2(-ImGui.GetMainViewport().Size.X / 3 - config.Size.X / 2, -config.Size.Y / 2);
+            config.Position = new Vector2(-ImGui.GetMainViewport().Size.X / 3 - 180, -120);
 
             return config;
         }
 
-        public Vector2 Size = new Vector2(380, 340);
-
         [Checkbox("Preview", isMonitored = true)]
         [Order(4)]
         public bool Preview = false;
+
+        [DragInt("Rows", spacing = true, isMonitored = true, min = 1, max = 8, velocity = 0.2f)]
+        [Order(10)]
+        public int Rows = 4;
+
+        [DragInt("Columns", isMonitored = true, min = 1, max = 8, velocity = 0.2f)]
+        [Order(11)]
+        public int Columns = 2;
 
         [Anchor("Bars Anchor", isMonitored = true, spacing = true)]
         [Order(15)]

--- a/DelvUI/Interface/Party/PartyFramesConfig.cs
+++ b/DelvUI/Interface/Party/PartyFramesConfig.cs
@@ -701,7 +701,7 @@ namespace DelvUI.Interface.Party
         }
     }
 
-    [DisableParentSettings("Position")]
+    [DisableParentSettings("Position", "Strata")]
     [Exportable(false)]
     public class PartyFramesCleanseTrackerConfig : MovablePluginConfigObject
     {

--- a/DelvUI/Interface/Party/PartyFramesHud.cs
+++ b/DelvUI/Interface/Party/PartyFramesHud.cs
@@ -394,14 +394,6 @@ namespace DelvUI.Interface.Party
                 }
             };
 
-            Action drawElementsAction = () =>
-            {
-                foreach (PartyFramesBar bar in bars)
-                {
-                    AddDrawActions(bar.GetElementsDrawActions(origin));
-                }
-            };
-
             AddDrawAction(Config.StrataLevel, () =>
             {
                 ImGui.PushStyleColor(ImGuiCol.Border, 0x66FFFFFF);
@@ -415,7 +407,10 @@ namespace DelvUI.Interface.Party
                 ImGui.PopStyleVar(2);
             });
 
-            drawElementsAction();
+            foreach (PartyFramesBar bar in bars)
+            {
+                AddDrawActions(bar.GetElementsDrawActions(origin));
+            }
         }
     }
 

--- a/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
@@ -221,10 +221,11 @@ namespace DelvUI.Interface.PartyCooldowns
                     }
 
                     string? name = character == null ? "Fake Name" : null;
+                    Vector2 labelPos = origin + pos;
 
                     AddDrawAction(_barConfig.NameLabel.StrataLevel, () =>
                     {
-                        _nameLabelHud.Draw(origin + pos, size, character, name);
+                        _nameLabelHud.Draw(labelPos, size, character, name);
                     });
 
                     // time
@@ -243,7 +244,7 @@ namespace DelvUI.Interface.PartyCooldowns
 
                     AddDrawAction(_barConfig.TimeLabel.StrataLevel, () =>
                     {
-                        _timeLabelHud.Draw(origin + pos, size, character);
+                        _timeLabelHud.Draw(labelPos, size, character);
                     });
 
                     // tooltip

--- a/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
@@ -179,7 +179,8 @@ namespace DelvUI.Interface.PartyCooldowns
 
                         bar.SetBackground(background);
                         bar.AddForegrounds(fill);
-                        bar.Draw(origin);
+
+                        AddDrawActions(bar.GetDrawActions(origin, _barConfig.StrataLevel));
                     }
 
                     // icon
@@ -189,23 +190,26 @@ namespace DelvUI.Interface.PartyCooldowns
                         Vector2 iconSize = new Vector2(size.Y);
                         bool recharging = effectTime == 0 && cooldownTime > 0;
 
-                        DrawHelper.DrawInWindow(barId + "_icon", iconPos, iconSize, false, false, (drawList) =>
+                        AddDrawAction(_barConfig.StrataLevel, () =>
                         {
-                            uint color = recharging ? 0xAAFFFFFF : 0xFFFFFFFF;
-                            DrawHelper.DrawIcon(cooldown.Data.IconId, iconPos, iconSize, false, color, drawList);
-
-                            if (_barConfig.ShowIconCooldownAnimation && effectTime == 0 && cooldownTime > 0)
+                            DrawHelper.DrawInWindow(barId + "_icon", iconPos, iconSize, false, false, (drawList) =>
                             {
-                                DrawHelper.DrawIconCooldown(iconPos, iconSize, cooldownTime, cooldown.Data.CooldownDuration, drawList);
-                            }
+                                uint color = recharging ? 0xAAFFFFFF : 0xFFFFFFFF;
+                                DrawHelper.DrawIcon(cooldown.Data.IconId, iconPos, iconSize, false, color, drawList);
 
-                            if (_barConfig.DrawBorder)
-                            {
-                                bool active = effectTime > 0 && _barConfig.ChangeIconBorderWhenActive;
-                                uint iconBorderColor = active ? _barConfig.IconActiveBorderColor.Base : _barConfig.BorderColor.Base;
-                                int thickness = active ? _barConfig.IconActiveBorderThickness : _barConfig.BorderThickness;
-                                drawList.AddRect(iconPos, iconPos + iconSize, iconBorderColor, 0, ImDrawFlags.None, thickness);
-                            }
+                                if (_barConfig.ShowIconCooldownAnimation && effectTime == 0 && cooldownTime > 0)
+                                {
+                                    DrawHelper.DrawIconCooldown(iconPos, iconSize, cooldownTime, cooldown.Data.CooldownDuration, drawList);
+                                }
+
+                                if (_barConfig.DrawBorder)
+                                {
+                                    bool active = effectTime > 0 && _barConfig.ChangeIconBorderWhenActive;
+                                    uint iconBorderColor = active ? _barConfig.IconActiveBorderColor.Base : _barConfig.BorderColor.Base;
+                                    int thickness = active ? _barConfig.IconActiveBorderThickness : _barConfig.BorderThickness;
+                                    drawList.AddRect(iconPos, iconPos + iconSize, iconBorderColor, 0, ImDrawFlags.None, thickness);
+                                }
+                            });
                         });
                     }
 
@@ -217,7 +221,11 @@ namespace DelvUI.Interface.PartyCooldowns
                     }
 
                     string? name = character == null ? "Fake Name" : null;
-                    _nameLabelHud.Draw(origin + pos, size, character, name);
+
+                    AddDrawAction(_barConfig.NameLabel.StrataLevel, () =>
+                    {
+                        _nameLabelHud.Draw(origin + pos, size, character, name);
+                    });
 
                     // time
                     if (effectTime > 0)
@@ -232,7 +240,11 @@ namespace DelvUI.Interface.PartyCooldowns
                     {
                         _barConfig.TimeLabel.SetText("");
                     }
-                    _timeLabelHud.Draw(origin + pos, size, character);
+
+                    AddDrawAction(_barConfig.TimeLabel.StrataLevel, () =>
+                    {
+                        _timeLabelHud.Draw(origin + pos, size, character);
+                    });
 
                     // tooltip
                     pos = origin + new Vector2(Config.Position.X + offsetX, y);

--- a/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
@@ -220,30 +220,29 @@ namespace DelvUI.Interface.PartyCooldowns
                         character = player;
                     }
 
-                    string? name = character == null ? "Fake Name" : null;
                     Vector2 labelPos = origin + pos;
-
                     AddDrawAction(_barConfig.NameLabel.StrataLevel, () =>
                     {
+                        string? name = character == null ? "Fake Name" : null;
                         _nameLabelHud.Draw(labelPos, size, character, name);
                     });
 
                     // time
-                    if (effectTime > 0)
-                    {
-                        _barConfig.TimeLabel.SetValue(effectTime);
-                    }
-                    else if (cooldownTime > 0)
-                    {
-                        _barConfig.TimeLabel.SetText(Utils.DurationToFullString(cooldownTime));
-                    }
-                    else
-                    {
-                        _barConfig.TimeLabel.SetText("");
-                    }
-
                     AddDrawAction(_barConfig.TimeLabel.StrataLevel, () =>
                     {
+                        if (effectTime > 0)
+                        {
+                            _barConfig.TimeLabel.SetValue(effectTime);
+                        }
+                        else if (cooldownTime > 0)
+                        {
+                            _barConfig.TimeLabel.SetText(Utils.DurationToFullString(cooldownTime));
+                        }
+                        else
+                        {
+                            _barConfig.TimeLabel.SetText("");
+                        }
+
                         _timeLabelHud.Draw(labelPos, size, character);
                     });
 

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -244,6 +244,8 @@ namespace DelvUI.Interface.StatusEffects
             SetGrowthDirections(growthDirections);
 
             IconConfig = iconConfig;
+
+            Strata = StrataLevel.HIGH;
         }
 
         private void SetGrowthDirections(GrowthDirections growthDirections)

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -393,11 +393,10 @@ namespace DelvUI.Interface.StatusEffects
                     !statusEffectData.Data.IsPermanent &&
                     !statusEffectData.Data.IsFcBuff)
                 {
-                    var duration = Math.Round(Math.Abs(statusEffectData.Status.RemainingTime));
-                    Config.IconConfig.DurationLabelConfig.SetText(Utils.DurationToString(duration));
-
                     AddDrawAction(Config.IconConfig.DurationLabelConfig.StrataLevel, () =>
                     {
+                        double duration = Math.Round(Math.Abs(statusEffectData.Status.RemainingTime));
+                        Config.IconConfig.DurationLabelConfig.SetText(Utils.DurationToString(duration));
                         _durationLabel.Draw(iconPos, Config.IconConfig.Size);
                     });
                 }
@@ -408,11 +407,9 @@ namespace DelvUI.Interface.StatusEffects
                     statusEffectData.Status.StackCount > 0 &&
                     !statusEffectData.Data.IsFcBuff)
                 {
-                    var text = $"{statusEffectData.Status.StackCount}";
-                    Config.IconConfig.StacksLabelConfig.SetText(text);
-
                     AddDrawAction(Config.IconConfig.StacksLabelConfig.StrataLevel, () =>
                     {
+                        Config.IconConfig.StacksLabelConfig.SetText($"{statusEffectData.Status.StackCount}");
                         _stacksLabel.Draw(iconPos, Config.IconConfig.Size);
                     });
                 }

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -339,44 +339,47 @@ namespace DelvUI.Interface.StatusEffects
             var windowPos = minPos - margin;
             var windowSize = maxPos - minPos;
 
-            DrawHelper.DrawInWindow(ID, windowPos, windowSize + margin * 2, true, false, (drawList) =>
+            AddDrawAction(Config.StrataLevel, () =>
             {
-                // area
-                if (Config.Preview)
+                DrawHelper.DrawInWindow(ID, windowPos, windowSize + margin * 2, true, false, (drawList) =>
                 {
-                    drawList.AddRectFilled(areaPos, areaPos + Config.Size, 0x88000000);
-                }
-
-                for (var i = 0; i < count; i++)
-                {
-                    var iconPos = iconPositions[i];
-                    var statusEffectData = list[i];
-
-                    // icon
-                    var cropIcon = Config.IconConfig.CropIcon;
-                    int stackCount = cropIcon ? 1 : statusEffectData.Data.MaxStacks > 0 ? statusEffectData.Status.StackCount : 0;
-                    DrawHelper.DrawIcon<LuminaStatus>(drawList, statusEffectData.Data, iconPos, Config.IconConfig.Size, false, cropIcon, stackCount);
-
-                    // border
-                    var borderConfig = GetBorderConfig(statusEffectData);
-                    if (borderConfig != null && cropIcon)
+                    // area
+                    if (Config.Preview)
                     {
-                        drawList.AddRect(iconPos, iconPos + Config.IconConfig.Size, borderConfig.Color.Base, 0, ImDrawFlags.None, borderConfig.Thickness);
+                        drawList.AddRectFilled(areaPos, areaPos + Config.Size, 0x88000000);
                     }
 
-                    // Draw dispell indicator above dispellable status effect on uncropped icons
-                    if (borderConfig != null && !cropIcon && statusEffectData.Data.CanDispel)
+                    for (var i = 0; i < count; i++)
                     {
-                        var dispellIndicatorColor = new Vector4(141f / 255f, 206f / 255f, 229f / 255f, 100f / 100f);
-                        // 24x32
-                        drawList.AddRectFilled(
-                            iconPos + new Vector2(Config.IconConfig.Size.X * .07f, Config.IconConfig.Size.Y * .07f),
-                            iconPos + new Vector2(Config.IconConfig.Size.X * .93f, Config.IconConfig.Size.Y * .14f),
-                            ImGui.ColorConvertFloat4ToU32(dispellIndicatorColor),
-                            8f
-                        );
+                        var iconPos = iconPositions[i];
+                        var statusEffectData = list[i];
+
+                        // icon
+                        var cropIcon = Config.IconConfig.CropIcon;
+                        int stackCount = cropIcon ? 1 : statusEffectData.Data.MaxStacks > 0 ? statusEffectData.Status.StackCount : 0;
+                        DrawHelper.DrawIcon<LuminaStatus>(drawList, statusEffectData.Data, iconPos, Config.IconConfig.Size, false, cropIcon, stackCount);
+
+                        // border
+                        var borderConfig = GetBorderConfig(statusEffectData);
+                        if (borderConfig != null && cropIcon)
+                        {
+                            drawList.AddRect(iconPos, iconPos + Config.IconConfig.Size, borderConfig.Color.Base, 0, ImDrawFlags.None, borderConfig.Thickness);
+                        }
+
+                        // Draw dispell indicator above dispellable status effect on uncropped icons
+                        if (borderConfig != null && !cropIcon && statusEffectData.Data.CanDispel)
+                        {
+                            var dispellIndicatorColor = new Vector4(141f / 255f, 206f / 255f, 229f / 255f, 100f / 100f);
+                            // 24x32
+                            drawList.AddRectFilled(
+                                    iconPos + new Vector2(Config.IconConfig.Size.X * .07f, Config.IconConfig.Size.Y * .07f),
+                                    iconPos + new Vector2(Config.IconConfig.Size.X * .93f, Config.IconConfig.Size.Y * .14f),
+                                    ImGui.ColorConvertFloat4ToU32(dispellIndicatorColor),
+                                    8f
+                                );
+                        }
                     }
-                }
+                });
             });
 
             // labels need to be drawn separated since they have their own window for clipping
@@ -393,7 +396,10 @@ namespace DelvUI.Interface.StatusEffects
                     var duration = Math.Round(Math.Abs(statusEffectData.Status.RemainingTime));
                     Config.IconConfig.DurationLabelConfig.SetText(Utils.DurationToString(duration));
 
-                    _durationLabel.Draw(iconPos, Config.IconConfig.Size);
+                    AddDrawAction(Config.IconConfig.DurationLabelConfig.StrataLevel, () =>
+                    {
+                        _durationLabel.Draw(iconPos, Config.IconConfig.Size);
+                    });
                 }
 
                 // stacks
@@ -405,7 +411,10 @@ namespace DelvUI.Interface.StatusEffects
                     var text = $"{statusEffectData.Status.StackCount}";
                     Config.IconConfig.StacksLabelConfig.SetText(text);
 
-                    _stacksLabel.Draw(iconPos, Config.IconConfig.Size);
+                    AddDrawAction(Config.IconConfig.StacksLabelConfig.StrataLevel, () =>
+                    {
+                        _stacksLabel.Draw(iconPos, Config.IconConfig.Size);
+                    });
                 }
 
                 // tooltips / interaction

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -98,7 +98,7 @@ namespace DelvUI
                 AssemblyLocation = Assembly.GetExecutingAssembly().Location;
             }
 
-            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.6.1.3";
+            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.6.2.0";
 
             FontsManager.Initialize(AssemblyLocation);
             LoadBanner();

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,10 +1,14 @@
 # 0.6.2.0
 Features:
+- Party Frames layout is now configured with the new Rows and Column settings:
+    + Party Frames are not longer draggable / resizable when the config window is opened.
+    + This is a breaking change in the config. When updating, the Party Frames will likely be in a bad position and with an incorrect layout. Use the Position, Rows and Columns settings to correct it. The actual elements inside the frames should remain exactly the same as before the update.
 - Added Strata Level settings to most UI elements (these allow the user to choose which elements are drawn on top of others).
 - Added Thresholds for Bard Songs with the recommended song rotation (43, 34, 43).  
 
 Fixes:
 - Fixed Dancer Proc Bars so they can be individually disabled.
+- Fixed Reaper and Sage not appearing in Party Frames on preview mode.
 
 # 0.6.1.2
 Features:

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,5 +1,6 @@
-# 0.6.1.3
+# 0.6.2.0
 Features:
+- Added Strata Level settings to most UI elements (these allow the user to choose which elements are drawn on top of others).
 - Added Thresholds for Bard Songs with the recommended song rotation (43, 34, 43).  
 
 Fixes:


### PR DESCRIPTION
* StrataLevels is a property of MovablePluginConfigObject
* HUDManager manages the first "layer" of strata levels by having an ordered array of the base UI elements sorted by strata level
* Each HUDElement has a second "layer" of strata levels by having ordered arrays of its sub elements sorted organized by strata level
* Party Frames were giving me a lot of issues. I removed the "party frames are unlocked, draggable and resizable when config window is opened" system. It caused many issues even before this implementation. The Position, Rows and Columns settings can be used instead to define the layout of the Party Frames.

Note: Party Frames still need to be ported to BarHud. Will probably do that in another PR for that once this gets merged.