### PR TITLE
SGE Addersgall / WHM Lily options

### DIFF
--- a/DelvUI/Interface/Jobs/SageHud.cs
+++ b/DelvUI/Interface/Jobs/SageHud.cs
@@ -104,7 +104,7 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.AddersgallBar.HideWhenInactive || adderScale > 0)
             {
-                BarHud[] bars = BarUtilities.GetChunkedBars(Config.AddersgallBar, 3, adderScale, 3, 0, player, glowConfig: glow, chunksToGlow: new[] { true, true, true });
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.AddersgallBar, 3, adderScale, 3, 0, player, partialFillColor: Config.AddersgallBar.PartialFillColor, glowConfig: glow, chunksToGlow: new[] { true, true, true });
                 foreach (BarHud bar in bars)
                 {
                     AddDrawActions(bar.GetDrawActions(origin, Config.AddersgallBar.StrataLevel));
@@ -179,7 +179,7 @@ namespace DelvUI.Interface.Jobs
         );
 
         [NestedConfig("Addersting Bar", 40)]
-        public AddersgallBarConfig AdderstingBar = new AddersgallBarConfig(
+        public AdderstingBarConfig AdderstingBar = new AdderstingBarConfig(
             new(64, -32),
             new(126, 20),
             new PluginConfigColor(new(255f / 255f, 232f / 255f, 255f / 255f, 100f / 100f))
@@ -213,7 +213,29 @@ namespace DelvUI.Interface.Jobs
         [NestedConfig("Glow Color (when Eukrasia active)", 60, separator = false, spacing = true)]
         public BarGlowConfig GlowConfig = new();
 
+        [Checkbox("Use Partial Fill Color", spacing = true)]
+        [Order(65)]
+        public bool UsePartialFillColor = false;
+
+        [ColorEdit4("Partial Fill Color")]
+        [Order(66, collapseWith = nameof(UsePartialFillColor))]
+        public PluginConfigColor PartialFillColor;
+
         public AddersgallBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)
+             : base(position, size, fillColor)
+        {
+            GlowConfig.Color = new PluginConfigColor(new(247f / 255f, 177f / 255f, 67f / 255f, 100f / 100f));
+            PartialFillColor = new PluginConfigColor(new(197 / 255f, 247f / 255f, 255f / 255f, 50f / 100f));
+        }
+    }
+
+    [Exportable(false)]
+    public class AdderstingBarConfig : ChunkedBarConfig
+    {
+        [NestedConfig("Glow Color (when Eukrasia active)", 60, separator = false, spacing = true)]
+        public BarGlowConfig GlowConfig = new();
+
+        public AdderstingBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)
              : base(position, size, fillColor)
         {
             GlowConfig.Color = new PluginConfigColor(new(247f / 255f, 177f / 255f, 67f / 255f, 100f / 100f));

--- a/DelvUI/Interface/Jobs/WhiteMageHud.cs
+++ b/DelvUI/Interface/Jobs/WhiteMageHud.cs
@@ -124,7 +124,7 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.LilyBar.HideWhenInactive || lilyScale > 0)
             {
-                BarHud[] bars = BarUtilities.GetChunkedBars(Config.LilyBar, 3, lilyScale, 3, 0, player);
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.LilyBar, 3, lilyScale, 3, 0, player, partialFillColor: Config.LilyBar.PartialFillColor);
                 foreach (BarHud bar in bars)
                 {
                     AddDrawActions(bar.GetDrawActions(origin, Config.LilyBar.StrataLevel));
@@ -133,7 +133,8 @@ namespace DelvUI.Interface.Jobs
 
             if (!Config.BloodLilyBar.HideWhenInactive && Config.BloodLilyBar.Enabled || gauge.BloodLily > 0)
             {
-                BarHud[] bars = BarUtilities.GetChunkedBars(Config.BloodLilyBar, 3, gauge.BloodLily, 3, 0, player);
+                BarGlowConfig? glow = gauge.BloodLily == 3 ? Config.BloodLilyBar.GlowConfig : null;
+                BarHud[] bars = BarUtilities.GetChunkedBars(Config.BloodLilyBar, 3, gauge.BloodLily, 3, 0, player, glowConfig: glow, chunksToGlow: new[] { true, true, true });
                 foreach (BarHud bar in bars)
                 {
                     AddDrawActions(bar.GetDrawActions(origin, Config.BloodLilyBar.StrataLevel));
@@ -215,14 +216,14 @@ namespace DelvUI.Interface.Jobs
         }
 
         [NestedConfig("Lily Bar", 30)]
-        public ChunkedBarConfig LilyBar = new ChunkedBarConfig(
+        public LilyBarConfig LilyBar = new LilyBarConfig(
             new(-64, -32),
             new(126, 20),
             new PluginConfigColor(new(0f / 255f, 64f / 255f, 255f / 255f, 100f / 100f))
         );
 
         [NestedConfig("Blood Lily Bar", 35)]
-        public ChunkedBarConfig BloodLilyBar = new ChunkedBarConfig(
+        public BloodLilyBarConfig BloodLilyBar = new BloodLilyBarConfig(
             new(64, -32),
             new(126, 20),
             new PluginConfigColor(new(199f / 255f, 40f / 255f, 9f / 255f, 100f / 100f))
@@ -262,5 +263,36 @@ namespace DelvUI.Interface.Jobs
             new(62, 15),
             new PluginConfigColor(new(100f / 255f, 207f / 255f, 211f / 255f, 100f / 100f))
         );
+    }
+
+    [Exportable(false)]
+    public class LilyBarConfig : ChunkedBarConfig
+    {
+        [Checkbox("Use Partial Fill Color", spacing = true)]
+        [Order(65)]
+        public bool UsePartialFillColor = false;
+
+        [ColorEdit4("Partial Fill Color")]
+        [Order(66, collapseWith = nameof(UsePartialFillColor))]
+        public PluginConfigColor PartialFillColor;
+
+        public LilyBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)
+             : base(position, size, fillColor)
+        {
+            PartialFillColor = new PluginConfigColor(new(0f / 255f, 64f / 255f, 255f / 255f, 50f / 100f));
+        }
+    }
+
+    [Exportable(false)]
+    public class BloodLilyBarConfig : ChunkedBarConfig
+    {
+        [NestedConfig("Glow Color (when Misery ready)", 60, separator = false, spacing = true)]
+        public BarGlowConfig GlowConfig = new();
+
+        public BloodLilyBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)
+             : base(position, size, fillColor)
+        {
+            GlowConfig.Color = new PluginConfigColor(new(247f / 255f, 177f / 255f, 67f / 255f, 100f / 100f));
+        }
     }
 }

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,6 +1,6 @@
 # 1.0.1.2
 Features:
-- Added Partial Fill Color options for Sage's Addersgall Bar.
+- Added Partial Fill Color options for Sage's Addersgall Bar and White Mage's Lily Bar.
 
 # 1.0.1.1
 Features:

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.1.2
+Features:
+- Added Partial Fill Color options for Sage's Addersgall Bar.
+
 # 1.0.1.1
 Features:
 - Added a sub-option to keep hiding Player Unitframe outside of combat when not full health if "Hide DelvUI outside of combat" is enabled.

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,6 +1,7 @@
 # 1.0.1.2
 Features:
 - Added Partial Fill Color options for Sage's Addersgall Bar and White Mage's Lily Bar.
+- Added options for Glow to White Mage's Blood Lily bar when filled.
 
 # 1.0.1.1
 Features:


### PR DESCRIPTION
Since this has been requested:
- Added Partial Fill Color options for SGE Addersgall & WHM Lily bars
- Separated Addersting config from Addersgall a bit
- Added glow options for when Blood Lily bar is full (Misery available)
