### PR TITLE
DRK 10k mana

### DIFF
--- a/DelvUI/Interface/Jobs/DarkKnightHud.cs
+++ b/DelvUI/Interface/Jobs/DarkKnightHud.cs
@@ -116,7 +116,7 @@ namespace DelvUI.Interface.Jobs
                 Config.ManaBar,
                 gauge.HasDarkArts ? 1 : 3,
                 player.CurrentMp,
-                9000,
+                Config.ManaBar.ShowFullMana ? player.MaxMp : 9000,
                 0f,
                 player,
                 null,
@@ -283,6 +283,10 @@ namespace DelvUI.Interface.Jobs
         [ColorEdit4("Dark Arts Color" + "##MP")]
         [Order(26)]
         public PluginConfigColor DarkArtsColor = new PluginConfigColor(new Vector4(210f / 255f, 33f / 255f, 33f / 255f, 100f / 100f));
+
+        [Checkbox("Show mana values up to 10k (will break thresholds)", spacing = true)]
+        [Order(27)]
+        public bool ShowFullMana = false;
 
         public DarkKnightManaBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)
              : base(position, size, fillColor)

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,4 +1,7 @@
 # 1.0.0.2
+Features:
+- Added an option to show mana up to 10k on Dark Knight's mana bar. Note that this will break thresholds.
+
 Fixes:
 - Fixed "Use Job Color" and "Use Role Color" for status effects duration and stacks labels.
 - Fixed Job Huds strata level not working properly.


### PR DESCRIPTION
Added an option by request to let the bar fill up to 10k instead of 9k mana, breaks thresholds for those who wants use it though so disabled by default