### PR TITLE
Job role background color for party/unitframes

### DIFF
--- a/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
@@ -168,6 +168,14 @@ namespace DelvUI.Interface.GeneralElements
         [Order(55)]
         public bool UseMissingHealthBar = false;
 
+        [Checkbox("Job Color As Missing Health Color")]
+        [Order(56, collapseWith = nameof(UseMissingHealthBar))]
+        public bool UseJobColorAsMissingHealthColor = false;
+
+        [Checkbox("Role Color As Missing Health Color")]
+        [Order(57, collapseWith = nameof(UseMissingHealthBar))]
+        public bool UseRoleColorAsMissingHealthColor = false;
+
         [ColorEdit4("Color" + "##MissingHealth")]
         [Order(60, collapseWith = nameof(UseMissingHealthBar))]
         public PluginConfigColor HealthMissingColor = new PluginConfigColor(new Vector4(255f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));

--- a/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
@@ -160,6 +160,10 @@ namespace DelvUI.Interface.GeneralElements
         [Order(50)]
         public bool UseJobColorAsBackgroundColor = false;
 
+        [Checkbox("Role Color As Background Color")]
+        [Order(51)]
+        public bool UseRoleColorAsBackgroundColor = false;
+
         [Checkbox("Missing Health Color")]
         [Order(55)]
         public bool UseMissingHealthBar = false;

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -139,7 +139,13 @@ namespace DelvUI.Interface.GeneralElements
                     ? Config.Position
                     : Config.Position + BarUtilities.GetFillDirectionOffset(healthFill.Size, Config.FillDirection);
 
-                PluginConfigColor missingHealthColor = Config.HealthMissingColor;
+                //PluginConfigColor missingHealthColor = Config.HealthMissingColor;
+                PluginConfigColor missingHealthColor = Config.UseJobColorAsMissingHealthColor
+                    ? GlobalColors.Instance.SafeColorForJobId(character!.ClassJob.Id)
+                    : Config.UseRoleColorAsMissingHealthColor
+                        ? GlobalColors.Instance.SafeRoleColorForJobId(character!.ClassJob.Id)
+                        : Config.HealthMissingColor;
+
                 if (Config.UseCustomInvulnerabilityColor && character is BattleChara battleChara)
                 {
                     Status? tankInvuln = Utils.GetTankInvulnerabilityID(battleChara);

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -315,6 +315,10 @@ namespace DelvUI.Interface.GeneralElements
                 {
                     return GlobalColors.Instance.SafeColorForJobId(chara.ClassJob.Id);
                 }
+                else if (Config.UseRoleColorAsBackgroundColor)
+                {
+                    return GlobalColors.Instance.SafeRoleColorForJobId(chara.ClassJob.Id);
+                }
                 else if (Config.UseDeathIndicatorBackgroundColor && chara.CurrentHp <= 0)
                 {
                     return Config.DeathIndicatorBackgroundColor;

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -138,8 +138,7 @@ namespace DelvUI.Interface.GeneralElements
                 Vector2 healthMissingPos = Config.FillDirection.IsInverted()
                     ? Config.Position
                     : Config.Position + BarUtilities.GetFillDirectionOffset(healthFill.Size, Config.FillDirection);
-
-                //PluginConfigColor missingHealthColor = Config.HealthMissingColor;
+                
                 PluginConfigColor missingHealthColor = Config.UseJobColorAsMissingHealthColor
                     ? GlobalColors.Instance.SafeColorForJobId(character!.ClassJob.Id)
                     : Config.UseRoleColorAsMissingHealthColor

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -138,7 +138,7 @@ namespace DelvUI.Interface.GeneralElements
                 Vector2 healthMissingPos = Config.FillDirection.IsInverted()
                     ? Config.Position
                     : Config.Position + BarUtilities.GetFillDirectionOffset(healthFill.Size, Config.FillDirection);
-                
+
                 PluginConfigColor missingHealthColor = Config.UseJobColorAsMissingHealthColor
                     ? GlobalColors.Instance.SafeColorForJobId(character!.ClassJob.Id)
                     : Config.UseRoleColorAsMissingHealthColor

--- a/DelvUI/Interface/Party/PartyFramesBar.cs
+++ b/DelvUI/Interface/Party/PartyFramesBar.cs
@@ -226,11 +226,11 @@ namespace DelvUI.Interface.Party
             // missing health
             if (_configs.HealthBar.ColorsConfig.UseMissingHealthBar)
             {
-                
+
 
                 Vector2 healthMissingSize = _configs.HealthBar.Size - BarUtilities.GetFillDirectionOffset(healthFill.Size, _configs.HealthBar.FillDirection);
                 Vector2 healthMissingPos = _configs.HealthBar.FillDirection.IsInverted() ? Position : Position + BarUtilities.GetFillDirectionOffset(healthFill.Size, _configs.HealthBar.FillDirection);
-                
+
                 PluginConfigColor? missingHealthColor = _configs.HealthBar.ColorsConfig.UseJobColorAsMissingHealthColor
                     ? GlobalColors.Instance.SafeColorForJobId(character!.ClassJob.Id)
                     : _configs.HealthBar.ColorsConfig.UseRoleColorAsMissingHealthColor

--- a/DelvUI/Interface/Party/PartyFramesBar.cs
+++ b/DelvUI/Interface/Party/PartyFramesBar.cs
@@ -11,6 +11,7 @@ using Dalamud.Game.ClientState.Objects.Types;
 using System.Collections.Generic;
 using DelvUI.Enums;
 using DelvUI.Interface.Bars;
+using FFXIVClientStructs.FFXIV.Client.UI;
 
 namespace DelvUI.Interface.Party
 {
@@ -174,6 +175,10 @@ namespace DelvUI.Interface.Party
                 bgColor = _configs.HealthBar.RangeConfig.Enabled
                     ? GetDistanceColor(character, _configs.HealthBar.ColorsConfig.DeathIndicatorBackgroundColor)
                     : _configs.HealthBar.ColorsConfig.DeathIndicatorBackgroundColor;
+            }
+            else if (_configs.HealthBar.ColorsConfig.UseJobColorAsBackgroundColor && character is BattleChara)
+            {
+                bgColor = GlobalColors.Instance.SafeColorForJobId(character.ClassJob.Id);
             }
 
             Rect background = new Rect(Position, _configs.HealthBar.Size, bgColor);

--- a/DelvUI/Interface/Party/PartyFramesBar.cs
+++ b/DelvUI/Interface/Party/PartyFramesBar.cs
@@ -230,8 +230,7 @@ namespace DelvUI.Interface.Party
 
                 Vector2 healthMissingSize = _configs.HealthBar.Size - BarUtilities.GetFillDirectionOffset(healthFill.Size, _configs.HealthBar.FillDirection);
                 Vector2 healthMissingPos = _configs.HealthBar.FillDirection.IsInverted() ? Position : Position + BarUtilities.GetFillDirectionOffset(healthFill.Size, _configs.HealthBar.FillDirection);
-                // PluginConfigColor? missingHealthColor = _configs.HealthBar.ColorsConfig.HealthMissingColor;
-
+                
                 PluginConfigColor? missingHealthColor = _configs.HealthBar.ColorsConfig.UseJobColorAsMissingHealthColor
                     ? GlobalColors.Instance.SafeColorForJobId(character!.ClassJob.Id)
                     : _configs.HealthBar.ColorsConfig.UseRoleColorAsMissingHealthColor

--- a/DelvUI/Interface/Party/PartyFramesBar.cs
+++ b/DelvUI/Interface/Party/PartyFramesBar.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Numerics;
 using Dalamud.Game.ClientState.Objects.Types;
 using System.Collections.Generic;
+using Dalamud.Game.ClientState.Statuses;
 using DelvUI.Enums;
 using DelvUI.Interface.Bars;
 using FFXIVClientStructs.FFXIV.Client.UI;
@@ -225,9 +226,27 @@ namespace DelvUI.Interface.Party
             // missing health
             if (_configs.HealthBar.ColorsConfig.UseMissingHealthBar)
             {
+                
+
                 Vector2 healthMissingSize = _configs.HealthBar.Size - BarUtilities.GetFillDirectionOffset(healthFill.Size, _configs.HealthBar.FillDirection);
                 Vector2 healthMissingPos = _configs.HealthBar.FillDirection.IsInverted() ? Position : Position + BarUtilities.GetFillDirectionOffset(healthFill.Size, _configs.HealthBar.FillDirection);
-                PluginConfigColor? missingHealthColor = _configs.HealthBar.ColorsConfig.HealthMissingColor;
+                // PluginConfigColor? missingHealthColor = _configs.HealthBar.ColorsConfig.HealthMissingColor;
+
+                PluginConfigColor? missingHealthColor = _configs.HealthBar.ColorsConfig.UseJobColorAsMissingHealthColor
+                    ? GlobalColors.Instance.SafeColorForJobId(character!.ClassJob.Id)
+                    : _configs.HealthBar.ColorsConfig.UseRoleColorAsMissingHealthColor
+                        ? GlobalColors.Instance.SafeRoleColorForJobId(character!.ClassJob.Id)
+                        : _configs.HealthBar.ColorsConfig.HealthMissingColor;
+
+                if (_configs.Trackers.Invuln.ChangeBackgroundColorWhenInvuln && character is BattleChara battleChara)
+                {
+                    Status? tankInvuln = Utils.GetTankInvulnerabilityID(battleChara);
+                    if (tankInvuln is not null)
+                    {
+                        missingHealthColor = _configs.Trackers.Invuln.BackgroundColor;
+                    }
+                }
+
                 bar.AddForegrounds(new Rect(healthMissingPos, healthMissingSize, missingHealthColor));
             }
 

--- a/DelvUI/Interface/Party/PartyFramesBar.cs
+++ b/DelvUI/Interface/Party/PartyFramesBar.cs
@@ -180,6 +180,10 @@ namespace DelvUI.Interface.Party
             {
                 bgColor = GlobalColors.Instance.SafeColorForJobId(character.ClassJob.Id);
             }
+            else if (_configs.HealthBar.ColorsConfig.UseRoleColorAsBackgroundColor && character is BattleChara)
+            {
+                bgColor = GlobalColors.Instance.SafeRoleColorForJobId(character.ClassJob.Id);
+            }
 
             Rect background = new Rect(Position, _configs.HealthBar.Size, bgColor);
 

--- a/DelvUI/Interface/Party/PartyFramesConfig.cs
+++ b/DelvUI/Interface/Party/PartyFramesConfig.cs
@@ -193,26 +193,34 @@ namespace DelvUI.Interface.Party
         [ColorEdit4("Highlight Color")]
         [Order(45, collapseWith = nameof(ShowHighlight))]
         public PluginConfigColor HighlightColor = new PluginConfigColor(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 5f / 100f));
-        
-        
+
+
         [Checkbox("Missing Health Color", spacing = true)]
         [Order(46)]
         public bool UseMissingHealthBar = false;
 
-        [ColorEdit4("Color" + "##MissingHealth")]
+        [Checkbox("Job Color As Missing Health Color")]
         [Order(47, collapseWith = nameof(UseMissingHealthBar))]
+        public bool UseJobColorAsMissingHealthColor = false;
+
+        [Checkbox("Role Color As Missing Health Color")]
+        [Order(48, collapseWith = nameof(UseMissingHealthBar))]
+        public bool UseRoleColorAsMissingHealthColor = false;
+
+        [ColorEdit4("Color" + "##MissingHealth")]
+        [Order(49, collapseWith = nameof(UseMissingHealthBar))]
         public PluginConfigColor HealthMissingColor = new(new Vector4(255f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
 
         [Checkbox("Job Color As Background Color")]
-        [Order(48)]
+        [Order(50)]
         public bool UseJobColorAsBackgroundColor = false;
 
         [Checkbox("Role Color As Background Color")]
-        [Order(49)]
+        [Order(51)]
         public bool UseRoleColorAsBackgroundColor = false;
 
         [Checkbox("Show Enmity Border Colors", spacing = true)]
-        [Order(50)]
+        [Order(54)]
         public bool ShowEnmityBorderColors = true;
 
         [ColorEdit4("Enmity Leader Color")]

--- a/DelvUI/Interface/Party/PartyFramesConfig.cs
+++ b/DelvUI/Interface/Party/PartyFramesConfig.cs
@@ -207,6 +207,10 @@ namespace DelvUI.Interface.Party
         [Order(48)]
         public bool UseJobColorAsBackgroundColor = false;
 
+        [Checkbox("Role Color As Background Color")]
+        [Order(49)]
+        public bool UseRoleColorAsBackgroundColor = false;
+
         [Checkbox("Show Enmity Border Colors", spacing = true)]
         [Order(50)]
         public bool ShowEnmityBorderColors = true;

--- a/DelvUI/Interface/Party/PartyFramesConfig.cs
+++ b/DelvUI/Interface/Party/PartyFramesConfig.cs
@@ -193,6 +193,8 @@ namespace DelvUI.Interface.Party
         [ColorEdit4("Highlight Color")]
         [Order(45, collapseWith = nameof(ShowHighlight))]
         public PluginConfigColor HighlightColor = new PluginConfigColor(new Vector4(255f / 255f, 255f / 255f, 255f / 255f, 5f / 100f));
+        
+        
         [Checkbox("Missing Health Color", spacing = true)]
         [Order(46)]
         public bool UseMissingHealthBar = false;
@@ -200,6 +202,10 @@ namespace DelvUI.Interface.Party
         [ColorEdit4("Color" + "##MissingHealth")]
         [Order(47, collapseWith = nameof(UseMissingHealthBar))]
         public PluginConfigColor HealthMissingColor = new(new Vector4(255f / 255f, 0f / 255f, 0f / 255f, 100f / 100f));
+
+        [Checkbox("Job Color As Background Color")]
+        [Order(48)]
+        public bool UseJobColorAsBackgroundColor = false;
 
         [Checkbox("Show Enmity Border Colors", spacing = true)]
         [Order(50)]

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,6 +1,7 @@
 # 0.6.3.1
 Features:
 - Added option to show Total Casttime on top of Current Casttime for Castbars.
+- Added option to use Job Color as Backgroudn Color in party frames.
 
 Fixes:
 - Fixed positioning of the label on Dark Knight's Delirium Bar.

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -2,13 +2,16 @@
 Features:
 - Added option to show Total Casttime on top of Current Casttime for Castbars.
 - Added option to use Job and Role Color as Background Color in Party Frames.
+- Added option to use Job and Role Color as Missing Health Color in Party Frames.
 - Added option to use Role Color as Background Color in Unit Frames.
+- Added option to use Job and Role Color as Missing Health Color in Unit Frames.
 
 Fixes:
 - Fixed positioning of the label on Dark Knight's Delirium Bar.
 - Fixed positioning of the label on Warrior's Inner Release Bar.
 - Spearfishing window will now be drawn on top of DelvUI.
 - Fixed Party Frames not updating properly when resizing the health bars.
+- Fixed Party Frames Tank Invulnerability Background Color when using Missing Health Color.
 
 # 0.6.3.0
 Features:

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,7 +1,8 @@
 # 0.6.3.1
 Features:
 - Added option to show Total Casttime on top of Current Casttime for Castbars.
-- Added option to use Job Color as Backgroudn Color in party frames.
+- Added option to use Job and Role Color as Background Color in Party Frames.
+- Added option to use Role Color as Background Color in Unit Frames.
 
 Fixes:
 - Fixed positioning of the label on Dark Knight's Delirium Bar.


### PR DESCRIPTION
- Added option to use Job and Role Color as Background Color in Party Frames.
- Added option to use Job and Role Color as Missing Health Color in Party Frames.
- Added option to use Role Color as Background Color in Unit Frames.
- Added option to use Job and Role Color as Missing Health Color in Unit Frames.
- Fixed Party Frames Tank Invulnerability Background Color when using Missing Health Color.