### PR TITLE
Fix Change Alpha Based on Range for Missing Health Color

### DIFF
--- a/DelvUI/Interface/Party/PartyFramesBar.cs
+++ b/DelvUI/Interface/Party/PartyFramesBar.cs
@@ -237,6 +237,11 @@ namespace DelvUI.Interface.Party
                         ? GlobalColors.Instance.SafeRoleColorForJobId(character!.ClassJob.Id)
                         : _configs.HealthBar.ColorsConfig.HealthMissingColor;
 
+                if (_configs.HealthBar.RangeConfig.Enabled)
+                {
+                    missingHealthColor = GetDistanceColor(character, missingHealthColor);
+                }
+
                 if (_configs.Trackers.Invuln.ChangeBackgroundColorWhenInvuln && character is BattleChara battleChara)
                 {
                     Status? tankInvuln = Utils.GetTankInvulnerabilityID(battleChara);

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -7,6 +7,9 @@ Features:
     + A new "Performance" mode was added which has the clipping functionallity reduced in favor of FPS.
     + Details on all the modes can be found in Misc > Window Clipping.
 
+ Fixes:
+ - Fix "Change Alpha Based on Range" for Missing Health Color.
+
 # 0.6.3.4
 - Fixed window clipping not working.
 


### PR DESCRIPTION
should fix the alpha not changing based on range for missing health color in party frames (#965)