### PR TITLE
option to hide the experience bar in downsynced content

### DIFF
--- a/DelvUI/Interface/GeneralElements/ExperienceBarConfig.cs
+++ b/DelvUI/Interface/GeneralElements/ExperienceBarConfig.cs
@@ -11,6 +11,10 @@ namespace DelvUI.Interface.GeneralElements
     [SubSection("Experience Bar", 0)]
     public class ExperienceBarConfig : BarConfig
     {
+        [Checkbox("Hide When Downsynced")]
+        [Order(44, collapseWith = nameof(HideWhenInactive))]
+        public bool HideWhenDownsynced = false;
+
         [Checkbox("Use Job Color")]
         [Order(45)]
         public bool UseJobColor = false;

--- a/DelvUI/Interface/GeneralElements/ExperienceBarHud.cs
+++ b/DelvUI/Interface/GeneralElements/ExperienceBarHud.cs
@@ -13,6 +13,8 @@ namespace DelvUI.Interface.GeneralElements
 
         public GameObject? Actor { get; set; } = null;
 
+        private ExperienceHelper _helper = new ExperienceHelper();
+
         public ExperienceBarHud(ExperienceBarConfig config, string displayName) : base(config, displayName) { }
 
         protected override (List<Vector2>, List<Vector2>) ChildrenPositionsAndSizes()
@@ -22,7 +24,7 @@ namespace DelvUI.Interface.GeneralElements
 
         public override void DrawChildren(Vector2 origin)
         {
-            if (!Config.Enabled || Actor is null || Config.HideWhenInactive && (Plugin.ClientState.LocalPlayer?.Level ?? 0) >= 90)
+            if (!Config.Enabled || Actor is null || Config.HideWhenInactive && (Plugin.ClientState.LocalPlayer?.Level ?? 0) >= 90 || (Config.HideWhenInactive && Config.HideWhenDownsynced && _helper.IsMaxLevel()))
             {
                 return;
             }

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.1.2
+Features:
+- Added a sub-option to the Experience Bars' "Hide When Inactive" to hide the experience bar in downsynced content when on a max level job.
+
 # 1.0.1.1
 Features:
 - Added a sub-option to keep hiding Player Unitframe outside of combat when not full health if "Hide DelvUI outside of combat" is enabled.


### PR DESCRIPTION
when on a max level job, sub-option to "hide when inactive"