### PR TITLE
Make sure DelvUI_HUD window doesn't steal focus

### DIFF
--- a/DelvUI/Interface/HudManager.cs
+++ b/DelvUI/Interface/HudManager.cs
@@ -433,6 +433,7 @@ namespace DelvUI.Interface
               | ImGuiWindowFlags.NoBackground
               | ImGuiWindowFlags.NoInputs
               | ImGuiWindowFlags.NoBringToFrontOnFocus
+              | ImGuiWindowFlags.NoFocusOnAppearing
               | ImGuiWindowFlags.NoSavedSettings
             );
 


### PR DESCRIPTION
Simple flag so that wiping (and thus redrawing DelvUI_HUD) doesn't steal focus away from other plugins for no reason.

My specific use case was trying to type in Chat2 in between pulls and DelvUI defocuses the window making my typing hit all my spells instead :)