### PR TITLE
"Current Casttime / Max Casttime" for castbar labels

### DIFF
--- a/DelvUI/Extensions.cs
+++ b/DelvUI/Extensions.cs
@@ -132,5 +132,8 @@ namespace DelvUI
 
             return str;
         }
+
+        public static string Repeat(this string s, int n)
+            => new StringBuilder(s.Length * n).Insert(0, s, n).ToString();
     }
 }

--- a/DelvUI/Interface/GeneralElements/CastbarConfig.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarConfig.cs
@@ -176,15 +176,19 @@ namespace DelvUI.Interface.GeneralElements
         [Order(4)]
         public bool ShowIcon = true;
 
+        [Checkbox("Reverse Fill Background Color")]
+        [Order(5)]
+        public bool UseReverseFill = false;
+
+        [Checkbox("Show Current Cast Time + Max Cast Time")]
+        [Order(6)]
+        public bool ShowMaxCastTime = false;
+
         [NestedConfig("Cast Name", 500)]
         public LabelConfig CastNameLabel;
 
         [NestedConfig("Cast Time", 505)]
         public NumericLabelConfig CastTimeLabel;
-
-        [Checkbox("Reverse Fill Background Color", spacing = true)]
-        [Order(510)]
-        public bool UseReverseFill = false;
 
         [ColorEdit4("Color" + "##ReverseFill")]
         [Order(515, collapseWith = nameof(UseReverseFill))]

--- a/DelvUI/Interface/GeneralElements/CastbarHud.cs
+++ b/DelvUI/Interface/GeneralElements/CastbarHud.cs
@@ -8,7 +8,9 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Numerics;
+using System.Text;
 
 namespace DelvUI.Interface.GeneralElements
 {
@@ -122,7 +124,17 @@ namespace DelvUI.Interface.GeneralElements
             bool isTimeLeftAnchored = Config.CastTimeLabel.TextAnchor is DrawAnchor.Left or DrawAnchor.TopLeft or DrawAnchor.BottomLeft;
             Vector2 timePos = Config.ShowIcon && isTimeLeftAnchored ? startPos + new Vector2(iconSize.X, 0) : startPos;
             float value = Config.Preview ? 0.5f : totalCastTime - currentCastTime;
-            Config.CastTimeLabel.SetValue(value);
+
+            if (Config.ShowMaxCastTime)
+            {
+                string format = "0".Repeat(Config.CastTimeLabel.NumberFormat);
+                Config.CastTimeLabel.SetText(value.ToString($"####0.{format}", CultureInfo.InvariantCulture)
+                    + " / " + totalCastTime.ToString($"####0.{format}", CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                Config.CastTimeLabel.SetValue(value);
+            }
 
             AddDrawAction(Config.CastTimeLabel.StrataLevel, () =>
             {

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,11 @@
+# 0.6.3.1
+Features:
+- Added option to show Total Casttime on top of Current Casttime for Castbars.
+
+Fixes:
+- Fixed positioning of the label on Dark Knight's Delirium Bar.
+- Fixed positioning of the label on Warrior's Inner Release Bar.
+
 # 0.6.3.0
 Features:
 - Added setting to Status Effects Lists to disable mouse interactions.


### PR DESCRIPTION
Added option to show "Current Casttime / Max Casttime" on Cast Time Label instead of just Current Casttime