### PR TITLE
fix(job bars): corrects job bar options

### DIFF
--- a/DelvUI/Interface/Bars/BarConfig.cs
+++ b/DelvUI/Interface/Bars/BarConfig.cs
@@ -48,10 +48,6 @@ namespace DelvUI.Interface.Bars
         [Order(41)]
         public bool HideWhenInactive = false;
 
-        [Checkbox("Invert", spacing = true)]
-        [Order(44)]
-        public bool Invert = false;
-
         public BarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor, BarDirection fillDirection = BarDirection.Right)
         {
             Position = position;

--- a/DelvUI/Interface/Bars/BarUtilities.cs
+++ b/DelvUI/Interface/Bars/BarUtilities.cs
@@ -200,7 +200,7 @@ namespace DelvUI.Interface.Bars
 
                 Rect background = new(chunkPos, chunkSize, config.BackgroundColor);
                 Rect foreground = GetFillRect(chunkPos, chunkSize, config.FillDirection, chunks[i].Item1, chunks[i].Item2, 1f, 0f);
-                BarGlowConfig? glow = chunksToGlow?[i] == true ? glowConfig : null;
+                BarGlowConfig? glow = (glowConfig?.Enabled == true && chunksToGlow?[i] == true) ? glowConfig : null;
 
                 bars[i] = new BarHud(config.ID + i,
                     config.DrawBorder,

--- a/DelvUI/Interface/Jobs/ViperHud.cs
+++ b/DelvUI/Interface/Jobs/ViperHud.cs
@@ -374,6 +374,10 @@ namespace DelvUI.Interface.Jobs
             [Order(44)]
             public PluginConfigColor ComboEndAOEColor = new(new Vector4(69f / 255f, 115f / 255f, 202f / 255f, 1f));
 
+            [Checkbox("Invert", spacing = true)]
+            [Order(45)]
+            public bool Invert = false;
+
             public VipersightBarConfig(Vector2 position, Vector2 size, PluginConfigColor fillColor)
                 : base(position, size, fillColor)
             {


### PR DESCRIPTION
What: Moves the `Invert` checkbox from `ChunkedBarConfig` -> `VipersightBarConfig`.
Why: The invert checkbox was meant for specifically the Vipersight gauge, as `GrowDirection` satisfies the `Invert` condition for most bars.

What: Confirm `GlowConfig.Enabled` is truthy before glowing `ChunkedBarConfig` elements
Why: The `Glow.Enabled` checkbox in `Vipersight` doesn't do anything in the current implementation.