### PR TITLE
Minor Party Cooldowns fixes

### DIFF
--- a/DelvUI/DelvUI.csproj
+++ b/DelvUI/DelvUI.csproj
@@ -10,9 +10,9 @@
 	<!-- Assembly Configuration -->
 	<PropertyGroup>
 		<AssemblyName>DelvUI</AssemblyName>
-		<AssemblyVersion>2.2.1.1</AssemblyVersion>
-		<FileVersion>2.2.1.1</FileVersion>
-		<InformationalVersion>2.2.1.1</InformationalVersion>
+		<AssemblyVersion>2.2.1.2</AssemblyVersion>
+		<FileVersion>2.2.1.2</FileVersion>
+		<InformationalVersion>2.2.1.2</InformationalVersion>
 	</PropertyGroup>
 
 	<!-- Build Configuration -->

--- a/DelvUI/Interface/PartyCooldowns/PartyCooldownsConfig.cs
+++ b/DelvUI/Interface/PartyCooldowns/PartyCooldownsConfig.cs
@@ -638,7 +638,7 @@ namespace DelvUI.Interface.PartyCooldowns
             [7390] = NewData(7390, JobIDs.DRK, 68, 60, 15, 10, 3, PartyCooldownEnabled.PartyFrames), // delirium
 
             [3636] = NewData(3636, JobIDs.DRK, 38, 120, 15, 90, 4, PartyCooldownEnabled.PartyFrames, disabledAfterLevel: 92), // shadow wall
-            [36927] = NewData(36927, JobIDs.DRK, 38, 120, 15, 90, 4, PartyCooldownEnabled.PartyFrames), // shadowed vigil
+            [36927] = NewData(36927, JobIDs.DRK, 92, 120, 15, 90, 4, PartyCooldownEnabled.PartyFrames), // shadowed vigil
 
             // GNB
             [16152] = NewData(16152, JobIDs.GNB, 50, 360, 10, 100, 4, PartyCooldownEnabled.PartyFrames), // superbolide
@@ -765,7 +765,7 @@ namespace DelvUI.Interface.PartyCooldowns
 
             // MULTI-ROLE  -------------------------------------------------------------------------------------------------
             [7541] = NewData(7541, new List<JobRoles>() { JobRoles.DPSMelee, JobRoles.DPSRanged }, 8, 120, 0, 80, 4, PartyCooldownEnabled.PartyFrames), // second wind
-            [7561] = NewData(7561, new List<JobRoles>() { JobRoles.Healer, JobRoles.DPSCaster }, 18, 60, 1, 80, 5, PartyCooldownEnabled.PartyFrames, null, new HashSet<uint>() { JobIDs.BLM, JobIDs.SMN, JobIDs.RDM }), // swiftcast
+            [7561] = NewData(7561, new List<JobRoles>() { JobRoles.Healer, JobRoles.DPSCaster }, 18, 60, 10, 80, 5, PartyCooldownEnabled.PartyFrames, null, new HashSet<uint>() { JobIDs.BLM, JobIDs.SMN, JobIDs.RDM }), // swiftcast
             [7562] = NewData(7562, new List<JobRoles>() { JobRoles.Healer, JobRoles.DPSCaster }, 14, 60, 21, 80, 5, PartyCooldownEnabled.Disabled), // lucid dreaming
         };
 

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -106,7 +106,7 @@ namespace DelvUI
                 AssemblyLocation = Assembly.GetExecutingAssembly().Location;
             }
 
-            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "2.2.1.1";
+            Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "2.2.1.2";
 
             FontsManager.Initialize(AssemblyLocation);
             BarTexturesManager.Initialize(AssemblyLocation);

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,3 +1,8 @@
+# 2.2.1.2
+- Minor Party Cooldowns fixes:
+  * Fixed Shadowed Vigil showing up in Party Cooldowns for characters below lvl 92.
+  * Fixed duration of Swiftcast.
+
 # 2.2.1.1
 - Removed `Misc > HUD Options > Support Special Mouse Clicks` setting:
   * This has been replaced with the `/delvui mouse on/off` command.


### PR DESCRIPTION
  * Fixed Shadowed Vigil showing up in Party Cooldowns for characters below lvl 92.
  * Fixed duration of Swiftcast.