### PR TITLE
Reworking visibility settings

### DIFF
--- a/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
+++ b/DelvUI/Config/Attributes/ConfigTypeAttributes.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using System.Reflection;
-using Dalamud.Interface;
+﻿using Dalamud.Interface;
 using DelvUI.Enums;
 using DelvUI.Helpers;
 using DelvUI.Interface.GeneralElements;
 using ImGuiNET;
+using System;
+using System.Linq;
+using System.Numerics;
+using System.Reflection;
 
 namespace DelvUI.Config.Attributes
 {
@@ -488,112 +487,6 @@ namespace DelvUI.Config.Attributes
             }
 
             return false;
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Field)]
-    public class DynamicListAttribute : ConfigAttribute
-    {
-        public string[] options;
-
-        public DynamicListAttribute(string friendlyName, params string[] options) : base(friendlyName)
-        {
-            this.options = options;
-        }
-
-        public override bool DrawField(FieldInfo field, PluginConfigObject config, string? ID, bool collapsingHeader)
-        {
-            var changed = false;
-
-            List<string>? fieldVal = (List<string>?)field.GetValue(config);
-            List<string> opts = fieldVal ?? new List<string>();
-
-            var idText = IDText(ID);
-            int indexToRemove = -1;
-
-            ImGui.BeginChild(friendlyName, new Vector2(400, 230));
-
-            List<string> addOptions = new(options);
-            for (int i = 0; i < opts.Count; i++)
-            {
-                addOptions.Remove(opts[i]);
-            }
-
-            int intVal = 0;
-            ImGui.Text("Add");
-            if (ImGui.Combo("##Add" + idText + friendlyName, ref intVal, addOptions.ToArray(), addOptions.Count, 6))
-            {
-                changed = true;
-
-                var change = addOptions[intVal];
-                opts.Add(change);
-                field.SetValue(config, opts);
-
-                TriggerChangeEvent<string>(config, field.Name, change, ChangeType.ListAdd);
-            }
-
-            ImGui.Text(friendlyName + ":");
-            var flags =
-                ImGuiTableFlags.RowBg |
-                ImGuiTableFlags.Borders |
-                ImGuiTableFlags.BordersOuter |
-                ImGuiTableFlags.BordersInner |
-                ImGuiTableFlags.ScrollY |
-                ImGuiTableFlags.SizingFixedSame;
-
-            if (ImGui.BeginTable("##myTable2" + friendlyName + idText, 2, flags, new Vector2(326, 150)))
-            {
-                ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch, 0, 0);
-                ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 0, 1);
-
-                ImGui.TableSetupScrollFreeze(0, 1);
-                ImGui.TableHeadersRow();
-
-                for (int i = 0; i < opts.Count(); i++)
-                {
-                    ImGui.PushID(i.ToString());
-                    ImGui.TableNextRow(ImGuiTableRowFlags.None);
-
-                    if (ImGui.TableSetColumnIndex(0))
-                    {
-                        ImGui.Text(opts[i]);
-                    }
-
-                    if (ImGui.TableSetColumnIndex(1))
-                    {
-                        ImGui.PushFont(UiBuilder.IconFont);
-                        ImGui.PushStyleColor(ImGuiCol.Button, Vector4.Zero);
-                        ImGui.PushStyleColor(ImGuiCol.ButtonActive, Vector4.Zero);
-                        ImGui.PushStyleColor(ImGuiCol.ButtonHovered, Vector4.Zero);
-
-                        if (ImGui.Button(FontAwesomeIcon.Trash.ToIconString()))
-                        {
-                            changed = true;
-                            indexToRemove = i;
-                        }
-
-                        ImGui.PopFont();
-                        ImGui.PopStyleColor(3);
-                    }
-                }
-
-                ImGui.EndTable();
-            }
-
-            if (indexToRemove >= 0)
-            {
-                changed = true;
-
-                var change = opts[indexToRemove];
-                opts.Remove(change);
-                field.SetValue(config, opts);
-
-                TriggerChangeEvent<string>(config, field.Name, change, ChangeType.ListRemove);
-            }
-
-            ImGui.EndChild();
-
-            return changed;
         }
     }
 

--- a/DelvUI/Config/ConfigurationManager.cs
+++ b/DelvUI/Config/ConfigurationManager.cs
@@ -22,6 +22,7 @@ namespace DelvUI.Config
 {
     public delegate void ConfigurationManagerEventHandler(ConfigurationManager configurationManager);
     public delegate void StrataLevelsEventHandler(ConfigurationManager configurationManager, PluginConfigObject config);
+    public delegate void GlobalVisibilityEventHandler(ConfigurationManager configurationManager, VisibilityConfig config);
 
     public class ConfigurationManager : IDisposable
     {
@@ -95,6 +96,7 @@ namespace DelvUI.Config
         public event ConfigurationManagerEventHandler? LockEvent;
         public event ConfigurationManagerEventHandler? ConfigClosedEvent;
         public event StrataLevelsEventHandler? StrataLevelsChangedEvent;
+        public event GlobalVisibilityEventHandler? GlobalVisibilityEvent;
 
         public ConfigurationManager()
         {
@@ -241,6 +243,13 @@ namespace DelvUI.Config
         }
         #endregion
 
+        #region visibility
+        public void OnGlobalVisibilityChanged(VisibilityConfig config)
+        {
+            GlobalVisibilityEvent?.Invoke(this, config);
+        }
+        #endregion
+
         #region windows
         public void ToggleConfigWindow()
         {
@@ -376,7 +385,7 @@ namespace DelvUI.Config
             }
 
             BaseNode node = maybeNode!;
-            if(IsConfigWindowOpened || string.IsNullOrEmpty(node.SelectedOptionName))
+            if (IsConfigWindowOpened || string.IsNullOrEmpty(node.SelectedOptionName))
             {
                 node.SelectedOptionName = ConfigBaseNode.SelectedOptionName;
                 node.RefreshSelectedNode();
@@ -545,6 +554,9 @@ namespace DelvUI.Config
             typeof(CastersColorConfig),
             typeof(RolesColorConfig),
             typeof(MiscColorConfig),
+
+            typeof(GlobalVisibilityConfig),
+            typeof(HotbarsVisibilityConfig),
 
             typeof(FontsConfig),
             typeof(HUDOptionsConfig),

--- a/DelvUI/DelvUI.csproj
+++ b/DelvUI/DelvUI.csproj
@@ -10,9 +10,9 @@
     <!-- Assembly Configuration -->
     <PropertyGroup>
         <AssemblyName>DelvUI</AssemblyName>
-        <AssemblyVersion>1.1.5.0</AssemblyVersion>
-        <FileVersion>1.1.5.0</FileVersion>
-        <InformationalVersion>1.1.5.0</InformationalVersion>
+        <AssemblyVersion>1.2.0.0</AssemblyVersion>
+        <FileVersion>1.2.0.0</FileVersion>
+        <InformationalVersion>1.2.0.0</InformationalVersion>
     </PropertyGroup>
 
     <!-- Build Configuration -->

--- a/DelvUI/Helpers/TooltipsHelper.cs
+++ b/DelvUI/Helpers/TooltipsHelper.cs
@@ -157,6 +157,9 @@ namespace DelvUI.Helpers
                 drawList.AddRect(_position, _position + _size, _config.BorderConfig.Color.Base, 0, ImDrawFlags.None, _config.BorderConfig.Thickness);
             }
 
+            // no idea why i have to do this
+            float globalScaleCorrection = -15 + 15 * ImGuiHelpers.GlobalScale;
+
             if (_currentTooltipTitle != null)
             {
                 // title
@@ -165,7 +168,7 @@ namespace DelvUI.Helpers
                 {
                     cursorPos = new Vector2(windowMargin.X + _size.X / 2f - _titleSize.X / 2f, Margin);
                     ImGui.SetCursorPos(cursorPos);
-                    ImGui.PushTextWrapPos(cursorPos.X + _titleSize.X - 10 + 10 * ImGuiHelpers.GlobalScale);
+                    ImGui.PushTextWrapPos(cursorPos.X + _titleSize.X + globalScaleCorrection);
                     ImGui.TextColored(_config.TitleColor.Vector, _currentTooltipTitle);
                     ImGui.PopTextWrapPos();
                 }
@@ -175,7 +178,7 @@ namespace DelvUI.Helpers
                 {
                     cursorPos = new Vector2(windowMargin.X + _size.X / 2f - _textSize.X / 2f, Margin + _titleSize.Y);
                     ImGui.SetCursorPos(cursorPos);
-                    ImGui.PushTextWrapPos(cursorPos.X + _textSize.X - 10 + 10 * ImGuiHelpers.GlobalScale);
+                    ImGui.PushTextWrapPos(cursorPos.X + _textSize.X + globalScaleCorrection);
                     ImGui.TextColored(_config.TextColor.Vector, _currentTooltipText);
                     ImGui.PopTextWrapPos();
                 }
@@ -189,7 +192,7 @@ namespace DelvUI.Helpers
                     var textWidth = _size.X - Margin * 2;
 
                     ImGui.SetCursorPos(cursorPos);
-                    ImGui.PushTextWrapPos(cursorPos.X + textWidth);
+                    ImGui.PushTextWrapPos(cursorPos.X + textWidth + globalScaleCorrection);
                     ImGui.TextColored(_config.TextColor.Vector, _currentTooltipText);
                     ImGui.PopTextWrapPos();
                 }

--- a/DelvUI/Interface/GeneralElements/ExperienceBarConfig.cs
+++ b/DelvUI/Interface/GeneralElements/ExperienceBarConfig.cs
@@ -33,6 +33,9 @@ namespace DelvUI.Interface.GeneralElements
         [NestedConfig("Right Text", 65)]
         public EditableLabelConfig RightLabel;
 
+        [NestedConfig("Visibility", 70)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
+
         public ExperienceBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor) : base(position, size, fillColor)
         {
             LeftLabel = new EditableLabelConfig(new Vector2(5, 0), "[job]  Lv[level]  EXP [exp:current-short]/[exp:required-short]", DrawAnchor.BottomLeft, DrawAnchor.TopLeft);

--- a/DelvUI/Interface/GeneralElements/ExperienceBarHud.cs
+++ b/DelvUI/Interface/GeneralElements/ExperienceBarHud.cs
@@ -7,9 +7,10 @@ using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    public class ExperienceBarHud : DraggableHudElement, IHudElementWithActor
+    public class ExperienceBarHud : DraggableHudElement, IHudElementWithActor, IHudElementWithVisibilityConfig
     {
         private ExperienceBarConfig Config => (ExperienceBarConfig)_config;
+        public VisibilityConfig VisibilityConfig => Config.VisibilityConfig;
 
         public GameObject? Actor { get; set; } = null;
 

--- a/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorConfig.cs
@@ -78,6 +78,9 @@ namespace DelvUI.Interface.GeneralElements
             new PluginConfigColor(Vector4.Zero)
         );
 
+        [NestedConfig("Visibility", 70)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
+
         public new static GCDIndicatorConfig DefaultConfig() { return new GCDIndicatorConfig() { Enabled = false, Strata = StrataLevel.MID_HIGH }; }
     }
 

--- a/DelvUI/Interface/GeneralElements/GCDIndicatorHud.cs
+++ b/DelvUI/Interface/GeneralElements/GCDIndicatorHud.cs
@@ -11,9 +11,11 @@ using Dalamud.Logging;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    public class GCDIndicatorHud : DraggableHudElement, IHudElementWithActor
+    public class GCDIndicatorHud : DraggableHudElement, IHudElementWithActor, IHudElementWithVisibilityConfig
     {
         private GCDIndicatorConfig Config => (GCDIndicatorConfig)_config;
+        public VisibilityConfig VisibilityConfig => Config.VisibilityConfig;
+
         public GameObject? Actor { get; set; } = null;
 
         private bool _wasBarEnabled = true;

--- a/DelvUI/Interface/GeneralElements/GlobalVisibilityConfig.cs
+++ b/DelvUI/Interface/GeneralElements/GlobalVisibilityConfig.cs
@@ -1,0 +1,53 @@
+﻿using DelvUI.Config;
+using DelvUI.Config.Attributes;
+using DelvUI.Helpers;
+using ImGuiNET;
+using Newtonsoft.Json;
+using System.Numerics;
+
+namespace DelvUI.Interface.GeneralElements
+{
+    [Disableable(false)]
+    [Exportable(false)]
+    [Section("Visibility")]
+    [SubSection("Global", 0)]
+    public class GlobalVisibilityConfig : PluginConfigObject
+    {
+        public new static GlobalVisibilityConfig DefaultConfig() { return new GlobalVisibilityConfig(); }
+
+        [NestedConfig("Visibility", 50, collapsingHeader = false)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
+
+        [JsonIgnore]
+        private bool _applying = false;
+
+        [ManualDraw]
+        public bool Draw(ref bool changed)
+        {
+            ImGui.NewLine();
+
+            if (ImGui.Button("Apply to all elements", new Vector2(200, 30)))
+            {
+                _applying = true;
+            }
+
+            if (_applying)
+            {
+                string[] lines = new string[] { "This will replace the visibility settings", "for ALL DelvUI elements!", "Are you sure?" };
+                var (didConfirm, didClose) = ImGuiHelper.DrawConfirmationModal("Apply?", lines);
+
+                if (didConfirm)
+                {
+                    ConfigurationManager.Instance.OnGlobalVisibilityChanged(VisibilityConfig);
+                }
+
+                if (didConfirm || didClose)
+                {
+                    _applying = false;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/DelvUI/Interface/GeneralElements/GlobalVisibilityConfig.cs
+++ b/DelvUI/Interface/GeneralElements/GlobalVisibilityConfig.cs
@@ -39,6 +39,7 @@ namespace DelvUI.Interface.GeneralElements
                 if (didConfirm)
                 {
                     ConfigurationManager.Instance.OnGlobalVisibilityChanged(VisibilityConfig);
+                    changed = true;
                 }
 
                 if (didConfirm || didClose)

--- a/DelvUI/Interface/GeneralElements/HUDOptionsConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HUDOptionsConfig.cs
@@ -23,6 +23,10 @@ namespace DelvUI.Interface.GeneralElements
         [Order(10)]
         public bool DimConfigWindow = false;
 
+        [Checkbox("Automatically disable HUD elements preview", help = "Enabling this will make it so all HUD elements preview modes are disabled when DelvUI's setting window is closed.")]
+        [Order(11)]
+        public bool AutomaticPreviewDisabling = true;
+
         [Checkbox("Mouseover", separator = true)]
         [Order(15)]
         public bool MouseoverEnabled = true;
@@ -35,51 +39,7 @@ namespace DelvUI.Interface.GeneralElements
         [Order(16, collapseWith = nameof(MouseoverEnabled))]
         public bool MouseoverAutomaticMode = true;
 
-        [Checkbox("Hide DelvUI outside of combat", isMonitored = true, separator = true, help = "Show in Duty and Show on Weapon Drawn-options available once enabled.")]
-        [Order(17)]
-        public bool HideOutsideOfCombat = false;
-
-        [Checkbox("Hide Player Frame even when not at full HP outside of combat.")]
-        [Order(18, collapseWith = nameof(HideOutsideOfCombat))]
-        public bool AlwaysHidePlayerFrameWhenDelvUIHidden = false;               
-
-        [Checkbox("Show in duty" + "##HideOutsideCombat")]
-        [Order(21, collapseWith = nameof(HideOutsideOfCombat))]
-        public bool ShowDelvUIFramesInDuty = false;
-
-        [Checkbox("Show on Weapon Drawn" + "##HideOutsideCombat")]
-        [Order(22, collapseWith = nameof(HideOutsideOfCombat))]
-        public bool ShowDelvUIFramesOnWeaponDrawn = false;
-
-        [Checkbox("Show when Crafting" + "##HideOutsideCombat")]
-        [Order(23, collapseWith = nameof(HideOutsideOfCombat))]
-        public bool ShowDelvUIFramesWhenCrafting = false;
-
-        [Checkbox("Hide DelvUI in Gold Saucer")]
-        [Order(25)]
-        public bool HideInGoldSaucer = false;
-
-        [Checkbox("Hide Player Frame at full HP")]
-        [Order(26)]
-        public bool HidePlayerFrameAtFullHP = false;
-
-        [Checkbox("Hide only JobPack HUD outside of combat")]
-        [Order(30)]
-        public bool HideOnlyJobPackHudOutsideOfCombat = false;
-
-        [Checkbox("Show in duty" + "##HideOnlyJobPack")]
-        [Order(31, collapseWith = nameof(HideOnlyJobPackHudOutsideOfCombat))]
-        public bool ShowJobPackInDuty = false;
-
-        [Checkbox("Show on Weapon Drawn" + "##HideOnlyJobPack")]
-        [Order(322, collapseWith = nameof(HideOnlyJobPackHudOutsideOfCombat))]
-        public bool ShowJobPackOnWeaponDrawn = false;
-
-        [Checkbox("Automatically disable HUD elements preview", help = "Enabling this will make it so all HUD elements preview modes are disabled when DelvUI's setting window is closed.")]
-        [Order(35)]
-        public bool AutomaticPreviewDisabling = true;
-
-        [Checkbox("Hide Default Job Gauges", isMonitored = true, spacing = true)]
+        [Checkbox("Hide Default Job Gauges", isMonitored = true, separator = true)]
         [Order(40)]
         public bool HideDefaultJobGauges = false;
 
@@ -90,27 +50,6 @@ namespace DelvUI.Interface.GeneralElements
         [Checkbox("Hide Default Pulltimer", isMonitored = true)]
         [Order(50)]
         public bool HideDefaultPulltimer = false;
-
-        [Checkbox("Enable Combat Hotbars", isMonitored = true, separator = true, help =
-            "Show in Duty, Show on Weapon Drawn and Use with Cross Hotbar-options available once enabled.")]
-        [Order(200)]
-        public bool EnableCombatActionBars = false;
-
-        [Checkbox("Show in duty" + "##CombatActionBars")]
-        [Order(201, collapseWith = nameof(EnableCombatActionBars))]
-        public bool ShowCombatActionBarsInDuty = false;
-
-        [Checkbox("Show on Weapon Drawn" + "##CombatActionBars")]
-        [Order(202, collapseWith = nameof(EnableCombatActionBars))]
-        public bool ShowCombatActionBarsOnWeaponDrawn = false;
-
-        [Checkbox("Use with Cross Hotbar", isMonitored = true, help = "Show in Duty and Show on Weapon Drawn will apply to Cross Hotbar instead when enabled.")]
-        [Order(203, collapseWith = nameof(EnableCombatActionBars))]
-        public bool CombatActionBarsWithCrossHotbar = false;
-
-        [DynamicList("Hotbars Shown Only In Combat", "Hotbar 1", "Hotbar 2", "Hotbar 3", "Hotbar 4", "Hotbar 5", "Hotbar 6", "Hotbar 7", "Hotbar 8", "Hotbar 9", "Hotbar 10", isMonitored = true)]
-        [Order(204, collapseWith = nameof(EnableCombatActionBars))]
-        public List<string> CombatActionBars = new();
 
         // saves original positions for all 4 layouts
         public Vector2[] CastBarOriginalPositions = new Vector2[] { Vector2.Zero, Vector2.Zero, Vector2.Zero, Vector2.Zero };

--- a/DelvUI/Interface/GeneralElements/HotbarsVisibilityConfig.cs
+++ b/DelvUI/Interface/GeneralElements/HotbarsVisibilityConfig.cs
@@ -1,0 +1,71 @@
+﻿using DelvUI.Config;
+using DelvUI.Config.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DelvUI.Interface.GeneralElements
+{
+    [Disableable(false)]
+    [Exportable(false)]
+    [Section("Visibility")]
+    [SubSection("Hotbars", 0)]
+    public class HotbarsVisibilityConfig : PluginConfigObject
+    {
+        public new static HotbarsVisibilityConfig DefaultConfig() { return new HotbarsVisibilityConfig(); }
+
+        [NestedConfig("Hotbar 1", 50)]
+        public VisibilityConfig HotbarConfig1 = new VisibilityConfig();
+
+        [NestedConfig("Hotbar 2", 51)]
+        public VisibilityConfig HotbarConfig2 = new VisibilityConfig();
+
+        [NestedConfig("Hotbar 3", 52)]
+        public VisibilityConfig HotbarConfig3 = new VisibilityConfig();
+
+        [NestedConfig("Hotbar 4", 53)]
+        public VisibilityConfig HotbarConfig4 = new VisibilityConfig();
+
+        [NestedConfig("Hotbar 5", 54)]
+        public VisibilityConfig HotbarConfig5 = new VisibilityConfig();
+
+        [NestedConfig("Hotbar 6", 55)]
+        public VisibilityConfig HotbarConfig6 = new VisibilityConfig();
+
+        [NestedConfig("Hotbar 7", 56)]
+        public VisibilityConfig HotbarConfig7 = new VisibilityConfig();
+
+        [NestedConfig("Hotbar 8", 57)]
+        public VisibilityConfig HotbarConfig8 = new VisibilityConfig();
+
+        [NestedConfig("Hotbar 9", 58)]
+        public VisibilityConfig HotbarConfig9 = new VisibilityConfig();
+
+        [NestedConfig("Hotbar 10", 59)]
+        public VisibilityConfig HotbarConfig10 = new VisibilityConfig();
+
+        [NestedConfig("Cross Hotbar", 60)]
+        public VisibilityConfig HotbarConfigCross = new VisibilityConfig();
+
+        private List<VisibilityConfig> _configs;
+        public List<VisibilityConfig> GetHotbarConfigs() => _configs;
+
+        public HotbarsVisibilityConfig()
+        {
+            _configs = new List<VisibilityConfig>() {
+                HotbarConfig1,
+                HotbarConfig2,
+                HotbarConfig3,
+                HotbarConfig4,
+                HotbarConfig5,
+                HotbarConfig6,
+                HotbarConfig7,
+                HotbarConfig8,
+                HotbarConfig9,
+                HotbarConfig10
+            };
+        }
+    }
+}

--- a/DelvUI/Interface/GeneralElements/LimitBreakConfig.cs
+++ b/DelvUI/Interface/GeneralElements/LimitBreakConfig.cs
@@ -11,6 +11,9 @@ namespace DelvUI.Interface.GeneralElements
     [SubSection("Limit Break", 0)]
     public class LimitBreakConfig : ChunkedProgressBarConfig
     {
+        [NestedConfig("Visibility", 70)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
+
         public LimitBreakConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor) : base(position, size, fillColor)
         {
         }

--- a/DelvUI/Interface/GeneralElements/LimitBreakHud.cs
+++ b/DelvUI/Interface/GeneralElements/LimitBreakHud.cs
@@ -7,9 +7,10 @@ using System.Numerics;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    public class LimitBreakHud : DraggableHudElement, IHudElementWithActor
+    public class LimitBreakHud : DraggableHudElement, IHudElementWithActor, IHudElementWithVisibilityConfig
     {
         private LimitBreakConfig Config => (LimitBreakConfig)_config;
+        public VisibilityConfig VisibilityConfig => Config.VisibilityConfig;
 
         public GameObject? Actor { get; set; } = null;
 

--- a/DelvUI/Interface/GeneralElements/MPTickerConfig.cs
+++ b/DelvUI/Interface/GeneralElements/MPTickerConfig.cs
@@ -29,6 +29,9 @@ namespace DelvUI.Interface.GeneralElements
             new PluginConfigColor(new(240f / 255f, 92f / 255f, 232f / 255f, 100f / 100f))
         );
 
+        [NestedConfig("Visibility", 70)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
+
         public new static MPTickerConfig DefaultConfig()
         {
             var config = new MPTickerConfig();

--- a/DelvUI/Interface/GeneralElements/MPTickerHud.cs
+++ b/DelvUI/Interface/GeneralElements/MPTickerHud.cs
@@ -11,9 +11,10 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    public class MPTickerHud : DraggableHudElement, IHudElementWithActor
+    public class MPTickerHud : DraggableHudElement, IHudElementWithActor, IHudElementWithVisibilityConfig
     {
         private MPTickerConfig Config => (MPTickerConfig)_config;
+        public VisibilityConfig VisibilityConfig => Config.VisibilityConfig;
 
         private MPTickHelper _mpTickHelper = null!;
         public GameObject? Actor { get; set; } = null;

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceConfig.cs
@@ -107,6 +107,9 @@ namespace DelvUI.Interface.GeneralElements
         [Order(17, collapseWith = nameof(AnchorToUnitFrame))]
         public DrawAnchor UnitFrameAnchor = DrawAnchor.Bottom;
 
+        [NestedConfig("Visibility", 1200)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
+
         public UnitFramePrimaryResourceConfig(Vector2 position, Vector2 size)
             : base(position, size)
         {

--- a/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
+++ b/DelvUI/Interface/GeneralElements/PrimaryResourceHud.cs
@@ -12,9 +12,10 @@ using DelvUI.Interface.Party;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    public class PrimaryResourceHud : ParentAnchoredDraggableHudElement, IHudElementWithActor, IHudElementWithAnchorableParent
+    public class PrimaryResourceHud : ParentAnchoredDraggableHudElement, IHudElementWithActor, IHudElementWithAnchorableParent, IHudElementWithVisibilityConfig
     {
         private PrimaryResourceConfig Config => (PrimaryResourceConfig)_config;
+        public VisibilityConfig? VisibilityConfig => Config is UnitFramePrimaryResourceConfig config ? config.VisibilityConfig : null;
 
         public PrimaryResourceTypes ResourceType = PrimaryResourceTypes.MP;
 

--- a/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameConfig.cs
@@ -244,6 +244,9 @@ namespace DelvUI.Interface.GeneralElements
         [NestedConfig("Custom Mouseover Area", 150)]
         public MouseoverAreaConfig MouseoverAreaConfig = new MouseoverAreaConfig();
 
+        [NestedConfig("Visibility", 200)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
+
         public UnitFrameConfig(Vector2 position, Vector2 size, EditableLabelConfig leftLabelConfig, EditableLabelConfig rightLabelConfig, EditableLabelConfig optionalLabelConfig)
             : base(position, size, new PluginConfigColor(new(40f / 255f, 40f / 255f, 40f / 255f, 100f / 100f)))
         {

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -17,9 +17,10 @@ using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace DelvUI.Interface.GeneralElements
 {
-    public unsafe class UnitFrameHud : DraggableHudElement, IHudElementWithActor, IHudElementWithMouseOver, IHudElementWithPreview
+    public unsafe class UnitFrameHud : DraggableHudElement, IHudElementWithActor, IHudElementWithMouseOver, IHudElementWithPreview, IHudElementWithVisibilityConfig
     {
         public UnitFrameConfig Config => (UnitFrameConfig)_config;
+        public VisibilityConfig VisibilityConfig => Config.VisibilityConfig;
 
         private readonly OpenContextMenuFromTarget _openContextMenuFromTarget;
 

--- a/DelvUI/Interface/GeneralElements/VisibilityConfig.cs
+++ b/DelvUI/Interface/GeneralElements/VisibilityConfig.cs
@@ -92,6 +92,7 @@ namespace DelvUI.Interface
 
         public void CopyFrom(VisibilityConfig config)
         {
+            Enabled = config.Enabled;
             HideOutsideOfCombat = config.HideOutsideOfCombat;
             HideInGoldSaucer = config.HideInGoldSaucer;
             HideOnFullHP = config.HideOnFullHP;

--- a/DelvUI/Interface/GeneralElements/VisibilityConfig.cs
+++ b/DelvUI/Interface/GeneralElements/VisibilityConfig.cs
@@ -1,0 +1,112 @@
+﻿using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Game.ClientState.Objects.Enums;
+using Dalamud.Game.ClientState.Objects.SubKinds;
+using DelvUI.Config;
+using DelvUI.Config.Attributes;
+using DelvUI.Interface.GeneralElements;
+using DelvUI.Interface.Party;
+using System.Linq;
+
+namespace DelvUI.Interface
+{
+    [Exportable(false)]
+    public class VisibilityConfig : PluginConfigObject
+    {
+        [Checkbox("Hide outside of combat")]
+        [Order(5)]
+        public bool HideOutsideOfCombat = false;
+
+        [Checkbox("Hide in combat")]
+        [Order(6)]
+        public bool HideInCombat = false;
+
+        [Checkbox("Hide in Gold Saucer")]
+        [Order(7)]
+        public bool HideInGoldSaucer = false;
+
+        [Checkbox("Hide while at full HP")]
+        [Order(8)]
+        public bool HideOnFullHP = false;
+
+        [Checkbox("Always show when in duty")]
+        [Order(10)]
+        public bool ShowInDuty = false;
+
+        [Checkbox("Always show when weapon is drawn")]
+        [Order(11)]
+        public bool ShowOnWeaponDrawn = false;
+
+        [Checkbox("Always show when crafting")]
+        [Order(12)]
+        public bool ShowWhileCrafting = false;
+
+        [Checkbox("Always show when gathering")]
+        [Order(13)]
+        public bool ShowWhileGathering = false;
+
+        [Checkbox("Always show while in a party")]
+        [Order(14)]
+        public bool ShowInParty = false;
+
+
+        private bool IsInCombat() => Plugin.Condition[ConditionFlag.InCombat];
+
+        private bool IsInDuty() => Plugin.Condition[ConditionFlag.BoundByDuty];
+
+        private bool IsCrafting() => Plugin.Condition[ConditionFlag.Crafting] || Plugin.Condition[ConditionFlag.Crafting40];
+
+        private bool IsGathering() => Plugin.Condition[ConditionFlag.Gathering] || Plugin.Condition[ConditionFlag.Gathering42];
+
+        private bool HasWeaponDrawn() => (Plugin.ClientState.LocalPlayer != null && Plugin.ClientState.LocalPlayer.StatusFlags.HasFlag(StatusFlags.WeaponOut));
+
+        private readonly uint[] _goldSaucerIDs = { 144, 388, 389, 390, 391, 579, 792, 899, 941 };
+
+        public bool IsElementVisible(HudElement? element = null)
+        {
+            if (!Enabled) { return true; }
+            if (!ConfigurationManager.Instance.LockHUD) { return true; }
+            if (element != null && element.GetType() == typeof(PlayerCastbarHud)) { return true; }
+            if (element != null && !element.GetConfig().Enabled) { return false; }
+
+            if (ShowInDuty && IsInDuty()) { return true; }
+
+            if (ShowOnWeaponDrawn && HasWeaponDrawn()) { return true; }
+
+            if (ShowWhileCrafting && IsCrafting()) { return true; }
+
+            if (ShowWhileGathering && IsGathering()) { return true; }
+
+            if (ShowInParty && PartyManager.Instance.MemberCount > 1) { return true; }
+
+            if (HideOutsideOfCombat && !IsInCombat()) { return false; }
+
+            if (HideInCombat && IsInCombat()) { return false; }
+
+            if (HideInGoldSaucer && _goldSaucerIDs.Any(id => id == Plugin.ClientState.TerritoryType)) { return false; }
+
+            PlayerCharacter? player = Plugin.ClientState.LocalPlayer;
+            if (HideOnFullHP && player != null && player.CurrentHp == player.MaxHp) { return false; }
+
+            return true;
+        }
+
+        public void CopyFrom(VisibilityConfig config)
+        {
+            HideOutsideOfCombat = config.HideOutsideOfCombat;
+            HideInGoldSaucer = config.HideInGoldSaucer;
+            HideOnFullHP = config.HideOnFullHP;
+            ShowInDuty = config.ShowInDuty;
+            ShowOnWeaponDrawn = config.ShowOnWeaponDrawn;
+            ShowWhileCrafting = config.ShowWhileCrafting;
+            ShowWhileGathering = config.ShowWhileGathering;
+            ShowInParty = config.ShowInParty;
+        }
+
+        public VisibilityConfig()
+        {
+            Enabled = false;
+        }
+    }
+}
+
+

--- a/DelvUI/Interface/HudElement.cs
+++ b/DelvUI/Interface/HudElement.cs
@@ -112,4 +112,9 @@ namespace DelvUI.Interface
     {
         public void StopPreview();
     }
+
+    public interface IHudElementWithVisibilityConfig
+    {
+        public VisibilityConfig? VisibilityConfig { get; }
+    }
 }

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -55,6 +55,7 @@ namespace DelvUI.Interface
             ConfigurationManager.Instance.LockEvent += OnHUDLockChanged;
             ConfigurationManager.Instance.ConfigClosedEvent += OnConfingWindowClosed;
             ConfigurationManager.Instance.StrataLevelsChangedEvent += OnStrataLevelsChanged;
+            ConfigurationManager.Instance.GlobalVisibilityEvent += OnGlobalVisibilityChanged;
 
             CreateHudElements();
         }
@@ -89,6 +90,7 @@ namespace DelvUI.Interface
             ConfigurationManager.Instance.LockEvent -= OnHUDLockChanged;
             ConfigurationManager.Instance.ConfigClosedEvent -= OnConfingWindowClosed;
             ConfigurationManager.Instance.StrataLevelsChangedEvent -= OnStrataLevelsChanged;
+            ConfigurationManager.Instance.GlobalVisibilityEvent -= OnGlobalVisibilityChanged;
         }
 
         private void OnConfigReset(ConfigurationManager sender)
@@ -138,6 +140,17 @@ namespace DelvUI.Interface
             }
 
             _hudElements = tmp;
+        }
+
+        private void OnGlobalVisibilityChanged(ConfigurationManager sender, VisibilityConfig config)
+        {
+            foreach (DraggableHudElement element in _hudElements.Values)
+            {
+                if (element is IHudElementWithVisibilityConfig e)
+                {
+                    e.VisibilityConfig?.CopyFrom(config);
+                }
+            }
         }
 
         private void OnDraggableElementSelected(DraggableHudElement sender)

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -42,6 +42,7 @@ namespace DelvUI.Interface
 
         private Dictionary<uint, JobHudTypes> _jobsMap = null!;
         private Dictionary<uint, Type> _unsupportedJobsMap = null!;
+        private List<Type> _jobTypes = null!;
 
         private double _occupiedInQuestStartTime = -1;
 
@@ -152,9 +153,10 @@ namespace DelvUI.Interface
                 }
             }
 
-            if (_jobHud != null && _jobHud is IHudElementWithVisibilityConfig jobHud)
+            foreach (Type jobType in _jobTypes)
             {
-                jobHud.VisibilityConfig?.CopyFrom(config);
+                JobConfig jobConfig = (JobConfig)ConfigurationManager.Instance.GetConfigObjectForType(jobType);
+                jobConfig.VisibilityConfig.CopyFrom(config);
             }
         }
 
@@ -640,6 +642,34 @@ namespace DelvUI.Interface
                 [JobIDs.MIN] = typeof(MinerConfig),
                 [JobIDs.BOT] = typeof(BotanistConfig),
                 [JobIDs.FSH] = typeof(FisherConfig),
+            };
+
+            _jobTypes = new List<Type>()
+            {
+                typeof(PaladinConfig),
+                typeof(WarriorConfig),
+                typeof(DarkKnightConfig),
+                typeof(GunbreakerConfig),
+
+                typeof(WhiteMageConfig),
+                typeof(ScholarConfig),
+                typeof(AstrologianConfig),
+                typeof(SageConfig),
+
+                typeof(MonkConfig),
+                typeof(DragoonConfig),
+                typeof(NinjaConfig),
+                typeof(SamuraiConfig),
+                typeof(ReaperConfig),
+
+                typeof(BardConfig),
+                typeof(MachinistConfig),
+                typeof(DancerConfig),
+
+                typeof(BlackMageConfig),
+                typeof(SummonerConfig),
+                typeof(RedMageConfig),
+                typeof(BlueMageConfig)
             };
         }
     }

--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -151,6 +151,11 @@ namespace DelvUI.Interface
                     e.VisibilityConfig?.CopyFrom(config);
                 }
             }
+
+            if (_jobHud != null && _jobHud is IHudElementWithVisibilityConfig jobHud)
+            {
+                jobHud.VisibilityConfig?.CopyFrom(config);
+            }
         }
 
         private void OnDraggableElementSelected(DraggableHudElement sender)

--- a/DelvUI/Interface/Jobs/JobConfig.cs
+++ b/DelvUI/Interface/Jobs/JobConfig.cs
@@ -16,6 +16,9 @@ namespace DelvUI.Interface.Jobs
         [Order(20)]
         public bool UseDefaultPrimaryResourceBar = false;
 
+        [NestedConfig("Visibility", 2000)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
+
         [JsonIgnore]
         public PrimaryResourceTypes PrimaryResourceType = PrimaryResourceTypes.MP;
 

--- a/DelvUI/Interface/Jobs/JobHud.cs
+++ b/DelvUI/Interface/Jobs/JobHud.cs
@@ -5,11 +5,12 @@ using System.Numerics;
 
 namespace DelvUI.Interface.Jobs
 {
-    public class JobHud : DraggableHudElement, IHudElementWithActor
+    public class JobHud : DraggableHudElement, IHudElementWithActor, IHudElementWithVisibilityConfig
     {
         protected DalamudPluginInterface PluginInterface => Plugin.PluginInterface;
 
         public JobConfig Config => (JobConfig)_config;
+        public VisibilityConfig VisibilityConfig => Config.VisibilityConfig;
 
         public GameObject? Actor { get; set; } = null;
         protected PlayerCharacter? Player => Actor is PlayerCharacter ? (PlayerCharacter)Actor : null;

--- a/DelvUI/Interface/Party/PartyFramesConfig.cs
+++ b/DelvUI/Interface/Party/PartyFramesConfig.cs
@@ -61,6 +61,9 @@ namespace DelvUI.Interface.Party
         [Checkbox("Show Chocobo", isMonitored = true)]
         [Order(55)]
         public bool ShowChocobo = true;
+
+        [NestedConfig("Visibility", 200)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
     }
 
     [Exportable(false)]

--- a/DelvUI/Interface/Party/PartyFramesHud.cs
+++ b/DelvUI/Interface/Party/PartyFramesHud.cs
@@ -11,9 +11,10 @@ using System.Runtime.InteropServices;
 
 namespace DelvUI.Interface.Party
 {
-    public class PartyFramesHud : DraggableHudElement, IHudElementWithMouseOver, IHudElementWithPreview
+    public class PartyFramesHud : DraggableHudElement, IHudElementWithMouseOver, IHudElementWithPreview, IHudElementWithVisibilityConfig
     {
         private PartyFramesConfig Config => (PartyFramesConfig)_config;
+        public VisibilityConfig VisibilityConfig => Config.VisibilityConfig;
         private PartyFramesConfigs Configs;
 
         private delegate void OpenContextMenu(IntPtr agentHud, int parentAddonId, int index);

--- a/DelvUI/Interface/PartyCooldowns/PartyCooldownsConfig.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldownsConfig.cs
@@ -58,6 +58,9 @@ namespace DelvUI.Interface.PartyCooldowns
         [Checkbox("Show When Solo", isMonitored = true)]
         [Order(21)]
         public bool ShowWhenSolo = false;
+
+        [NestedConfig("Visibility", 200)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
     }
 
     [Disableable(false)]

--- a/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
@@ -12,9 +12,10 @@ using System.Numerics;
 
 namespace DelvUI.Interface.PartyCooldowns
 {
-    public class PartyCooldownsHud : DraggableHudElement, IHudElementWithPreview
+    public class PartyCooldownsHud : DraggableHudElement, IHudElementWithPreview, IHudElementWithVisibilityConfig
     {
         private PartyCooldownsConfig Config => (PartyCooldownsConfig)_config;
+        public VisibilityConfig VisibilityConfig => Config.VisibilityConfig;
         private PartyCooldownsBarConfig _barConfig = null!;
         private PartyCooldownsDataConfig _dataConfig = null!;
 

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -162,6 +162,9 @@ namespace DelvUI.Interface.StatusEffects
         [Order(17, collapseWith = nameof(AnchorToUnitFrame))]
         public DrawAnchor UnitFrameAnchor = DrawAnchor.TopLeft;
 
+        [NestedConfig("Visibility", 200)]
+        public VisibilityConfig VisibilityConfig = new VisibilityConfig();
+
         public UnitFrameStatusEffectsListConfig(Vector2 position, Vector2 size, bool showBuffs, bool showDebuffs, bool showPermanentEffects,
             GrowthDirections growthDirections, StatusEffectIconConfig iconConfig)
             : base(position, size, showBuffs, showDebuffs, showPermanentEffects, growthDirections, iconConfig)

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -16,9 +16,10 @@ using StatusStruct = FFXIVClientStructs.FFXIV.Client.Game.Status;
 
 namespace DelvUI.Interface.StatusEffects
 {
-    public class StatusEffectsListHud : ParentAnchoredDraggableHudElement, IHudElementWithActor, IHudElementWithAnchorableParent, IHudElementWithPreview, IHudElementWithMouseOver
+    public class StatusEffectsListHud : ParentAnchoredDraggableHudElement, IHudElementWithActor, IHudElementWithAnchorableParent, IHudElementWithPreview, IHudElementWithMouseOver, IHudElementWithVisibilityConfig
     {
         protected StatusEffectsListConfig Config => (StatusEffectsListConfig)_config;
+        public VisibilityConfig? VisibilityConfig => Config is UnitFrameStatusEffectsListConfig config ? config.VisibilityConfig : null;
 
         private LayoutInfo _layoutInfo;
 

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -97,7 +97,7 @@ namespace DelvUI
                 AssemblyLocation = Assembly.GetExecutingAssembly().Location;
             }
 
-            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.1.5.0";
+            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.2.0.0";
 
             FontsManager.Initialize(AssemblyLocation);
             LoadBanner();

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -2,8 +2,8 @@
 Features:
 - Completely reworked visibility options for DelvUI elements and the game's hotbars:
     + Most DelvUI elements now have their own visibility settings and can be changed individually.
-    + A global setting can be applied to all elements in Visibility > Global.
-    + Hotbar visibility settings were moved from Misc > HUD options to Visibility > Hotbars.
+    + A global setting can be applied to all elements in 'Visibility > Global'.
+    + Hotbar visibility settings were moved from 'Misc > HUD Options' to 'Visibility > Hotbars'.
     + Due to the change in the structure, all visibility related settings will be reset.
 
 # 1.1.5.0

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,11 @@
+# 1.2.0.0
+Features:
+- Completely reworked visibility options for DelvUI elements and the game's hotbars:
+    + Most DelvUI elements now have their own visibility settings and can be changed individually.
+    + A global setting can be applied to all elements in Visibility > Global.
+    + Hotbar visibility settings were moved from Misc > HUD options to Visibility > Hotbars.
+    + Due to the change in the structure, all visibility related settings will be reset.
+
 # 1.1.5.0
 Fixes:
 - Fixed tooltips not working properly with high Dalamud Global Font Scales.


### PR DESCRIPTION
Most elements now have individual visibility settings: 
![image](https://user-images.githubusercontent.com/6404136/181139454-317691ae-9c15-4321-858d-0b4ef16da5b3.png)

There's global visibility settings that can be applied to all elements:
![image](https://user-images.githubusercontent.com/6404136/181139502-7e8348d5-b270-438e-8247-3871273337ae.png)
![image](https://user-images.githubusercontent.com/6404136/181139512-66da0bce-b54a-4209-b121-cd26771ae679.png)

Hotbars settings were moved to this new section:
![image](https://user-images.githubusercontent.com/6404136/181139551-03c88e77-df8f-4d4a-9711-78276c4ec888.png)
