### PR TITLE
[Feat] Add Option to Hide Current Target from Enemy List

### DIFF
--- a/DelvUI/Interface/EnemyList/EnemyListConfig.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListConfig.cs
@@ -34,6 +34,10 @@ namespace DelvUI.Interface.EnemyList
         [Order(4)]
         public bool Preview = false;
 
+        [Checkbox("Hide Current Target", isMonitored = true)]
+        [Order(5)]
+        public bool HideCurrentTarget = false;
+
         [Combo("Growth Direction", "Down", "Up", spacing = true)]
         [Order(20)]
         public EnemyListGrowthDirection GrowthDirection = EnemyListGrowthDirection.Down;

--- a/DelvUI/Interface/EnemyList/EnemyListHelper.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListHelper.cs
@@ -23,7 +23,17 @@ namespace DelvUI.Interface.EnemyList
                 return target != null && target.GameObjectId == objectId;
             }
 
-        public void Update(bool hideCurrentTarget)
+        private List<EnemyListData> GeneratePreviewData()
+        {
+            List<EnemyListData> previewData = new List<EnemyListData>();
+            for (int i = 0; i < 8; i++)
+            {
+                previewData.Add(new EnemyListData((ulong)i, i, Math.Min(4, i + 1)));
+            }
+            return previewData;
+        }
+
+        public void Update(bool hideCurrentTarget, bool preview)
         {
             UIModule* uiModule = StructsFramework.Instance()->GetUIModule();
             if (uiModule != null)

--- a/DelvUI/Interface/EnemyList/EnemyListHelper.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListHelper.cs
@@ -35,6 +35,12 @@ namespace DelvUI.Interface.EnemyList
 
         public void Update(bool hideCurrentTarget, bool preview)
         {
+            if (preview)
+            {
+                _enemiesData = GeneratePreviewData();
+                return;
+            }
+
             UIModule* uiModule = StructsFramework.Instance()->GetUIModule();
             if (uiModule != null)
             {

--- a/DelvUI/Interface/EnemyList/EnemyListHelper.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListHelper.cs
@@ -17,8 +17,13 @@ namespace DelvUI.Interface.EnemyList
         private List<EnemyListData> _enemiesData = new List<EnemyListData>();
         public IReadOnlyCollection<EnemyListData> EnemiesData => _enemiesData.AsReadOnly();
         public int EnemyCount => _enemiesData.Count;
+        public bool IsCurrentTarget(ulong objectId)
+            {
+                var target = Plugin.TargetManager.Target;
+                return target != null && target.GameObjectId == objectId;
+            }
 
-        public void Update()
+        public void Update(bool hideCurrentTarget)
         {
             UIModule* uiModule = StructsFramework.Instance()->GetUIModule();
             if (uiModule != null)
@@ -42,14 +47,16 @@ namespace DelvUI.Interface.EnemyList
                 int index = 8 + (i * 6);
                 if (numberArrayData->AtkArrayData.Size <= index) { break; }
 
-                int objectId = numberArrayData->IntArray[index];
+                ulong objectId = (ulong)numberArrayData->IntArray[index];
+                if (hideCurrentTarget && IsCurrentTarget(objectId)) { continue; }
+                
                 int? letter = GetEnemyLetter(objectId, i);
                 int enmityLevel = GetEnmityLevelForIndex(i);
                 _enemiesData.Add(new EnemyListData(objectId, letter, enmityLevel));
             }
         }
 
-        private int? GetEnemyLetter(int objectId, int index)
+        private int? GetEnemyLetter(ulong objectId, int index)
         {
             if (_raptureAtkModule == null || _raptureAtkModule->AtkModule.AtkArrayDataHolder.StringArrayCount <= EnemyListNamesIndex)
             {
@@ -95,11 +102,11 @@ namespace DelvUI.Interface.EnemyList
 
     public struct EnemyListData
     {
-        public int ObjectId;
+        public ulong ObjectId;
         public int? LetterIndex;
         public int EnmityLevel;
 
-        public EnemyListData(int objectId, int? letterIndex, int enmityLevel)
+        public EnemyListData(ulong objectId, int? letterIndex, int enmityLevel)
         {
             ObjectId = objectId;
             LetterIndex = letterIndex;

--- a/DelvUI/Interface/EnemyList/EnemyListHud.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListHud.cs
@@ -122,18 +122,20 @@ namespace DelvUI.Interface.EnemyList
         {
             if (!Config.Enabled) { return; }
 
-            _helper.Update();
+            _helper.Update(Config.HideCurrentTarget);
 
             int count = Math.Min(MaxEnemyCount, Config.Preview ? MaxEnemyCount : _helper.EnemyCount);
             uint fakeMaxHp = 100000;
 
             ICharacter? mouseoverTarget = null;
             bool hovered = false;
-
-            for (int i = 0; i < count; i++)
+            
+            for (int i = 0, j = 0; i < count && j < _helper.EnemiesData.Count; i++, j++)
             {
                 // hp bar
-                ICharacter? character = Config.Preview ? null : Plugin.ObjectTable.SearchById((uint)_helper.EnemiesData.ElementAt(i).ObjectId) as ICharacter;
+                ICharacter? character = Config.Preview ? null : Plugin.ObjectTable.SearchById(_helper.EnemiesData.ElementAt(j).ObjectId) as ICharacter;
+
+                if (character == null) { i--; continue; }
 
                 uint currentHp = Config.Preview ? (uint)(_previewValues[i] * fakeMaxHp) : character?.CurrentHp ?? fakeMaxHp;
                 uint maxHp = Config.Preview ? fakeMaxHp : character?.MaxHp ?? fakeMaxHp;
@@ -219,7 +221,7 @@ namespace DelvUI.Interface.EnemyList
                 {
                     var parentPos = Utils.GetAnchoredPosition(origin + pos, -Configs.HealthBar.Size, Configs.EnmityIcon.HealthBarAnchor);
                     var iconPos = Utils.GetAnchoredPosition(parentPos + Configs.EnmityIcon.Position, Configs.EnmityIcon.Size, Configs.EnmityIcon.Anchor);
-                    int enmityIndex = Config.Preview ? Math.Min(3, i) : _helper.EnemiesData.ElementAt(i).EnmityLevel - 1;
+                    int enmityIndex = Config.Preview ? Math.Min(3, j) : _helper.EnemiesData.ElementAt(j).EnmityLevel - 1;
 
                     AddDrawAction(Configs.EnmityIcon.StrataLevel, () =>
                     {
@@ -300,8 +302,8 @@ namespace DelvUI.Interface.EnemyList
                 });
 
                 // castbar
-                EnemyListCastbarHud castbar = _castbarHud[i];
-                castbar.EnemyListIndex = i;
+                EnemyListCastbarHud castbar = _castbarHud[j];
+                castbar.EnemyListIndex = j;
 
                 var castbarPos = Utils.GetAnchoredPosition(origin + pos, -Configs.HealthBar.Size, Configs.CastBar.HealthBarAnchor);
                 AddDrawAction(Configs.CastBar.StrataLevel, () =>

--- a/DelvUI/Interface/EnemyList/EnemyListHud.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListHud.cs
@@ -122,7 +122,7 @@ namespace DelvUI.Interface.EnemyList
         {
             if (!Config.Enabled) { return; }
 
-            _helper.Update(Config.HideCurrentTarget);
+            _helper.Update(Config.HideCurrentTarget, Config.Preview);
 
             int count = Math.Min(MaxEnemyCount, Config.Preview ? MaxEnemyCount : _helper.EnemyCount);
             uint fakeMaxHp = 100000;
@@ -135,11 +135,11 @@ namespace DelvUI.Interface.EnemyList
                 // hp bar
                 ICharacter? character = Config.Preview ? null : Plugin.ObjectTable.SearchById(_helper.EnemiesData.ElementAt(j).ObjectId) as ICharacter;
 
-                if (character == null) { i--; continue; }
+                if (character == null && !Config.Preview) { i--; continue; }
 
                 uint currentHp = Config.Preview ? (uint)(_previewValues[i] * fakeMaxHp) : character?.CurrentHp ?? fakeMaxHp;
                 uint maxHp = Config.Preview ? fakeMaxHp : character?.MaxHp ?? fakeMaxHp;
-                int enmityLevel = Config.Preview ? Math.Max(4, i + 1) : _helper.EnemiesData.ElementAt(i).EnmityLevel;
+                int enmityLevel = Config.Preview ? Math.Max(4, i + 1) : _helper.EnemiesData.ElementAt(j).EnmityLevel;
 
                 if (Configs.HealthBar.SmoothHealthConfig.Enabled)
                 {

--- a/DelvUI/Interface/EnemyList/EnemyListHud.cs
+++ b/DelvUI/Interface/EnemyList/EnemyListHud.cs
@@ -189,7 +189,7 @@ namespace DelvUI.Interface.EnemyList
                 // highlight
                 var (areaStart, areaEnd) = Configs.HealthBar.MouseoverAreaConfig.GetArea(origin + pos, Configs.HealthBar.Size);
                 bool isHovering = character != null && ImGui.IsMouseHoveringRect(areaStart, areaEnd);
-                bool isSoftTarget = character != null && character == Plugin.TargetManager.SoftTarget;
+                bool isSoftTarget = character != null && character.EntityId == Plugin.TargetManager.SoftTarget?.EntityId;
                 if (isHovering || isSoftTarget)
                 {
                     if (Configs.HealthBar.Colors.ShowHighlight)
@@ -347,7 +347,7 @@ namespace DelvUI.Interface.EnemyList
 
         private PluginConfigColor GetBorderColor(ICharacter? character, int enmityLevel)
         {
-            IGameObject? target = Plugin.TargetManager.Target;
+            IGameObject? target = Plugin.TargetManager.SoftTarget ?? Plugin.TargetManager.Target;
             if (character != null && target != null && character.EntityId == target.EntityId)
             {
                 return Configs.HealthBar.Colors.TargetBordercolor;

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,6 +1,7 @@
 # 2.2.0.8
 - Fixed chat being spammed with hotbar commands.
-- Fixed soft targeting support for the EnemyList.
+- Fixed Chocobo showing up as a Viper in the party list.
+- Fixed Dark Knight's Blood Weapon Stacks being 3 instead of the previous 5.
 
 # 2.2.0.7
 - Fixed Honorific Title integration.

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,5 +1,6 @@
 # 2.2.0.8
 - Fixed chat being spammed with hotbar commands.
+- Fixed soft targeting support for the EnemyList.
 
 # 2.2.0.7
 - Fixed Honorific Title integration.


### PR DESCRIPTION
This PR adds a checkbox in the Enemy List config to hide the player's current target from the Enemy List, for players who like to keep the Enemy List next to the Target Frame.

Addresses my issue below:

https://github.com/DelvUI/DelvUI/issues/1216