### PR TITLE
Added Vipersight feature: #1207 Allow Vipersight gauge color to change based on buff

### DIFF
--- a/DelvUI/Interface/Jobs/ViperHud.cs
+++ b/DelvUI/Interface/Jobs/ViperHud.cs
@@ -130,7 +130,7 @@ namespace DelvUI.Interface.Jobs
             
             var start = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboStartColor, 1, null);
             var endFlank = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboEndFlankColor, 1, null);
-            var endRear = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboEndRearColor, 1, null);
+            var endHind = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboEndRearColor, 1, null);
             var endAOE = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboAOEEndColor, 1, null);
 
             switch (comboState)
@@ -167,21 +167,23 @@ namespace DelvUI.Interface.Jobs
                 }
                 case 2: // Combo Finisher, bar fully filled
                 {
+                    var isFlankEnder = Utils.StatusListForBattleChara(player).Any(o => o.StatusId is 3645 or 3646);
+                    var isHindEnder = Utils.StatusListForBattleChara(player).Any(o => o.StatusId is 3647 or 3647);
+
                     Tuple<PluginConfigColor, float, LabelConfig?> end;
                     
-                    if (lastUsedActionId == (uint)ViperCombo.HuntersSting)
+                    if (isFlankEnder)
                     {
                         end = endFlank;
                     }
-                    else if (lastUsedActionId == (uint)ViperCombo.SwiftskinsSting)
+                    else if (isHindEnder)
                     {
-                        end = endRear;
+                        end = endHind;
                     }
                     else
                     {
                         end = endAOE;
                     }
-
 
                     chunks = [end, start, start, end];
                     if (isSteelFangsEnder)
@@ -346,17 +348,17 @@ namespace DelvUI.Interface.Jobs
             [Order(41)]
             public PluginConfigColor ComboStartColor = new(new Vector4(230f / 255f, 33f / 255f, 33f / 255f, 100f / 100f));
 
-            [ColorEdit4("Combo AOE End")]
+            [ColorEdit4("Flank ender")]
             [Order(42)]
-            public PluginConfigColor ComboAOEEndColor = new(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 1f));
-
-            [ColorEdit4("Combo End - Flank Positional")]
-            [Order(43)]
             public PluginConfigColor ComboEndFlankColor = new(new Vector4(46f / 255f, 228f / 255f, 42f / 255f, 1f));
             
-            [ColorEdit4("Combo End - Rear Positional")]
-            [Order(44)]
+            [ColorEdit4("Hind ender")]
+            [Order(43)]
             public PluginConfigColor ComboEndRearColor = new(new Vector4(230f / 255f, 33f / 255f, 33f / 255f, 1f));
+
+            [ColorEdit4("Grim/Default Ender")]
+            [Order(44)]
+            public PluginConfigColor ComboAOEEndColor = new(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 1f));
 
             public VipersightBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)
                 : base(position, size, fillColor)

--- a/DelvUI/Interface/Jobs/ViperHud.cs
+++ b/DelvUI/Interface/Jobs/ViperHud.cs
@@ -129,7 +129,9 @@ namespace DelvUI.Interface.Jobs
             var empty = new Tuple<PluginConfigColor, float, LabelConfig?>(PluginConfigColor.Empty, 1, null);
             
             var start = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboStartColor, 1, null);
-            var end = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboEndColor, 1, null);
+            var endFlank = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboEndFlankColor, 1, null);
+            var endRear = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboEndRearColor, 1, null);
+            var endAOE = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboAOEEndColor, 1, null);
 
             switch (comboState)
             {
@@ -165,6 +167,22 @@ namespace DelvUI.Interface.Jobs
                 }
                 case 2: // Combo Finisher, bar fully filled
                 {
+                    Tuple<PluginConfigColor, float, LabelConfig?> end;
+                    
+                    if (lastUsedActionId == (uint)ViperCombo.HuntersSting)
+                    {
+                        end = endFlank;
+                    }
+                    else if (lastUsedActionId == (uint)ViperCombo.SwiftskinsSting)
+                    {
+                        end = endRear;
+                    }
+                    else
+                    {
+                        end = endAOE;
+                    }
+
+
                     chunks = [end, start, start, end];
                     if (isSteelFangsEnder)
                     {   // Glow left
@@ -328,9 +346,17 @@ namespace DelvUI.Interface.Jobs
             [Order(41)]
             public PluginConfigColor ComboStartColor = new(new Vector4(230f / 255f, 33f / 255f, 33f / 255f, 100f / 100f));
 
-            [ColorEdit4("Combo End")]
+            [ColorEdit4("Combo AOE End")]
             [Order(42)]
-            public PluginConfigColor ComboEndColor = new(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 1f));
+            public PluginConfigColor ComboAOEEndColor = new(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 1f));
+
+            [ColorEdit4("Combo End - Flank Positional")]
+            [Order(43)]
+            public PluginConfigColor ComboEndFlankColor = new(new Vector4(46f / 255f, 228f / 255f, 42f / 255f, 1f));
+            
+            [ColorEdit4("Combo End - Rear Positional")]
+            [Order(44)]
+            public PluginConfigColor ComboEndRearColor = new(new Vector4(230f / 255f, 33f / 255f, 33f / 255f, 1f));
 
             public VipersightBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)
                 : base(position, size, fillColor)

--- a/DelvUI/Interface/Jobs/ViperHud.cs
+++ b/DelvUI/Interface/Jobs/ViperHud.cs
@@ -130,8 +130,8 @@ namespace DelvUI.Interface.Jobs
             
             var start = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboStartColor, 1, null);
             var endFlank = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboEndFlankColor, 1, null);
-            var endHind = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboEndRearColor, 1, null);
-            var endAOE = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboAOEEndColor, 1, null);
+            var endHind = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboEndHindColor, 1, null);
+            var endAOE = new Tuple<PluginConfigColor, float, LabelConfig?>(Config.Vipersight.ComboEndAOEColor, 1, null);
 
             switch (comboState)
             {
@@ -168,7 +168,7 @@ namespace DelvUI.Interface.Jobs
                 case 2: // Combo Finisher, bar fully filled
                 {
                     var isFlankEnder = Utils.StatusListForBattleChara(player).Any(o => o.StatusId is 3645 or 3646);
-                    var isHindEnder = Utils.StatusListForBattleChara(player).Any(o => o.StatusId is 3647 or 3647);
+                    var isHindEnder = Utils.StatusListForBattleChara(player).Any(o => o.StatusId is 3647 or 3648);
 
                     Tuple<PluginConfigColor, float, LabelConfig?> end;
                     
@@ -354,11 +354,11 @@ namespace DelvUI.Interface.Jobs
             
             [ColorEdit4("Hind ender")]
             [Order(43)]
-            public PluginConfigColor ComboEndRearColor = new(new Vector4(230f / 255f, 33f / 255f, 33f / 255f, 1f));
+            public PluginConfigColor ComboEndHindColor = new(new Vector4(230f / 255f, 33f / 255f, 33f / 255f, 1f));
 
             [ColorEdit4("Grim/Default Ender")]
             [Order(44)]
-            public PluginConfigColor ComboAOEEndColor = new(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 1f));
+            public PluginConfigColor ComboEndAOEColor = new(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 1f));
 
             public VipersightBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)
                 : base(position, size, fillColor)


### PR DESCRIPTION
Adds an option to specify what color the final section of the Vipersight bar will be based on available combo finshers:

![image](https://github.com/DelvUI/DelvUI/assets/5423920/ff262507-8cbc-49bb-86ef-5b17154306a3)

![image](https://github.com/DelvUI/DelvUI/assets/5423920/f97a5b2a-194c-41ea-bacd-0594b60d76b7)

![image](https://github.com/DelvUI/DelvUI/assets/5423920/b9683036-90f4-4afd-bc4c-27c31d6f1370)