### PR TITLE
Add option to color Party Cooldown bars by Job Color

### DIFF
--- a/DelvUI/Interface/PartyCooldowns/PartyCooldownsConfig.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldownsConfig.cs
@@ -91,6 +91,10 @@ namespace DelvUI.Interface.PartyCooldowns
         [Order(74, collapseWith = nameof(ShowBar))]
         public PluginConfigColor RechargingBackgroundColor = new PluginConfigColor(new Vector4(150f / 255f, 0f / 255f, 0f / 255f, 25f / 100f));
 
+        [Checkbox("Use Job Colors")]
+        [Order(75, collapseWith = nameof(ShowBar))]
+        public bool UseJobColors = false;
+
         [Checkbox("Show Icon", spacing = true)]
         [Order(80)]
         public bool ShowIcon = true;

--- a/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldownsHud.cs
@@ -183,6 +183,16 @@ namespace DelvUI.Interface.PartyCooldowns
                         PluginConfigColor fillColor = effectTime > 0 ? _barConfig.AvailableColor : _barConfig.RechargingColor;
                         PluginConfigColor bgColor = effectTime > 0 || cooldownTime == 0 ? _barConfig.AvailableBackgroundColor : _barConfig.RechargingBackgroundColor;
 
+                        if (_barConfig.UseJobColors)
+                        {
+                            PluginConfigColor jobColor = GlobalColors.Instance.SafeColorForJobId(cooldown.Data.JobId);
+                            PluginConfigColor bgJobColor = new PluginConfigColor(new Vector4(jobColor.Vector[0], jobColor.Vector[1], jobColor.Vector[2], 40f / 100f));
+                            PluginConfigColor rechargeJobColor = new PluginConfigColor(new Vector4(jobColor.Vector[0], jobColor.Vector[1], jobColor.Vector[2], 25f / 100f));
+                            PluginConfigColor nonActive = new PluginConfigColor(new Vector4(0f / 255f, 0f / 255f, 0f / 255f, 50f / 100f));
+                            fillColor = effectTime > 0 ? jobColor : rechargeJobColor;
+                            bgColor = effectTime > 0 || cooldownTime == 0 ? bgJobColor : nonActive;
+                        }
+
                         Rect background = new Rect(pos, size, bgColor);
                         Rect fill = BarUtilities.GetFillRect(pos, size, _barConfig.FillDirection, fillColor, current, max);
 


### PR DESCRIPTION
Just wanted to have the ability to use the defined job colors as the predominant color for the cooldown bars so it's easier to get information at a glance rather than having to read names for common skills (i.e reprisal, swiftcast).

Truthfully, didn't delve (haha) too deep into the code and just found what I needed to modify. Not sure if there was a better way to accomplish this so if there is I can go back through and modify.