### PR TITLE
Player Unitframe visibility options

### DIFF
--- a/DelvUI/Interface/GeneralElements/HUDOptionsConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HUDOptionsConfig.cs
@@ -36,8 +36,12 @@ namespace DelvUI.Interface.GeneralElements
         public bool MouseoverAutomaticMode = true;
 
         [Checkbox("Hide DelvUI outside of combat", isMonitored = true, separator = true, help = "Show in Duty and Show on Weapon Drawn-options available once enabled.")]
-        [Order(20)]
+        [Order(17)]
         public bool HideOutsideOfCombat = false;
+
+        [Checkbox("Hide Player Frame even when not at full HP outside of combat.")]
+        [Order(18, collapseWith = nameof(HideOutsideOfCombat))]
+        public bool AlwaysHidePlayerFrameWhenDelvUIHidden = false;               
 
         [Checkbox("Show in duty" + "##HideOutsideCombat")]
         [Order(21, collapseWith = nameof(HideOutsideOfCombat))]
@@ -50,6 +54,10 @@ namespace DelvUI.Interface.GeneralElements
         [Checkbox("Hide DelvUI in Gold Saucer")]
         [Order(25)]
         public bool HideInGoldSaucer = false;
+
+        [Checkbox("Hide Player Frame at full HP")]
+        [Order(26)]
+        public bool HidePlayerFrameAtFullHP = false;
 
         [Checkbox("Hide only JobPack HUD outside of combat")]
         [Order(30)]

--- a/DelvUI/Interface/HudHelper.cs
+++ b/DelvUI/Interface/HudHelper.cs
@@ -206,9 +206,14 @@ namespace DelvUI.Interface
                             : Config.HideOnlyJobPackHudOutsideOfCombat && !IsInCombat();
                 }
 
+                // hide player frame when at full health
+                if (Config.HidePlayerFrameAtFullHP && element.GetConfig().GetType() == typeof(PlayerUnitFrameConfig) && !Config.HideOutsideOfCombat)
+                {
+                    isHidden = !isHidden && player.CurrentHp == player.MaxHp;
+                }
                 else if (element.GetConfig().GetType() == typeof(PlayerUnitFrameConfig))
                 {
-                    isHidden = isHidden && player.CurrentHp == player.MaxHp;
+                    isHidden = Config.AlwaysHidePlayerFrameWhenDelvUIHidden ? isHidden : isHidden && player.CurrentHp == player.MaxHp;
                 }
             }
 

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,8 @@
+# 1.0.1.1
+Features:
+- Added a sub-option to keep hiding Player Unitframe outside of combat when not full health if "Hide DelvUI outside of combat" is enabled.
+- Added a separate option to always hide Player Unitframe when at full health.
+
 # 1.0.1.0
 Features:
 - Added Rounding Mode, an option to choose in what way labels are handled (truncate, floor, ceil, round).


### PR DESCRIPTION
- Added a sub-option to keep hiding Player Unitframe outside of combat when not full health if "Hide DelvUI outside of combat" is enabled.
- Added a separate option to always hide Player Unitframe when at full health.