### PR TITLE
Rework Vipersight Bar

### DIFF
--- a/DelvUI/Helpers/SpellHelper.cs
+++ b/DelvUI/Helpers/SpellHelper.cs
@@ -70,5 +70,7 @@ namespace DelvUI.Helpers
 
             return maxStacks - (int)Math.Ceiling(cooldown / (recastTime / maxStacks));
         }
+
+        public unsafe bool IsActionHighlighted(uint actionId, ActionType type = ActionType.Action) => _actionManager->IsActionHighlighted(type, actionId);
     }
 }

--- a/DelvUI/Interface/Jobs/ViperHud.cs
+++ b/DelvUI/Interface/Jobs/ViperHud.cs
@@ -183,12 +183,6 @@ namespace DelvUI.Interface.Jobs
                 }
                 case ViperComboState.Finisher:
                 {
-                    var end = isFlankEnder ? endFlank : isHindEnder ? endHind : endAoE;
-                    chunks = [end, start, start, end];
-                    glows = [isLeftGlowing, isLeftGlowing, isRightGlowing, isRightGlowing];
-                    break;
-                    
-                    /*
                     var isFlankChain = (ViperCombo)lastUsedActionId == ViperCombo.HuntersSting;
                     var isHindChain = (ViperCombo)lastUsedActionId == ViperCombo.SwiftskinsSting;
 
@@ -206,7 +200,7 @@ namespace DelvUI.Interface.Jobs
                     glows = [isLeftGlowing, isLeftGlowing, isRightGlowing, isRightGlowing];
 
                     break;
-                    */
+                    
                 }
             }
 
@@ -275,8 +269,10 @@ namespace DelvUI.Interface.Jobs
             ViperConfig.SerpentOfferingsBarConfig config = Config.SerpentOfferings;
             var instance = JobGaugeManager.Instance();
             var gauge = (ViperGauge*)instance->CurrentGauge;
+            var fillColor = config.FillColor;
             
             float reawakenedDuration = Utils.StatusListForBattleChara(player).FirstOrDefault(o => o.StatusId is 3670 or 4094 && o.RemainingTime > 0f)?.RemainingTime ?? 0f;
+            bool reAwakenedReady = Utils.StatusListForBattleChara(player).Any(o => o.StatusId is 3671) || gauge->SerpentOffering >= 50;
             bool isReawakened = reawakenedDuration > 0;
             
             var serpentOffering = isReawakened ? reawakenedDuration : gauge->SerpentOffering;
@@ -287,16 +283,17 @@ namespace DelvUI.Interface.Jobs
 
                 bool showReawakened = isReawakened && config.EnableAwakenedTimer;
 
-                if (serpentOffering >= 50)
+                if (reAwakenedReady)
                 {
-                    config.FillColor = config.AwakenedColor;
+                    fillColor = config.AwakenedColor;
                 }
 
                 BarHud[] bars = BarUtilities.GetChunkedProgressBars(
                     config,
                     showReawakened ? 1 : 2,
                     showReawakened ? reawakenedDuration : serpentOffering,
-                    showReawakened ? 30f : 100f
+                    showReawakened ? 30f : 100f,
+                    fillColor: fillColor
                 );
                 
                 foreach (BarHud bar in bars)

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,6 +1,8 @@
 # 2.2.0.5
 - Fix Bard's Radiant Finale duration in Party Cooldowns
 - Fixed Who's Talking Indicator in Party Frames.
+- Slightly reworked Viper's Vipersight Bar
+  * Added a toggle named "Recommend Lower Buff Duration". This toggle behaves similarly to the current implementation, but now includes recommendations for lower duration buffs when using Steel Maw or Dread Maw. Turning off this toggle makes the bar behave identically to the game's default handling.
 
 # 2.2.0.4
 - Added duration labels for Pictomancer's Hammer Time and Hyperphantasia Bars.


### PR DESCRIPTION
Don't merge this yet, I want this tested more first.

Added a toggle named "Recommend Lower Buff Duration". This toggle behaves similarly to the current implementation, but now includes recommendations for lower duration buffs when using Steel Maw or Dread Maw. Turning off this toggle makes the bar behave identically to the game's default handling.