### PR TITLE
Pet Nicknames Compatibility

### DIFF
--- a/DelvUI/Helpers/PetRenamerHelper.cs
+++ b/DelvUI/Helpers/PetRenamerHelper.cs
@@ -1,0 +1,53 @@
+﻿using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using DelvUI.Helpers.PetRenamer;
+using Newtonsoft.Json;
+
+namespace DelvUI.Helpers
+{
+    public static class PetRenamerHelper
+    {
+        private static ICallGateSubscriber<Character, string>? GetCharacterNickname;
+        private const string GetCharacterNicknameIdentifier = "PetRenamer.GetCharacterNickname";
+
+        public static void Initialize(DalamudPluginInterface dalamudPluginInterface)
+        {
+            GetCharacterNickname = dalamudPluginInterface?.GetIpcSubscriber<Character, string>(GetCharacterNicknameIdentifier);
+        }
+
+        public static string GetPetNamesForCharacter(Character character) => GetCharacterNickname?.InvokeFunc(character) ?? string.Empty;
+        public static NicknameData? FromString(string? str) => JsonConvert.DeserializeObject<NicknameData>(str ?? string.Empty);
+    }
+}
+
+namespace DelvUI.Helpers.PetRenamer
+{
+    public class NicknameData
+    {
+        public int ID = -1;
+        public string? Nickname = string.Empty;
+        public int BattleID = -1;
+        public string? BattleNickname = string.Empty;
+
+        public NicknameData() { }
+
+        [JsonConstructor]
+        public NicknameData(int ID, string? nickname, int BattleID, string? BattleNickname)
+        {
+            this.ID = ID;
+            Nickname = nickname;
+            this.BattleID = BattleID;
+            this.BattleNickname = BattleNickname;
+        }
+
+        public new string ToString() => $"{ID}^{Nickname}^{BattleID}^{BattleNickname}";
+        public string ToNormalString() => ToString().Replace("^", ",");
+
+        public bool CompanionValid() => ID != -1 && Nickname != string.Empty;
+        public bool BatteValid() => BattleID != -1 && BattleNickname != string.Empty;
+
+        public bool Equals(NicknameData other) => ID == other.ID && Nickname == other.Nickname;
+        public bool IDEquals(NicknameData other) => ID == other.ID;
+    }
+}

--- a/DelvUI/Helpers/TextTagsHelper.cs
+++ b/DelvUI/Helpers/TextTagsHelper.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.Objects.Enums;
+using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
@@ -9,6 +9,9 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection.Metadata.Ecma335;
 using System.Text.RegularExpressions;
+using CSGameObjectManager = FFXIVClientStructs.FFXIV.Client.Game.Object.GameObjectManager;
+using CSCompanion = FFXIVClientStructs.FFXIV.Client.Game.Character.Companion;
+using DelvUI.Helpers.PetRenamer;
 
 namespace DelvUI.Helpers
 {
@@ -405,7 +408,71 @@ namespace DelvUI.Helpers
         private static string ValidateName(GameObject? actor, string? name)
         {
             string? n = actor?.Name.ToString() ?? name;
+
+            // Detour for PetRenamer
+            try 
+            { 
+                GetPetName(actor, ref n); 
+            }
+            catch { }
+
             return (n == null || n == "") ? "" : n;
+        }
+
+        /// <summary>
+        /// Gets Custom Pet Name where Applicable
+        /// </summary>
+        /// <param name="actor">GameObject to get custom name of</param>
+        /// <param name="n">String to validate</param>
+        private static unsafe void GetPetName(GameObject? actor, ref string? n)
+        {
+            // Null Check and valid ObjectKind Check.
+            // We only want to act on Minions and BattleNPCs
+            if (actor == null || (actor.ObjectKind != ObjectKind.Companion && actor.ObjectKind != ObjectKind.BattleNpc))
+            {
+                return;
+            }
+
+            // Get the owner of the BattlePet
+            int ownerID = (int)actor.OwnerId;
+            // For companions it doesn't work that way due to a missing Dalamud feature.
+            // Most Dalamud stuff does NOT work with unnetworked gameObjects so this workaround gets the owner ID of a companion.
+            if (actor?.ObjectKind == ObjectKind.Companion)
+            {
+                CSCompanion* gObj = (CSCompanion*)CSGameObjectManager.GetGameObjectByIndex(((Character)actor).ObjectIndex);
+                if (gObj == null)
+                {
+                    return;
+                }
+                ownerID = (int)gObj->Character.CompanionOwnerID;
+            }
+
+            // We get the Dalamud gameObject of the owner
+            GameObject? dalamudObj = Plugin.ObjectTable.SearchById((ulong)ownerID);
+            // Null Check
+            if (dalamudObj == null)
+            {
+                return;
+            }
+            // We get the petnames via IPC endpoints
+            // And convert that json data to usable data
+            string jsonData = PetRenamerHelper.GetPetNamesForCharacter((Character)dalamudObj);
+            NicknameData? nicknameData = PetRenamerHelper.FromString(jsonData);
+            if (nicknameData == null)
+            {
+                return;
+            }
+
+            // If the object is a BattleNPC and the nickname is valid, apply it!
+            if (actor?.ObjectKind == ObjectKind.BattleNpc && nicknameData.BatteValid())
+            {
+                n = nicknameData.BattleNickname;
+            }
+            // If the object is a Companion and the nickname is valid, apply it!
+            else if (actor?.ObjectKind == ObjectKind.Companion && nicknameData.CompanionValid())
+            {
+                n = nicknameData.Nickname;
+            }
         }
 
         private static string ValidatePlayerName(GameObject? actor, string? name, bool? isPlayerName = null)

--- a/DelvUI/Helpers/Utils.cs
+++ b/DelvUI/Helpers/Utils.cs
@@ -189,7 +189,7 @@ namespace DelvUI.Helpers
             int actualTargetId = GetActualTargetId(target);
             // The Object ID that gets returned from minions is in reality the index
             // Checking for the correct object ID wouldn't work anyways as you would yet again run into the ObjectID = 0xE0000000 issue
-            if (actualTargetId >= 0 && actors.Length < actualTargetId)
+            if (actualTargetId >= 0 && actualTargetId < actors.Length)
             {
                 return actors[actualTargetId];
             }

--- a/DelvUI/Helpers/Utils.cs
+++ b/DelvUI/Helpers/Utils.cs
@@ -16,6 +16,8 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using StructsCharacter = FFXIVClientStructs.FFXIV.Client.Game.Character.Character;
+using StructsGameObject = FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject;
+using StructsCharacterManager = FFXIVClientStructs.FFXIV.Client.Game.Character.CharacterManager;
 
 namespace DelvUI.Helpers
 {
@@ -181,6 +183,17 @@ namespace DelvUI.Helpers
                 return null;
             }
 
+            // Dalamud for now has an issue where it is only able to get the target ID of
+            // NON-Networked objects through anything but GetTargetId on ClientStruct Gameobjects.
+            // The bypass converts all Dalamud GameObject Data to ClientStructs GameObject Data and handles it accordingly.
+            int actualTargetId = GetActualTargetId(target);
+            // The Object ID that gets returned from minions is in reality the index
+            // Checking for the correct object ID wouldn't work anyways as you would yet again run into the ObjectID = 0xE0000000 issue
+            if (actualTargetId >= 0 && actors.Length < actualTargetId)
+            {
+                return actors[actualTargetId];
+            }
+
             if (target.TargetObjectId == 0 && player != null && player.TargetObjectId == 0)
             {
                 return player;
@@ -198,6 +211,48 @@ namespace DelvUI.Helpers
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Gets the actual target ID of your targets target.
+        /// </summary>
+        /// <param name="target">Your target</param>
+        /// <returns>Target ID of your targets targer. Returns -1 if old code should be ran.</returns>
+        private static unsafe int GetActualTargetId(GameObject target)
+        {
+            // We only need to check for companions. 
+            // Why not check target.TargetObject?.ObjectKind == ObjectKind.Companion?
+            // Due to the Non-Networked game object bug the game is unaware of what type the object should actually be
+            if (target.TargetObject?.ObjectKind != ObjectKind.Player)
+            {
+                return -1;
+            }
+            // Here we get the ClientStruct Character of our target (aka the player we are targeting)
+            StructsCharacter targetChara = StructsCharacterManager.Instance()->LookupBattleCharaByObjectId((int)target.ObjectId)->Character;
+            // This method is key. GetTargetId() returns the targets player target ID. If it is converted to a hex string and starts with the number 4, it is a minion.
+            // Even though it is a minion, it still returns the players target ID.
+            ulong realTargetID = targetChara.GetTargetId();
+            if (!realTargetID.ToString("X").StartsWith("4")) 
+            {
+                return -1;
+            }
+            // We look up the parents ClientStruct GameObject
+            StructsCharacter* realBattleChara = (StructsCharacter*)StructsCharacterManager.Instance()->LookupBattleCharaByObjectId((int)realTargetID);
+            if (realBattleChara == null)
+            {
+                return -1;
+            }
+            // And get the companion off of that
+            StructsGameObject * companionGameObject = (StructsGameObject*)realBattleChara->Companion.CompanionObject;
+            if (companionGameObject == null)
+            {
+                return -1;
+            }
+
+            // We return the index of the object here. Why?
+            // Again due to the bug where ObjectID = 0xE0000000
+            // The index does work and returns the exact minion index.
+            return companionGameObject->ObjectIndex;
         }
 
         public static Vector2 GetAnchoredPosition(Vector2 position, Vector2 size, DrawAnchor anchor)

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -124,6 +124,7 @@ namespace DelvUI
             TextTagsHelper.Initialize();
             TexturesCache.Initialize();
             TooltipsHelper.Initialize();
+            PetRenamerHelper.Initialize(pluginInterface);
 
             _hudManager = new HudManager();
 


### PR DESCRIPTION
Hi! Due to demand from a player and in my own interest here is PetRenamer compatibility.

Here is how it works:
At the place where the [name] string gets validated I created a bypass.
This bypass checks if the name we are printing is of type BattleNPC or Companion.
If they are, we ask for the nicknames via my IPC port and I provide either an emty nickname or a filled one.
If it's empty we don't do anything. If it's filled we replace the normal name with the companion nickname.

Target of target now also supports minions ;) You're welcome.