### PR TITLE
only hook UseAction when automatic mouseover is on

### DIFF
--- a/DelvUI/Helpers/InputsHelper.cs
+++ b/DelvUI/Helpers/InputsHelper.cs
@@ -75,7 +75,7 @@ namespace DelvUI.Helpers
                     ActionManager.Addresses.UseAction.String,
                     HandleRequestAction
                 );
-                _requestActionHook?.Enable();
+                // enabled by OnFrameworkUpdate depending on the mouseover config
             }
             catch
             {
@@ -361,6 +361,19 @@ namespace DelvUI.Helpers
 
         public void OnFrameworkUpdate(IFramework framework)
         {
+            // only hook when automatic mouseover is on
+            if (_config.MouseoverEnabled && _config.MouseoverAutomaticMode)
+            {
+                if (_requestActionHook?.IsEnabled == false)
+                {
+                    _requestActionHook.Enable();
+                }
+            }
+            else if (_requestActionHook?.IsEnabled == true)
+            {
+                _requestActionHook.Disable();
+            }
+
             if (IsProxyEnabled)
             {
                 if (_wndProcPtr == IntPtr.Zero) {


### PR DESCRIPTION
HandleRequestAction only swaps the target when automatic mouseover is on, otherwise it just calls Original. No reason to keep it installed the rest of the time, so this change enables/disables from OnFrameworkUpdate. mouseover without automatic mode doesn't go through this hook so nothing changes there.