### PR TITLE
add checkbox to StatusEffectsListConfig to allow showing effects when entity is dead

### DIFF
--- a/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListConfig.cs
@@ -231,20 +231,25 @@ namespace DelvUI.Interface.StatusEffects
         [Order(44)]
         public bool IncludePetAsOwn = false;
 
-        [Checkbox("Sort by Duration", spacing = true, help = "If enabled, \"Permanent Effects First\" and \"My Effects First\" will be ignored!")]
+        [Checkbox("Show When Dead")]
         [Order(45)]
+        public bool ShowWhenDead = false;
+
+
+        [Checkbox("Sort by Duration", spacing = true, help = "If enabled, \"Permanent Effects First\" and \"My Effects First\" will be ignored!")]
+        [Order(46)]
         public bool SortByDuration = false;
 
         [RadioSelector("Ascending", "Descending")]
-        [Order(46, collapseWith = nameof(SortByDuration))]
+        [Order(47, collapseWith = nameof(SortByDuration))]
         public StatusEffectDurationSortType DurationSortType = StatusEffectDurationSortType.Ascending;
 
         [Checkbox("Tooltips", spacing = true)]
-        [Order(47)]
+        [Order(48)]
         public bool ShowTooltips = true;
 
         [Checkbox("Disable Interaction", help = "Enabling this will disable right clicking buffs off, or the shortcut to blacklist/whitelist a status effect.")]
-        [Order(48)]
+        [Order(49)]
         public bool DisableInteraction = false;
 
         [NestedConfig("Icons", 65)]

--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -139,7 +139,7 @@ namespace DelvUI.Interface.StatusEffects
 
             if (_fakeEffects == null)
             {
-                if (actor == null || actor is not IBattleChara battleChara || battleChara.IsDead || battleChara.CurrentHp <= 0)
+                if (actor == null || actor is not IBattleChara battleChara || (battleChara.IsDead && !Config.ShowWhenDead) || (battleChara.CurrentHp <= 0 && !Config.ShowWhenDead))
                 {
                     return list;
                 }


### PR DESCRIPTION
currently all status effects are hidden when an entity is dead

however, some debuffs persist through death and being able to see them at a glance on party frames is helpful

![00047_ffxiv_dx11_GmfUAPG0K7](https://github.com/user-attachments/assets/d7ef3b68-1a67-4f4d-878b-40010a32be6a)
