### PR TITLE
Fix EnemyList Casting

### DIFF
--- a/DelvUI/Helpers/Utils.cs
+++ b/DelvUI/Helpers/Utils.cs
@@ -355,16 +355,17 @@ namespace DelvUI.Helpers
             if (index < 0 || index > 7) { return null; }
 
             AtkUnitBase* addon = (AtkUnitBase*)Plugin.GameGui.GetAddonByName("_EnemyList", 1).Address;
-            if (addon != null && addon->IsVisible)
-            {
-                AtkComponentButton* button = addon->GetComponentButtonById((uint)(20001 + index));
-                if (button == null || !button->AtkResNode->IsVisible()) { return false; }
+            if (addon == null || !addon->IsVisible) { return null; }
 
-                AtkImageNode* imageNode = button->GetImageNodeById(8);
-                return imageNode == null || imageNode->IsVisible();
+            uint buttonId = (index == 0) ? 2u : (uint)(20000 + index);
+            AtkComponentButton* button = addon->GetComponentButtonById(buttonId);
+            if (button == null || button->AtkResNode == null || !button->AtkResNode->IsVisible())
+            {
+                return false;
             }
 
-            return null;
+            AtkImageNode* imageNode = button->GetImageNodeById(8);
+            return imageNode == null || imageNode->IsVisible();
         }
 
         public static unsafe uint? SignIconIDForActor(IGameObject? actor)


### PR DESCRIPTION
<img width="531" height="421" alt="ffxiv_dx11_2025-09-07_09-13-31" src="https://github.com/user-attachments/assets/8d186c2a-b961-43b9-ad14-115bc75b28d9" />

Since SE uses node duplication I missed the fact that node 2 was the base node (and the first enemy) and 20001++ are the rest of the nodes.

Fixes #1308
