### PR TITLE
DNC Fixes

### DIFF
--- a/DelvUI/DelvUI.csproj
+++ b/DelvUI/DelvUI.csproj
@@ -10,9 +10,9 @@
     <!-- Assembly Configuration -->
     <PropertyGroup>
         <AssemblyName>DelvUI</AssemblyName>
-        <AssemblyVersion>1.0.1.2</AssemblyVersion>
-        <FileVersion>1.0.1.2</FileVersion>
-        <InformationalVersion>1.0.1.2</InformationalVersion>
+        <AssemblyVersion>1.0.1.3</AssemblyVersion>
+        <FileVersion>1.0.1.3</FileVersion>
+        <InformationalVersion>1.0.1.3</InformationalVersion>
     </PropertyGroup>
 
     <!-- Build Configuration -->

--- a/DelvUI/Interface/Jobs/DancerHud.cs
+++ b/DelvUI/Interface/Jobs/DancerHud.cs
@@ -118,7 +118,7 @@ namespace DelvUI.Interface.Jobs
 
         private void DrawProcBar(Vector2 origin, PlayerCharacter player, DancerProcBarConfig config, uint statusId)
         {
-            BarHud? bar = BarUtilities.GetProcBar(config, player, statusId, 20f, !config.IgnoreBuffDuration);
+            BarHud? bar = BarUtilities.GetProcBar(config, player, statusId, 30f, !config.IgnoreBuffDuration);
             if (bar != null)
             {
                 AddDrawActions(bar.GetDrawActions(origin, config.StrataLevel));
@@ -216,17 +216,16 @@ namespace DelvUI.Interface.Jobs
         private void DrawFeathersBar(Vector2 origin, PlayerCharacter player)
         {
             DNCGauge gauge = Plugin.JobGauges.Get<DNCGauge>();
-            if (Config.FeatherGauge.HideWhenInactive && gauge.Feathers is 0)
+            bool hasFlourishingBuff = player.StatusList.FirstOrDefault(o => o.StatusId is 1820 or 2021) != null;
+            bool[]? glows = null;
+
+            if (Config.FeatherGauge.HideWhenInactive && gauge.Feathers is 0 && !hasFlourishingBuff)
             {
                 return;
             }
 
-            bool hasFlourishingBuff = false;
-            bool[]? glows = null;
-
             if (Config.FeatherGauge.GlowConfig.Enabled)
             {
-                hasFlourishingBuff = player.StatusList.FirstOrDefault(o => o.StatusId is 1820 or 2021) != null;
                 glows = new bool[] { hasFlourishingBuff, hasFlourishingBuff, hasFlourishingBuff, hasFlourishingBuff };
             }
 

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -98,7 +98,7 @@ namespace DelvUI
                 AssemblyLocation = Assembly.GetExecutingAssembly().Location;
             }
 
-            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.0.1.2";
+            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.0.1.3";
 
             FontsManager.Initialize(AssemblyLocation);
             LoadBanner();

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,8 @@
+# 1.0.1.3
+Fixes:
+- Fixed the duration of Dancer Flourishing buffs.
+- Fixed Dancer "Fan Dance III" proc not showing on the Feather Gauge if "Hide When Inactive" was selected and no other feathers were available.
+
 # 1.0.1.2
 Features:
 - Added Partial Fill Color options for Sages' "Addersgall" bar and White Mages' "Lily" bar.


### PR DESCRIPTION
- Fix DNC feather gauge staying hidden if a fan dance III proc was available but no other feathers
- Fix duration of DNC flourishing buffs