### PR TITLE
Added new tag for consistent digit health percentage (#1013)

### DIFF
--- a/DelvUI/Helpers/TextTagsHelper.cs
+++ b/DelvUI/Helpers/TextTagsHelper.cs
@@ -119,7 +119,7 @@ namespace DelvUI.Helpers
 
             ["[health:percent]"] = (currentHp, maxHp) => (100f * currentHp / Math.Max(1, maxHp)).ToString("N0"),
 
-            ["[health:percent-decimal]"] = (currentHp, maxHp) => FormattableString.Invariant($"{100f * currentHp / Math.Max(1f, maxHp):##0.#}"),
+            ["[health:percent-decimal]"] = (currentHp, maxHp) => FormattableString.Invariant($"{100f * currentHp / Math.Max(1f, maxHp):0.0}"),
 
             ["[health:deficit]"] = (currentHp, maxHp) => currentHp == maxHp ? "0" : $"-{maxHp - currentHp}",
 

--- a/DelvUI/Helpers/TextTagsHelper.cs
+++ b/DelvUI/Helpers/TextTagsHelper.cs
@@ -152,6 +152,8 @@ namespace DelvUI.Helpers
 
             ["[mana:percent-decimal]"] = (currentMp, maxMp) => FormattableString.Invariant($"{100f * currentMp / Math.Max(1, maxMp):##0.#}"),
 
+            ["[mana:percent-decimal-uniform]"] = (currentMp, maxMp) => ConsistentDigitPercentage(currentMp, maxMp),
+
             ["[mana:deficit]"] = (currentMp, maxMp) => currentMp == maxMp ? "0" : $"-{currentMp - maxMp}",
 
             ["[mana:deficit-short]"] = (currentMp, maxMp) => currentMp == maxMp ? "0" : $"-{(currentMp - maxMp).KiloFormat()}",
@@ -220,8 +222,8 @@ namespace DelvUI.Helpers
             return actor != null ? actor.Name.ToString() : (name ?? "");
         }
 
-        private static string ConsistentDigitPercentage(float currentHp, float maxHp){
-            var rawPercentage = 100f * currentHp / Math.Max(1f, maxHp);
+        private static string ConsistentDigitPercentage(float currentVal, float maxVal){
+            var rawPercentage = 100f * currentVal / Math.Max(1f, maxVal);
             return rawPercentage >= 100 || rawPercentage <= 0 ? rawPercentage.ToString("N0") : rawPercentage.ToString("N1");
         }
     }

--- a/DelvUI/Helpers/TextTagsHelper.cs
+++ b/DelvUI/Helpers/TextTagsHelper.cs
@@ -119,9 +119,9 @@ namespace DelvUI.Helpers
 
             ["[health:percent]"] = (currentHp, maxHp) => (100f * currentHp / Math.Max(1, maxHp)).ToString("N0"),
 
-            ["[health:percent-decimal]"] = (currentHp, maxHp) => 100f * currentHp / Math.Max(1f, maxHp) >= 100.0 || 100f * currentHp / Math.Max(1f, maxHp) <= 0.0
-                                                                ? FormattableString.Invariant($"{100f * currentHp / Math.Max(1f, maxHp):##0.#}")
-                                                                : FormattableString.Invariant($"{100f * currentHp / Math.Max(1f, maxHp):0.0}"),
+            ["[health:percent-decimal]"] = (currentHp, maxHp) => FormattableString.Invariant($"{100f * currentHp / Math.Max(1f, maxHp):##0.#}"),
+
+            ["[health:percent-decimal-consistent]"] = (currentHp, maxHp) => ConsistentDigitPercentage(currentHp, maxHp),
 
             ["[health:deficit]"] = (currentHp, maxHp) => currentHp == maxHp ? "0" : $"-{maxHp - currentHp}",
 
@@ -218,6 +218,11 @@ namespace DelvUI.Helpers
         private static string ValidateName(GameObject? actor, string? name)
         {
             return actor != null ? actor.Name.ToString() : (name ?? "");
+        }
+
+        private static string ConsistentDigitPercentage(float currentHp, float maxHp){
+            var rawPercentage = 100f * currentHp / Math.Max(1f, maxHp);
+            return rawPercentage >= 100 || rawPercentage <= 0 ? rawPercentage.ToString("N0") : rawPercentage.ToString("N1");
         }
     }
 }

--- a/DelvUI/Helpers/TextTagsHelper.cs
+++ b/DelvUI/Helpers/TextTagsHelper.cs
@@ -121,7 +121,7 @@ namespace DelvUI.Helpers
 
             ["[health:percent-decimal]"] = (currentHp, maxHp) => FormattableString.Invariant($"{100f * currentHp / Math.Max(1f, maxHp):##0.#}"),
 
-            ["[health:percent-decimal-consistent]"] = (currentHp, maxHp) => ConsistentDigitPercentage(currentHp, maxHp),
+            ["[health:percent-decimal-uniform]"] = (currentHp, maxHp) => ConsistentDigitPercentage(currentHp, maxHp),
 
             ["[health:deficit]"] = (currentHp, maxHp) => currentHp == maxHp ? "0" : $"-{maxHp - currentHp}",
 

--- a/DelvUI/Helpers/TextTagsHelper.cs
+++ b/DelvUI/Helpers/TextTagsHelper.cs
@@ -119,7 +119,9 @@ namespace DelvUI.Helpers
 
             ["[health:percent]"] = (currentHp, maxHp) => (100f * currentHp / Math.Max(1, maxHp)).ToString("N0"),
 
-            ["[health:percent-decimal]"] = (currentHp, maxHp) => FormattableString.Invariant($"{100f * currentHp / Math.Max(1f, maxHp):0.0}"),
+            ["[health:percent-decimal]"] = (currentHp, maxHp) => 100f * currentHp / Math.Max(1f, maxHp) >= 100.0 || 100f * currentHp / Math.Max(1f, maxHp) <= 0.0
+                                                                ? FormattableString.Invariant($"{100f * currentHp / Math.Max(1f, maxHp):##0.#}")
+                                                                : FormattableString.Invariant($"{100f * currentHp / Math.Max(1f, maxHp):0.0}"),
 
             ["[health:deficit]"] = (currentHp, maxHp) => currentHp == maxHp ? "0" : $"-{maxHp - currentHp}",
 


### PR DESCRIPTION
This is in relation to #1013 
Would be great to get some feedback on:
- If the new tag name is clear `[health:percent-decimal-consistent]`.
- If the place I put the helper method `ConsistentDigitPercentage` is okay (at the bottom of TextTagsHelper.cs)
- If I should also add the tag to the mana dictionary.