### PR TITLE
fix death indicator color when using missing health color

### DIFF
--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -152,9 +152,9 @@ namespace DelvUI.Interface.GeneralElements
                         ? GlobalColors.Instance.SafeRoleColorForJobId(character!.ClassJob.Id)
                         : Config.HealthMissingColor;
 
-                if (Config.RangeConfig.Enabled || Config.EnemyRangeConfig.Enabled)
+                if (Config.UseDeathIndicatorBackgroundColor && character.CurrentHp <= 0)
                 {
-                    missingHealthColor = GetDistanceColor(character, missingHealthColor);
+                    missingHealthColor = Config.DeathIndicatorBackgroundColor;
                 }
 
                 if (Config.UseCustomInvulnerabilityColor && character is BattleChara battleChara)
@@ -164,6 +164,11 @@ namespace DelvUI.Interface.GeneralElements
                     {
                         missingHealthColor = Config.CustomInvulnerabilityColor;
                     }
+                }
+
+                if (Config.RangeConfig.Enabled || Config.EnemyRangeConfig.Enabled)
+                {
+                    missingHealthColor = GetDistanceColor(character, missingHealthColor);
                 }
 
                 bar.AddForegrounds(new Rect(healthMissingPos, healthMissingSize, missingHealthColor));

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -152,7 +152,7 @@ namespace DelvUI.Interface.GeneralElements
                         ? GlobalColors.Instance.SafeRoleColorForJobId(character!.ClassJob.Id)
                         : Config.HealthMissingColor;
 
-                if (Config.UseDeathIndicatorBackgroundColor && character.CurrentHp <= 0)
+                if (Config.UseDeathIndicatorBackgroundColor && character is BattleChara { CurrentHp: <= 0 })
                 {
                     missingHealthColor = Config.DeathIndicatorBackgroundColor;
                 }

--- a/DelvUI/Interface/Party/PartyFramesBar.cs
+++ b/DelvUI/Interface/Party/PartyFramesBar.cs
@@ -235,9 +235,9 @@ namespace DelvUI.Interface.Party
                         ? GlobalColors.Instance.SafeRoleColorForJobId(character!.ClassJob.Id)
                         : _configs.HealthBar.ColorsConfig.HealthMissingColor;
 
-                if (_configs.HealthBar.RangeConfig.Enabled)
+                if (_configs.HealthBar.ColorsConfig.UseDeathIndicatorBackgroundColor && Member.HP <= 0 && character != null)
                 {
-                    missingHealthColor = GetDistanceColor(character, missingHealthColor);
+                    missingHealthColor = _configs.HealthBar.ColorsConfig.DeathIndicatorBackgroundColor;
                 }
 
                 if (_configs.Trackers.Invuln.ChangeBackgroundColorWhenInvuln && character is BattleChara battleChara)
@@ -247,6 +247,11 @@ namespace DelvUI.Interface.Party
                     {
                         missingHealthColor = _configs.Trackers.Invuln.BackgroundColor;
                     }
+                }
+
+                if (_configs.HealthBar.RangeConfig.Enabled)
+                {
+                    missingHealthColor = GetDistanceColor(character, missingHealthColor);
                 }
 
                 bar.AddForegrounds(new Rect(healthMissingPos, healthMissingSize, missingHealthColor));

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.0.1
+Fixes:
+- Fixed Death Indicator Color when using Missing Health Color for unit and party frames.
+
 # 1.0.0.0
 Features:
 - Several changes made to Window Clipping:


### PR DESCRIPTION
fixed death indicator color when using missing health color for unit and party frames