### PR TITLE
feat: additional text tags

### DIFF
--- a/DelvUI/Extensions.cs
+++ b/DelvUI/Extensions.cs
@@ -15,13 +15,17 @@ namespace DelvUI
     {
         public static string Abbreviate(this string str)
         {
-            string[] splits = str.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            for (int i = 0; i < splits.Length - 1; i++)
-            {
-                splits[i] = splits[i][0].ToString();
+            if (str.Length > 20) {
+                string[] splits = str.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                for (int i = 0; i < splits.Length - 1; i++)
+                {
+                    splits[i] = splits[i][0].ToString();
+                }
+                
+                return string.Join(". ", splits).ToString();
             }
 
-            return string.Join(". ", splits).ToUpper();
+            return str;
         }
 
         public static string FirstName(this string str)

--- a/DelvUI/Helpers/TextTagsHelper.cs
+++ b/DelvUI/Helpers/TextTagsHelper.cs
@@ -49,6 +49,11 @@ namespace DelvUI.Helpers
                 Initials().
                 Truncated(length).
                 CheckForUpperCase(),
+
+            ["[name:abbreviate]"] = (actor, name, length, isPlayerName) => 
+                ValidateName(actor, name).
+                Abbreviate().
+                CheckForUpperCase(),
             #endregion
 
             #region player names
@@ -152,6 +157,8 @@ namespace DelvUI.Helpers
 
             ["[health:percent]"] = (currentHp, maxHp) => (100f * currentHp / Math.Max(1, maxHp)).ToString("N0"),
 
+            ["[health:percent-hidden]"] = (currentHp, maxHp) => currentHp == (0 | maxHp) ? "" : $"{Math.Round(100f / maxHp * currentHp)}",
+
             ["[health:percent-decimal]"] = (currentHp, maxHp) => (100f * currentHp / Math.Max(1f, maxHp)).ToString("N1", ConfigurationManager.Instance.ActiveCultreInfo),
 
             ["[health:percent-decimal-uniform]"] = (currentHp, maxHp) => ConsistentDigitPercentage(currentHp, maxHp),
@@ -205,6 +212,8 @@ namespace DelvUI.Helpers
             ["[company]"] = (chara) => chara.CompanyTag.ToString(),
 
             ["[level]"] = (chara) => chara.Level > 0 ? chara.Level.ToString() : "-",
+
+            ["[level:hidden]"] = (chara) => (chara.Level > 1 && chara.Level < 100) ? chara.Level.ToString() + " " : "",
 
             ["[job]"] = (chara) => JobsHelper.JobNames.TryGetValue(chara.ClassJob.Id, out var jobName) ? jobName : "",
 


### PR DESCRIPTION
Adds additional text tags for name, hp and level.

`name:abbreviate` abbreviates any name above 20 characters and formatting them as seen below.
![image](https://github.com/DelvUI/DelvUI/assets/62889588/4190df76-1c67-42bf-8328-2f88040f8f3a)

`health:percent-hidden` hides percentage based hp when at either 0 or 100%.

`level:hidden` hides the unit's level when it's either 0 or max level. This also comes with an additional whitespace at the end if the level **is** shown to avoid people having a weird whitespace when they do something like `[level] [name]`.
