### PR TITLE
Add Devilment and Standard Step

### DIFF
--- a/DelvUI/Interface/PartyCooldowns/PartyCooldown.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldown.cs
@@ -49,7 +49,7 @@ namespace DelvUI.Interface.PartyCooldowns
             int cooldown = GetCooldown();
             double timeSinceUse = OverridenCooldownStartTime != -1 ? ImGui.GetTime() - OverridenCooldownStartTime : ImGui.GetTime() - LastTimeUsed;
 
-            if (timeSinceUse > cooldown)
+            if (timeSinceUse > cooldown && Data.ActionId != 16003) // exclude standard step since duration > CD
             {
                 OverridenCooldownStartTime = -1;
                 LastTimeUsed = 0;

--- a/DelvUI/Interface/PartyCooldowns/PartyCooldownsConfig.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldownsConfig.cs
@@ -646,7 +646,9 @@ namespace DelvUI.Interface.PartyCooldowns
 
             // DNC
             [16012] = NewData(16012, JobIDs.DNC, 56, 90, 15, 70, 2, PartyCooldownEnabled.PartyFrames, "90-120"), // shield samba
-            [16004] = NewData(16004, JobIDs.DNC, 70, 120, 20, 30, 3, PartyCooldownEnabled.PartyCooldowns), // technical step / finish
+            [16011] = NewData(16011, JobIDs.DNC, 62, 120, 20, 30, 3, PartyCooldownEnabled.PartyCooldowns),       // devilment
+            [16003] = NewData(16003, JobIDs.DNC, 15, 30, 60, 30, 3, PartyCooldownEnabled.Disabled),        // standard step / finish
+            [16004] = NewData(16004, JobIDs.DNC, 70, 120, 20, 30, 3, PartyCooldownEnabled.PartyCooldowns),       // technical step / finish
 
             // MCH
             [16889] = NewData(16889, JobIDs.MCH, 56, 90, 15, 70, 2, PartyCooldownEnabled.PartyFrames, "90-120"), // tactician


### PR DESCRIPTION
Adds Devilment and Standard Step, Standard Step is disabled by default.

Ideally I'd like to add AST Cards and BRD Songs as well but dunno how since we completely disregard actual buffs on people.

Technically Devilment is only active on one person but since we already have Dragon Sight we should be consistent and have it too but for future cleanup/correctness we should check if the effect is on the player (or make it an option to only show stuff active on you). 

When we have something that also checks the buffs in place I could move and add Songs and Cards