### PR TITLE
Evaluate SeStrings for Status Tooltips

### DIFF
--- a/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
+++ b/DelvUI/Interface/StatusEffects/StatusEffectsListHud.cs
@@ -468,8 +468,10 @@ namespace DelvUI.Interface.StatusEffects
                 // tooltip
                 if (Config.ShowTooltips)
                 {
-                    TooltipsHelper.Instance.ShowTooltipOnCursor(
-                        EncryptedStringsHelper.GetString(data.Data.Description.ToDalamudString().ToString()),
+                    var seString = Plugin.SeStringEvaluator.Evaluate(data.Data.Description);
+
+                    TooltipsHelper.Instance.ShowSeStringTooltipOnCursor(
+                        seString,
                         EncryptedStringsHelper.GetString(data.Data.Name.ToString()),
                         data.Status.StatusId,
                         GetStatusActorName(data.Status)

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -34,6 +34,7 @@ namespace DelvUI
         public static IJobGauges JobGauges { get; private set; } = null!;
         public static IObjectTable ObjectTable { get; private set; } = null!;
         public static ISigScanner SigScanner { get; private set; } = null!;
+        public static ISeStringEvaluator SeStringEvaluator { get; private set; } = null!;
         public static IGameInteropProvider GameInteropProvider { get; private set; } = null!;
         public static ITargetManager TargetManager { get; private set; } = null!;
         public static IUiBuilder UiBuilder { get; private set; } = null!;
@@ -77,7 +78,8 @@ namespace DelvUI
             ITextureProvider textureProvider,
             IAddonLifecycle addonLifecycle,
             IChatGui chat,
-            IDutyState dutyState)
+            IDutyState dutyState,
+            ISeStringEvaluator seStringEvaluator)
         {
             BuddyList = buddyList;
             ClientState = clientState;
@@ -99,6 +101,7 @@ namespace DelvUI
             AddonLifecycle = addonLifecycle;
             Chat = chat;
             DutyState = dutyState;
+            SeStringEvaluator = seStringEvaluator;
 
             if (pluginInterface.AssemblyLocation.DirectoryName != null)
             {

--- a/DelvUI/changelog.md
+++ b/DelvUI/changelog.md
@@ -1,5 +1,6 @@
 # 2.6.2.2
 - Made resetting party cooldowns more reliable after a wipe.
+- Fixed a bug with status tooltips sometimes missing information in the description.
 
 # 2.6.2.1
 - Re-added the unengaged color for hostile enemies in the nameplates settings.


### PR DESCRIPTION
<img width="321" height="121" alt="Advanced_Combat_Tracker_2026-02-20_20-46-09" src="https://github.com/user-attachments/assets/7f54c2fd-9a74-4a1d-9efe-fb1e2fa88e05" />
<img width="203" height="67" alt="Advanced_Combat_Tracker_2026-02-20_20-46-14" src="https://github.com/user-attachments/assets/23721db5-9563-4289-8f54-81ce21082fd9" />

Fixes #1321 