### PR TITLE
Label number handling (truncate, floor, ceil, round)

### DIFF
--- a/DelvUI/Interface/GeneralElements/LabelConfig.cs
+++ b/DelvUI/Interface/GeneralElements/LabelConfig.cs
@@ -36,7 +36,7 @@ namespace DelvUI.Interface.GeneralElements
         [Order(10)]
         public int NumberFormat;
         
-        [Combo("Number Handling", "Truncate", "Floor", "Ceil", "Round")]
+        [Combo("Rounding Mode", "Truncate", "Floor", "Ceil", "Round")]
         [Order(15)]
         public int NumberFunction;
 

--- a/DelvUI/Interface/GeneralElements/LabelConfig.cs
+++ b/DelvUI/Interface/GeneralElements/LabelConfig.cs
@@ -35,6 +35,10 @@ namespace DelvUI.Interface.GeneralElements
         [Combo("Number Format", "No Decimals (i.e. \"12\")", "One Decimal (i.e. \"12.3\")", "Two Decimals (i.e. \"12.34\")")]
         [Order(10)]
         public int NumberFormat;
+        
+        [Combo("Number Handling", "Truncate", "Floor", "Ceil", "Round")]
+        [Order(15)]
+        public int NumberFunction;
 
         [Checkbox("Hide Text When Zero")]
         [Order(65)]
@@ -54,7 +58,18 @@ namespace DelvUI.Interface.GeneralElements
             }
 
             int aux = (int)Math.Pow(10, NumberFormat);
-            double v = Math.Truncate(value * aux) / aux;
+            double textValue = value * aux;
+
+            textValue = NumberFunction switch
+            {
+                0 => Math.Truncate(textValue),
+                1 => Math.Floor(textValue),
+                2 => Math.Ceiling(textValue),
+                3 => Math.Round(textValue),
+                var _ => Math.Truncate(textValue)
+            };
+
+            double v = textValue / aux;
             _text = v.ToString($"F{NumberFormat}", CultureInfo.InvariantCulture);
         }
 

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.0.4
+Features:
+- Added a option to choose in what way labels are handled (truncate, floor, ceil, round).
+
 # 1.0.0.3
 Features:
 - Added "Use Job Color" and "Use Role Color" options when using "Use Max Health Color".

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,6 +1,6 @@
 # 1.0.0.4
 Features:
-- Added a option to choose in what way labels are handled (truncate, floor, ceil, round).
+- Added Rounding Mode, an option to choose in what way labels are handled (truncate, floor, ceil, round).
 
 # 1.0.0.3
 Features:


### PR DESCRIPTION
There's probably a better way to name/describe this option, but my brain couldn't find it at the moment.

I mostly added this so people can set it to ceil to make it match what the game is doing for cooldowns for the trance bar for example.

https://user-images.githubusercontent.com/4972345/151149686-480b7b85-1343-431a-ae51-93694653af70.mp4


