### PR TITLE
Fix Weak Spots / Battle NPC parts not being drawn

### DIFF
--- a/DelvUI/Helpers/ColorUtils.cs
+++ b/DelvUI/Helpers/ColorUtils.cs
@@ -243,7 +243,7 @@ namespace DelvUI.Helpers
 
             if (character is BattleNpc npc)
             {
-                if (npc.BattleNpcKind == BattleNpcSubKind.Enemy && isHostile)
+                if ((npc.BattleNpcKind == BattleNpcSubKind.Enemy || npc.BattleNpcKind == BattleNpcSubKind.BattleNpcPart) && isHostile)
                 {
                     return GlobalColors.Instance.NPCHostileColor;
                 }

--- a/DelvUI/Helpers/Utils.cs
+++ b/DelvUI/Helpers/Utils.cs
@@ -82,7 +82,7 @@ namespace DelvUI.Helpers
             byte* unk = (byte*)(new IntPtr(character.Address) + 0x1F0);
 
             return character != null
-                && ((character.SubKind == (byte)BattleNpcSubKind.Enemy || (int)character.SubKind == 1)
+                && ((character.SubKind == (byte)BattleNpcSubKind.Enemy || (int)character.SubKind == (byte)BattleNpcSubKind.BattleNpcPart)
                 && *unk != 0);
         }
 

--- a/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
+++ b/DelvUI/Interface/GeneralElements/UnitFrameHud.cs
@@ -298,7 +298,7 @@ namespace DelvUI.Interface.GeneralElements
             float currentAlpha = color.Vector.W * 100f;
             float alpha = Config.RangeConfig.AlphaForDistance(distance, currentAlpha) / 100f;
 
-            if (character is BattleNpc { BattleNpcKind: BattleNpcSubKind.Enemy } && Config.EnemyRangeConfig.Enabled)
+            if (character is BattleNpc { BattleNpcKind: BattleNpcSubKind.Enemy or BattleNpcSubKind.BattleNpcPart } && Config.EnemyRangeConfig.Enabled)
             {
                 alpha = Config.EnemyRangeConfig.AlphaForDistance(distance, currentAlpha) / 100f;
             }

--- a/DelvUI/Interface/Nameplates/NameplatesHud.cs
+++ b/DelvUI/Interface/Nameplates/NameplatesHud.cs
@@ -157,7 +157,8 @@ namespace DelvUI.Interface.Nameplates
                         {
                             return _petHud;
                         }
-                        else if ((BattleNpcSubKind)battleNpc.SubKind == BattleNpcSubKind.Enemy)
+                        else if ((BattleNpcSubKind)battleNpc.SubKind == BattleNpcSubKind.Enemy || 
+                                 (BattleNpcSubKind)battleNpc.SubKind == BattleNpcSubKind.BattleNpcPart)
                         {
                             return Utils.IsHostile(battleNpc) ? _enemyHud : _npcHud;
                         }


### PR DESCRIPTION
This fixes the nameplates for stuff like: "Titan's Heart (Naval), Tioman's left and right wing (Sohm Al), Golem Soulstone (The Sunken Temple of Qarn)" not being drawn.
Also shows the correct hostile NPC color on the unit frame when targeting these.