### PR TITLE
added 'formatted' tag for current and max HP and MP

### DIFF
--- a/DelvUI/Helpers/TextTagsHelper.cs
+++ b/DelvUI/Helpers/TextTagsHelper.cs
@@ -105,6 +105,8 @@ namespace DelvUI.Helpers
 
             ["[health:current-short]"] = (currentHp, maxHp) => currentHp.KiloFormat(),
 
+            ["[health:current-formatted]"] = (currentHp, maxHp) => currentHp.ToString("N0"),
+
             ["[health:current-percent]"] = (currentHp, maxHp) => currentHp == maxHp ? currentHp.ToString() : (100f * currentHp / Math.Max(1, maxHp)).ToString("N0"),
 
             ["[health:current-percent-short]"] = (currentHp, maxHp) => currentHp == maxHp ? currentHp.KiloFormat() : (100f * currentHp / Math.Max(1, maxHp)).ToString("N0"),
@@ -116,6 +118,8 @@ namespace DelvUI.Helpers
             ["[health:max]"] = (currentHp, maxHp) => maxHp.ToString(),
 
             ["[health:max-short]"] = (currentHp, maxHp) => maxHp.KiloFormat(),
+
+            ["[health:max-formatted]"] = (currentHp, maxHp) => maxHp.ToString("N0"),
 
             ["[health:percent]"] = (currentHp, maxHp) => (100f * currentHp / Math.Max(1, maxHp)).ToString("N0"),
 
@@ -136,6 +140,8 @@ namespace DelvUI.Helpers
 
             ["[mana:current-short]"] = (currentMp, maxMp) => currentMp.KiloFormat(),
 
+            ["[mana:current-formatted]"] = (currentMp, maxMp) => currentMp.ToString("N0"),
+
             ["[mana:current-percent]"] = (currentMp, maxMp) => currentMp == maxMp ? currentMp.ToString() : (100f * currentMp / Math.Max(1, maxMp)).ToString("N0"),
 
             ["[mana:current-percent-short]"] = (currentMp, maxMp) => currentMp == maxMp ? currentMp.KiloFormat() : (100f * currentMp / Math.Max(1, maxMp)).ToString("N0"),
@@ -147,6 +153,8 @@ namespace DelvUI.Helpers
             ["[mana:max]"] = (currentMp, maxMp) => maxMp.ToString(),
 
             ["[mana:max-short]"] = (currentMp, maxMp) => maxMp.KiloFormat(),
+
+            ["[mana:max-formatted]"] = (currentMp, maxMp) => maxMp.ToString("N0"),
 
             ["[mana:percent]"] = (currentMp, maxMp) => (100f * currentMp / Math.Max(1, maxMp)).ToString("N0"),
 


### PR DESCRIPTION
Added a `xxx:current-formatted` and `xxx:max-formatted` tag for both HP and MP that adds a thousands separator to increase readability of large numbers. e.g. `136619` -> `136,619`.

I got 'formatted' from the discord suggestions channel but I'm happy to change it if it isn't clear.