### PR TITLE
feat(viper): adds `invert` option to vipersight guage

### DIFF
--- a/DelvUI/Interface/Bars/BarConfig.cs
+++ b/DelvUI/Interface/Bars/BarConfig.cs
@@ -48,6 +48,10 @@ namespace DelvUI.Interface.Bars
         [Order(41)]
         public bool HideWhenInactive = false;
 
+        [Checkbox("Invert", spacing = true)]
+        [Order(44)]
+        public bool Invert = false;
+
         public BarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor, BarDirection fillDirection = BarDirection.Right)
         {
             Position = position;

--- a/DelvUI/Interface/Jobs/ViperHud.cs
+++ b/DelvUI/Interface/Jobs/ViperHud.cs
@@ -181,7 +181,13 @@ namespace DelvUI.Interface.Jobs
                     break;
                 }
             }
-            
+
+            if (Config.Vipersight.Invert)
+            {
+                chunks.Reverse();
+                glows.Reverse();
+            }
+                
             if (!Config.Vipersight.HideWhenInactive)
             {
                 BarHud[] bars = BarUtilities.GetChunkedBars(Config.Vipersight, chunks.ToArray(), player, Config.Vipersight.GlowConfig, glows.ToArray());


### PR DESCRIPTION
What: Adds an invert checkbox to the `Vipersight` gauge

Why: As a user, my `Dread Fangs` keybind is `Q`, my `Steel Fangs` keybind is `E`, with the default Vipersight gauge orientation, when the left-most side glows to indicating the finisher to execute, I must press the right-most key. With this checkbox, I can better align my physical keypresses with the Vipersight gauge information.