### PR TITLE
Remove drawing from PCT gauge

### DIFF
--- a/DelvUI/Interface/Jobs/PictomancerHud.cs
+++ b/DelvUI/Interface/Jobs/PictomancerHud.cs
@@ -199,6 +199,26 @@ namespace DelvUI.Interface.Jobs
                 null
             );
 
+            // part drawing
+            PluginConfigColor? drawingColor = null;
+            if (gauge.CreatureFlags.HasFlag(CreatureFlags.Pom))
+            {
+                drawingColor = config.PomColor;
+            }
+            else if (gauge.CreatureFlags.HasFlag(CreatureFlags.Wings))
+            {
+                drawingColor = config.WingsColor;
+            }
+            else if (gauge.CreatureFlags.HasFlag(CreatureFlags.Claw))
+            {
+                drawingColor = config.ClawColor;
+            }
+            Tuple<PluginConfigColor, float, LabelConfig?> drawing = new(
+                drawingColor ?? PluginConfigColor.Empty,
+                drawingColor != null ? 1 : 0,
+                null
+            );
+
             // portrait
             PluginConfigColor? portraitColor = null;
             if (gauge.CreatureFlags.HasFlag(CreatureFlags.MooglePortait))
@@ -217,7 +237,7 @@ namespace DelvUI.Interface.Jobs
 
             var chunks = new Tuple<PluginConfigColor, float, LabelConfig?>[3];
             chunks[0] = canvas;
-            chunks[2] = portrait;
+            chunks[1] = portrait;
 
             BarHud[] bars = BarUtilities.GetChunkedBars(config, chunks, player);
             foreach (BarHud bar in bars)

--- a/DelvUI/Interface/Jobs/PictomancerHud.cs
+++ b/DelvUI/Interface/Jobs/PictomancerHud.cs
@@ -199,26 +199,6 @@ namespace DelvUI.Interface.Jobs
                 null
             );
 
-            // part drawing
-            PluginConfigColor? drawingColor = null;
-            if (gauge.CreatureFlags.HasFlag(CreatureFlags.Pom))
-            {
-                drawingColor = config.PomColor;
-            }
-            else if (gauge.CreatureFlags.HasFlag(CreatureFlags.Wings))
-            {
-                drawingColor = config.WingsColor;
-            }
-            else if (gauge.CreatureFlags.HasFlag(CreatureFlags.Claw))
-            {
-                drawingColor = config.ClawColor;
-            }
-            Tuple<PluginConfigColor, float, LabelConfig?> drawing = new(
-                drawingColor ?? PluginConfigColor.Empty,
-                drawingColor != null ? 1 : 0,
-                null
-            );
-
             // portrait
             PluginConfigColor? portraitColor = null;
             if (gauge.CreatureFlags.HasFlag(CreatureFlags.MooglePortait))
@@ -237,7 +217,6 @@ namespace DelvUI.Interface.Jobs
 
             var chunks = new Tuple<PluginConfigColor, float, LabelConfig?>[3];
             chunks[0] = canvas;
-            chunks[1] = drawing;
             chunks[2] = portrait;
 
             BarHud[] bars = BarUtilities.GetChunkedBars(config, chunks, player);

--- a/DelvUI/Interface/Jobs/PictomancerHud.cs
+++ b/DelvUI/Interface/Jobs/PictomancerHud.cs
@@ -199,26 +199,6 @@ namespace DelvUI.Interface.Jobs
                 null
             );
 
-            // part drawing
-            PluginConfigColor? drawingColor = null;
-            if (gauge.CreatureFlags.HasFlag(CreatureFlags.Pom))
-            {
-                drawingColor = config.PomColor;
-            }
-            else if (gauge.CreatureFlags.HasFlag(CreatureFlags.Wings))
-            {
-                drawingColor = config.WingsColor;
-            }
-            else if (gauge.CreatureFlags.HasFlag(CreatureFlags.Claw))
-            {
-                drawingColor = config.ClawColor;
-            }
-            Tuple<PluginConfigColor, float, LabelConfig?> drawing = new(
-                drawingColor ?? PluginConfigColor.Empty,
-                drawingColor != null ? 1 : 0,
-                null
-            );
-
             // portrait
             PluginConfigColor? portraitColor = null;
             if (gauge.CreatureFlags.HasFlag(CreatureFlags.MooglePortait))

--- a/DelvUI/Interface/Jobs/PictomancerHud.cs
+++ b/DelvUI/Interface/Jobs/PictomancerHud.cs
@@ -215,7 +215,7 @@ namespace DelvUI.Interface.Jobs
                 null
             );
 
-            var chunks = new Tuple<PluginConfigColor, float, LabelConfig?>[3];
+            var chunks = new Tuple<PluginConfigColor, float, LabelConfig?>[2];
             chunks[0] = canvas;
             chunks[1] = portrait;
 


### PR DESCRIPTION
Currently, the middle bar in the PCT canvas gauge uses the `CreatureFlags` to determine which color to draw in the middle. The CreatureFlags struct simply populates which drawing have been used already, which ends up in practice making the middle bar always equal to the MoogleColor because the moogle if statement is first, or an empty bar if the current painting is moogle.

With moogle painted
![image](https://github.com/DelvUI/DelvUI/assets/11250934/906a647c-ad70-4edc-8315-ad0e55d8fb29)

With claw painted
![image](https://github.com/DelvUI/DelvUI/assets/11250934/0577fff4-cbc0-449f-a7ad-769f0a55cb19)

With fang painted
![image](https://github.com/DelvUI/DelvUI/assets/11250934/f1176bce-3d97-4164-a4bc-42fdc82caaa2)


You can see that despite our last painting being a Fang muse, the middle bar is always the moogle color which is not very helpful information

In practice, this gauge is essentially useless because the previous Creature can always be inferred from the current canvas Gauge (1st bar).

In the base FF ui, the hud looks like
![image](https://github.com/DelvUI/DelvUI/assets/11250934/0885db2c-f7f0-4554-bab8-53af93f0f55d)


The top part of the gauge is what the middle bar was attempting to mimic, but there isn't a way to convey this information in a single bar because multiple flags can be active for the different drawings that have been consumed


Before
![image](https://github.com/DelvUI/DelvUI/assets/11250934/6fb962f3-5a10-4103-a682-ba9d9d79a82e)


After
![image](https://github.com/DelvUI/DelvUI/assets/11250934/a755f8ac-e53b-4397-949d-2dfaf964d3b1)
