### PR TITLE
Add [company:formatted]

### DIFF
--- a/DelvUI/Helpers/TextTagsHelper.cs
+++ b/DelvUI/Helpers/TextTagsHelper.cs
@@ -210,6 +210,8 @@ namespace DelvUI.Helpers
             ["[distance]"] = (chara) => (chara.YalmDistanceX + 1).ToString(),
 
             ["[company]"] = (chara) => chara.CompanyTag.ToString(),
+            
+            ["[company:formatted]"] = (chara) => !String.IsNullOrEmpty(chara.CompanyTag.ToString()) ? $"«{chara.CompanyTag}»" : "",
 
             ["[level]"] = (chara) => chara.Level > 0 ? chara.Level.ToString() : "-",
 

--- a/DelvUI/Helpers/TextTagsHelper.cs
+++ b/DelvUI/Helpers/TextTagsHelper.cs
@@ -211,7 +211,7 @@ namespace DelvUI.Helpers
 
             ["[company]"] = (chara) => chara.CompanyTag.ToString(),
             
-            ["[company:formatted]"] = (chara) => !String.IsNullOrEmpty(chara.CompanyTag.ToString()) ? $"«{chara.CompanyTag}»" : "",
+            ["[company-formatted]"] = (chara) => !String.IsNullOrEmpty(chara.CompanyTag.ToString()) ? $"«{chara.CompanyTag}»" : "",
 
             ["[level]"] = (chara) => chara.Level > 0 ? chara.Level.ToString() : "-",
 

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,5 +1,5 @@
 # 2.2.0.8
-- Added the `company:formatted` text tag.
+- Added the `company-formatted` text tag.
 - Changed Mug to Dokumori in Party Cooldowns.
 - Fixed chat being spammed with hotbar commands.
 - Fixed soft targeting support for the Enemy List.

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,5 +1,7 @@
 # 2.2.0.8
 - Fixed chat being spammed with hotbar commands.
+- Added [company:formatted] text tag.
+  * For more info check https://github.com/DelvUI/DelvUI/wiki/Text-Formatting
 
 # 2.2.0.7
 - Fixed Honorific Title integration.


### PR DESCRIPTION
Adds [company:formatted]. This will essentially just  add «CompanyName» that looks like the game.
This gets rid of the very frequent annoyance of players when you queue into any duty where the company tag will be empty but you'll be left with ugly «». This gets around that by just giving you an empty string when no company tag is present.

![Advanced_Combat_Tracker_2024-07-23_09-18-43](https://github.com/user-attachments/assets/aa6a0bfa-c1c1-4700-9efb-0fc7540fdb46)
![Advanced_Combat_Tracker_2024-07-23_09-19-17](https://github.com/user-attachments/assets/191e608a-892b-4cba-8dab-8e6558c7188b)
