### PR TITLE
MNK & GNB Gauge Overcap Update

### DIFF
--- a/DelvUI/Interface/Jobs/GunbreakerHud.cs
+++ b/DelvUI/Interface/Jobs/GunbreakerHud.cs
@@ -55,6 +55,8 @@ namespace DelvUI.Interface.Jobs
             if (!Config.PowderGauge.HideWhenInactive || gauge.Ammo > 0)
             {
                 var maxCartridges = player.Level >= 88 ? 3 : 2;
+                maxCartridges = Utils.StatusListForBattleChara(player).FirstOrDefault(o => o.StatusId is 5051)?.RemainingTime > 0f ? maxCartridges * 2 : maxCartridges;
+
                 BarHud[] bars = BarUtilities.GetChunkedBars(Config.PowderGauge, maxCartridges, gauge.Ammo, maxCartridges, 0, player);
                 foreach (BarHud bar in bars)
                 {

--- a/DelvUI/Interface/Jobs/MonkHud.cs
+++ b/DelvUI/Interface/Jobs/MonkHud.cs
@@ -102,7 +102,9 @@ namespace DelvUI.Interface.Jobs
                 return;
             }
 
-            BarHud[] bars = BarUtilities.GetChunkedBars(Config.ChakraBar, 5, gauge.Chakra, 5, 0, player);
+            var maxChakra = (Utils.StatusListForBattleChara(player).FirstOrDefault(o => o.StatusId is 1182)?.RemainingTime > 0f) ? 10 : 5;
+
+            BarHud[] bars = BarUtilities.GetChunkedBars(Config.ChakraBar, maxChakra, gauge.Chakra, 5, 0, player);
             foreach (BarHud bar in bars)
             {
                 AddDrawActions(bar.GetDrawActions(origin, Config.ChakraBar.StrataLevel));


### PR DESCRIPTION
- Adjusted GNB's maxCartridges var for new Bloodfest overcap protection.
- Added maxChakra var to MNK for Brotherhood's overcap protection.

Respective Job Specific gauges now automatically double while the effect is active and revert when it ends.