### PR TITLE
Change alpha based on range option for target/tot/focus targets

### DIFF
--- a/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
@@ -7,7 +7,7 @@ using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    [DisableParentSettings("HideWhenInactive", "HideHealthIfPossible")]
+    [DisableParentSettings("HideWhenInactive", "HideHealthIfPossible", "RangeConfig")]
     [Section("Unit Frames")]
     [SubSection("Player", 0)]
     public class PlayerUnitFrameConfig : UnitFrameConfig
@@ -235,6 +235,9 @@ namespace DelvUI.Interface.GeneralElements
         [NestedConfig("Shields", 140)]
         public ShieldConfig ShieldConfig = new ShieldConfig();
 
+        [NestedConfig("Change Alpha Based on Range", 145)]
+        public UnitFramesRangeConfig RangeConfig = new();
+
         [NestedConfig("Custom Mouseover Area", 150)]
         public MouseoverAreaConfig MouseoverAreaConfig = new MouseoverAreaConfig();
 
@@ -330,6 +333,50 @@ namespace DelvUI.Interface.GeneralElements
             bar.SetBackground(background);
 
             return bar;
+        }
+    }
+
+    [Exportable(false)]
+    public class UnitFramesRangeConfig : PluginConfigObject
+    {
+        [DragInt("Range (yalms)", min = 1, max = 500)]
+        [Order(5)]
+        public int Range = 30;
+
+        [DragFloat("Alpha", min = 1, max = 100)]
+        [Order(10)]
+        public float Alpha = 24;
+
+        [Checkbox("Use Additional Range Check")]
+        [Order(15)]
+        public bool UseAdditionalRangeCheck = false;
+
+        [DragInt("Additional Range (yalms)", min = 1, max = 500)]
+        [Order(20, collapseWith = nameof(UseAdditionalRangeCheck))]
+        public int AdditionalRange = 15;
+
+        [DragFloat("Additional Alpha", min = 1, max = 100)]
+        [Order(25, collapseWith = nameof(UseAdditionalRangeCheck))]
+        public float AdditionalAlpha = 60;
+
+        public float AlphaForDistance(int distance, float alpha = 100f)
+        {
+            if (!Enabled)
+            {
+                return 100f;
+            }
+
+            if (!UseAdditionalRangeCheck)
+            {
+                return distance > Range ? Alpha : alpha;
+            }
+
+            if (Range > AdditionalRange)
+            {
+                return distance > Range ? Alpha : (distance > AdditionalRange ? AdditionalAlpha : alpha);
+            }
+
+            return distance > AdditionalRange ? AdditionalAlpha : (distance > Range ? Alpha : alpha);
         }
     }
 }

--- a/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
@@ -235,8 +235,11 @@ namespace DelvUI.Interface.GeneralElements
         [NestedConfig("Shields", 140)]
         public ShieldConfig ShieldConfig = new ShieldConfig();
 
-        [NestedConfig("Change Alpha Based on Range", 145)]
+        [NestedConfig("Change Friendly Alpha Based on Range", 145)]
         public UnitFramesRangeConfig RangeConfig = new();
+
+        [NestedConfig("Change Enemy Alpha Based on Range", 146)]
+        public UnitFramesRangeConfig EnemyRangeConfig = new();
 
         [NestedConfig("Custom Mouseover Area", 150)]
         public MouseoverAreaConfig MouseoverAreaConfig = new MouseoverAreaConfig();

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -125,6 +125,11 @@ namespace DelvUI.Interface.GeneralElements
 
             PluginConfigColor fillColor = GetColor(character, currentHp, maxHp);
             Rect background = new Rect(Config.Position, Config.Size, BackgroundColor(character));
+            if (Config.RangeConfig.Enabled)
+            {
+                fillColor = GetDistanceColor(character, fillColor);
+                background.Color = GetDistanceColor(character, background.Color);
+            }
             Rect healthFill = BarUtilities.GetFillRect(Config.Position, Config.Size, Config.FillDirection, fillColor, currentHp, maxHp);
 
             BarHud bar = new BarHud(Config, character);
@@ -144,6 +149,11 @@ namespace DelvUI.Interface.GeneralElements
                     : Config.UseRoleColorAsMissingHealthColor && character is BattleChara
                         ? GlobalColors.Instance.SafeRoleColorForJobId(character!.ClassJob.Id)
                         : Config.HealthMissingColor;
+
+                if (Config.RangeConfig.Enabled)
+                {
+                    missingHealthColor = GetDistanceColor(character, missingHealthColor);
+                }
 
                 if (Config.UseCustomInvulnerabilityColor && character is BattleChara battleChara)
                 {
@@ -276,6 +286,15 @@ namespace DelvUI.Interface.GeneralElements
             }
 
             return Config.FillColor;
+        }
+
+        private PluginConfigColor GetDistanceColor(Character? character, PluginConfigColor color)
+        {
+            byte distance = character != null ? character.YalmDistanceX : byte.MaxValue;
+            float currentAlpha = color.Vector.W * 100f;
+            float alpha = Config.RangeConfig.AlphaForDistance(distance, currentAlpha) / 100f;
+
+            return new PluginConfigColor(color.Vector.WithNewAlpha(alpha));
         }
 
         private void DrawFriendlyNPC(Vector2 pos, GameObject? actor)

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using Dalamud.Game.ClientState.Objects.Enums;
 
 namespace DelvUI.Interface.GeneralElements
 {
@@ -125,11 +126,12 @@ namespace DelvUI.Interface.GeneralElements
 
             PluginConfigColor fillColor = GetColor(character, currentHp, maxHp);
             Rect background = new Rect(Config.Position, Config.Size, BackgroundColor(character));
-            if (Config.RangeConfig.Enabled)
+            if (Config.RangeConfig.Enabled || Config.EnemyRangeConfig.Enabled)
             {
                 fillColor = GetDistanceColor(character, fillColor);
                 background.Color = GetDistanceColor(character, background.Color);
             }
+
             Rect healthFill = BarUtilities.GetFillRect(Config.Position, Config.Size, Config.FillDirection, fillColor, currentHp, maxHp);
 
             BarHud bar = new BarHud(Config, character);
@@ -150,7 +152,7 @@ namespace DelvUI.Interface.GeneralElements
                         ? GlobalColors.Instance.SafeRoleColorForJobId(character!.ClassJob.Id)
                         : Config.HealthMissingColor;
 
-                if (Config.RangeConfig.Enabled)
+                if (Config.RangeConfig.Enabled || Config.EnemyRangeConfig.Enabled)
                 {
                     missingHealthColor = GetDistanceColor(character, missingHealthColor);
                 }
@@ -294,8 +296,15 @@ namespace DelvUI.Interface.GeneralElements
             float currentAlpha = color.Vector.W * 100f;
             float alpha = Config.RangeConfig.AlphaForDistance(distance, currentAlpha) / 100f;
 
+            if (character is BattleNpc { BattleNpcKind: BattleNpcSubKind.Enemy } && Config.EnemyRangeConfig.Enabled)
+            {
+                alpha = Config.EnemyRangeConfig.AlphaForDistance(distance, currentAlpha) / 100f;
+            }
+
             return new PluginConfigColor(color.Vector.WithNewAlpha(alpha));
         }
+
+
 
         private void DrawFriendlyNPC(Vector2 pos, GameObject? actor)
         {

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -6,6 +6,7 @@ Features:
     + It can still be manually enabled through the config window.
     + A new "Performance" mode was added which has the clipping functionallity reduced in favor of FPS.
     + Details on all the modes can be found in Misc > Window Clipping.
+- Added "Change Alpha Based on Range" options for Target, Target of Target and Focus Frames.
 
 Fixes:
 - Fixed "Change Alpha Based on Range" for Missing Health Color.

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -6,7 +6,7 @@ Features:
     + It can still be manually enabled through the config window.
     + A new "Performance" mode was added which has the clipping functionallity reduced in favor of FPS.
     + Details on all the modes can be found in Misc > Window Clipping.
-- Added "Change Alpha Based on Range" options for Target, Target of Target and Focus Frames.
+- Added "Change Alpha Based on Range" options for Target, Target of Target and Focus Frames separated into Friendly and Enemy settings.
 
 Fixes:
 - Fixed "Change Alpha Based on Range" for Missing Health Color.


### PR DESCRIPTION
#966 

Disabled for player frame.
Separates range based alpha settings on unit frames for Enemy and Friendly targets.